### PR TITLE
Split up physical register file, unified issue window; pipeline rename stage.

### DIFF
--- a/src/main/scala/brpredictor.scala
+++ b/src/main/scala/brpredictor.scala
@@ -715,7 +715,7 @@ class BranchReorderBuffer(fetch_width: Int, num_entries: Int)(implicit p: Parame
 
    // -----------------------------------------------
 
-   if (DEBUG_PRINTF)
+   if (DEBUG_PRINTF_BROB)
    {
       for (i <- 0 until num_entries)
       {

--- a/src/main/scala/brpredictor.scala
+++ b/src/main/scala/brpredictor.scala
@@ -189,8 +189,10 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
    val vlh_raw_spec_head = r_vlh.raw_spec_head
 
 
-   assert (r_ghistory_commit_copy === vlh_commit,
-      "[brpredictor] mistmatch between short history and very long history implementations.")
+   if (ENABLE_BPD_ASSERTS) {
+      assert (r_ghistory_commit_copy === vlh_commit,
+         "[brpredictor] mistmatch between short history and very long history implementations.")
+   }
 
 
    if (ENABLE_BPD_USHISTORY && !ENABLE_BPD_UMODE_ONLY)
@@ -477,9 +479,11 @@ class VeryLongHistoryRegister(hlen: Int, vlhr_len: Int)
 
    def commit(taken: Bool): Unit =
    {
-      assert(com_head =/= spec_head, "[brpredictor] VLHR: commit head is moving ahead of the spec head.")
       val debug_com_bit = (hist_buffer >> com_head) & UInt(1,1)
-      assert (debug_com_bit  === taken, "[brpredictor] VLHR: commit bit doesn't match speculative bit.")
+      if (ENABLE_BPD_ASSERTS) {
+         assert(com_head =/= spec_head, "[brpredictor] VLHR: commit head is moving ahead of the spec head.")
+         assert (debug_com_bit  === taken, "[brpredictor] VLHR: commit bit doesn't match speculative bit.")
+      }
       com_head := WrapInc(com_head, plen)
    }
 }

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -26,7 +26,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          nPerfCounters = 4,
          nPerfEvents = 31,
          fpu = Some(tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
-      btb = Some(BTBParams(nEntries = 40, nRAS = 8, updatesOutOfOrder = true))
+      btb = Some(BTBParams(nEntries = 40, nRAS = 4, updatesOutOfOrder = true))
    )}
 
    // BOOM-specific uarch Parameters

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -24,7 +24,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       useCompressed = false,
       nPerfCounters = 4,
       nPerfEvents = 31,
-      fpu = Some(tile.FPUParams(sfmaLatency=3, dfmaLatency=3, divSqrt=true))
+      fpu = Some(tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))
    ))}
 
    // BOOM-specific uarch Parameters
@@ -33,13 +33,13 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       issueParams = Seq(
          IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
          IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
-         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue)),
-      numIntPhysRegisters = 80,
+         IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)),
+      numIntPhysRegisters = 90,
       numFpPhysRegisters = 56,
       numLsuEntries = 16,
       maxBrCount = 8,
       enableBranchPredictor = true,
-      gshare = Some(GShareParameters(enabled = true, history_length=11))
+      gshare = Some(GShareParameters(enabled = true, history_length=14))
    )
   }
 )
@@ -67,7 +67,7 @@ class WithSmallBooms extends Config((site, here, up) => {
       numFpPhysRegisters = 48,
       numLsuEntries = 4,
       maxBrCount = 4,
-      gshare = Some(GShareParameters(enabled = true, history_length=11))
+      gshare = Some(GShareParameters(enabled = true, history_length=12))
       )
 })
 
@@ -85,7 +85,7 @@ class WithMediumBooms extends Config((site, here, up) => {
       numIntPhysRegisters = 80,
       numFpPhysRegisters = 56,
       numLsuEntries = 16,
-      gshare = Some(GShareParameters(enabled = true, history_length=11))
+      gshare = Some(GShareParameters(enabled = true, history_length=14))
       )
 })
 
@@ -99,11 +99,11 @@ class WithMegaBooms extends Config((site, here, up) => {
       issueParams = Seq(
          IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue),
          IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue),
-         IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)),
+         IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)), // TODO make this 2-wide issue
       numIntPhysRegisters = 128,
-      numFpPhysRegisters = 64,
+      numFpPhysRegisters = 80,
       numLsuEntries = 32,
-      gshare = Some(GShareParameters(enabled = true, history_length=11))
+      tage = Some(TageParameters())
       )
    // Widen L1toL2 bandwidth so we can increase icache rowBytes size for 4-wide fetch.
    case L1toL2Config => up(L1toL2Config, site).copy(

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -23,15 +23,16 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       useCompressed = false,
       nPerfCounters = 4,
       nPerfEvents = 31,
-      fpu = Some(tile.FPUParams(sfmaLatency=3, dfmaLatency=3))
+      fpu = None //Some(tile.FPUParams(sfmaLatency=3, dfmaLatency=3))
    ))}
 
    // BOOM-specific uarch Parameters
    case BoomKey => BoomCoreParams(
-      issueWidth = 3,
       numRobEntries = 48,
-      numIssueSlotEntries = 20,
-      numPhysRegisters = 110,
+      issueWidths = Seq(1, 2, 0), // Mem, Int, FP
+      numIssueSlotEntries = Seq(16, 16, 16), // Mem, Int, FP
+      numIntPhysRegisters = 80,
+      numFpPhysRegisters = 56,
       numLsuEntries = 16,
       maxBrCount = 8,
       enableBranchPredictor = true,
@@ -54,11 +55,12 @@ class WithSmallBooms extends Config((site, here, up) => {
       nPerfCounters = 1
       ))}
    case BoomKey => up(BoomKey, site).copy(
-      issueWidth = 1,
       numRobEntries = 24,
-      numIssueSlotEntries = 10,
+      issueWidths = Seq(1, 1, 0), // Mem, Int, FP
+      numIssueSlotEntries = Seq(4, 4, 4), // Mem, Int, FP
+      numIntPhysRegisters = 56,
+      numFpPhysRegisters = 48,
       numLsuEntries = 4,
-      numPhysRegisters = 100,
       maxBrCount = 4,
       gshare = Some(GShareParameters(enabled = true, history_length=11))
       )
@@ -70,11 +72,12 @@ class WithMediumBooms extends Config((site, here, up) => {
    case RocketTilesKey => up(RocketTilesKey, site) map { r =>r.copy(core = r.core.copy(
       fWidth = 2))}
    case BoomKey => up(BoomKey, site).copy(
-      issueWidth = 3,
       numRobEntries = 48,
-      numIssueSlotEntries = 20,
+      issueWidths = Seq(1, 2, 0), // Mem, Int, FP
+      numIssueSlotEntries = Seq(16, 16, 16), // Mem, Int, FP
+      numIntPhysRegisters = 80,
+      numFpPhysRegisters = 56,
       numLsuEntries = 16,
-      numPhysRegisters = 110,
       gshare = Some(GShareParameters(enabled = true, history_length=11))
       )
 })
@@ -85,11 +88,12 @@ class WithMegaBooms extends Config((site, here, up) => {
    case RocketTilesKey => up(RocketTilesKey, site) map { r => r.copy(core = r.core.copy(
       fWidth = 4))}
    case BoomKey => up(BoomKey, site).copy(
-      issueWidth = 4,
       numRobEntries = 128,
-      numIssueSlotEntries = 28,
+      issueWidths = Seq(1, 2, 0), // Mem, Int, FP
+      numIssueSlotEntries = Seq(20, 16, 20), // Mem, Int, FP
+      numIntPhysRegisters = 128,
+      numFpPhysRegisters = 64,
       numLsuEntries = 32,
-      numPhysRegisters = 128,
       gshare = Some(GShareParameters(enabled = true, history_length=11))
       )
    // Widen L1toL2 bandwidth so we can increase icache rowBytes size for 4-wide fetch.

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -23,13 +23,18 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       useCompressed = false,
       nPerfCounters = 4,
       nPerfEvents = 31,
-      fpu = None //Some(tile.FPUParams(sfmaLatency=3, dfmaLatency=3))
+      fpu = Some(tile.FPUParams(sfmaLatency=3, dfmaLatency=3, divSqrt=true))
    ))}
 
    // BOOM-specific uarch Parameters
    case BoomKey => BoomCoreParams(
       numRobEntries = 48,
-      issueWidths = Seq(1, 2, 0), // Mem, Int, FP
+//      issueParams = Seq(
+//         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
+//         IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
+//         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue))
+      // TODO update issueWindows to use case classes.
+      issueWidths = Seq(1, 2, 1), // Mem, Int, FP
       numIssueSlotEntries = Seq(16, 16, 16), // Mem, Int, FP
       numIntPhysRegisters = 80,
       numFpPhysRegisters = 56,
@@ -56,7 +61,7 @@ class WithSmallBooms extends Config((site, here, up) => {
       ))}
    case BoomKey => up(BoomKey, site).copy(
       numRobEntries = 24,
-      issueWidths = Seq(1, 1, 0), // Mem, Int, FP
+      issueWidths = Seq(1, 1, 1), // Mem, Int, FP
       numIssueSlotEntries = Seq(4, 4, 4), // Mem, Int, FP
       numIntPhysRegisters = 56,
       numFpPhysRegisters = 48,
@@ -73,7 +78,7 @@ class WithMediumBooms extends Config((site, here, up) => {
       fWidth = 2))}
    case BoomKey => up(BoomKey, site).copy(
       numRobEntries = 48,
-      issueWidths = Seq(1, 2, 0), // Mem, Int, FP
+      issueWidths = Seq(1, 2, 1), // Mem, Int, FP
       numIssueSlotEntries = Seq(16, 16, 16), // Mem, Int, FP
       numIntPhysRegisters = 80,
       numFpPhysRegisters = 56,
@@ -89,7 +94,7 @@ class WithMegaBooms extends Config((site, here, up) => {
       fWidth = 4))}
    case BoomKey => up(BoomKey, site).copy(
       numRobEntries = 128,
-      issueWidths = Seq(1, 2, 0), // Mem, Int, FP
+      issueWidths = Seq(1, 2, 2), // Mem, Int, FP
       numIssueSlotEntries = Seq(20, 16, 20), // Mem, Int, FP
       numIntPhysRegisters = 128,
       numFpPhysRegisters = 64,

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -19,13 +19,15 @@ class DefaultBoomConfig extends Config((site, here, up) => {
    case XLen => 64
 
    // Rocket/Core Parameters
-   case RocketTilesKey => up(RocketTilesKey, site) map { r => r.copy(core = r.core.copy(
-      fWidth = 2,
-      useCompressed = false,
-      nPerfCounters = 4,
-      nPerfEvents = 31,
-      fpu = Some(tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))
-   ))}
+   case RocketTilesKey => up(RocketTilesKey, site) map { r => r.copy(
+      core = r.core.copy(
+         fWidth = 2,
+         useCompressed = false,
+         nPerfCounters = 4,
+         nPerfEvents = 31,
+         fpu = Some(tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
+      btb = Some(BTBParams(nEntries = 40, nRAS = 8, updatesOutOfOrder = true))
+   )}
 
    // BOOM-specific uarch Parameters
    case BoomKey => BoomCoreParams(

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -11,6 +11,7 @@ import tile._
 import rocket._
 
 
+// Try to be a reasonable BOOM design point.
 class DefaultBoomConfig extends Config((site, here, up) => {
 
    // Top-Level
@@ -50,7 +51,7 @@ class WithNPerfCounters(n: Int) extends Config((site, here, up) => {
    ))}
 })
 
-// Small BOOM!
+// Small BOOM! Try to be fast to compile, easier to debug.
 class WithSmallBooms extends Config((site, here, up) => {
    case RocketTilesKey => up(RocketTilesKey, site) map { r =>r.copy(core = r.core.copy(
       fWidth = 1,

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -28,14 +28,11 @@ class DefaultBoomConfig extends Config((site, here, up) => {
 
    // BOOM-specific uarch Parameters
    case BoomKey => BoomCoreParams(
-      numRobEntries = 48,
-//      issueParams = Seq(
-//         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
-//         IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
-//         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue))
-      // TODO update issueWindows to use case classes.
-      issueWidths = Seq(1, 2, 1), // Mem, Int, FP
-      numIssueSlotEntries = Seq(16, 16, 16), // Mem, Int, FP
+      numRobEntries = 64,
+      issueParams = Seq(
+         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
+         IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
+         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue)),
       numIntPhysRegisters = 80,
       numFpPhysRegisters = 56,
       numLsuEntries = 16,
@@ -61,8 +58,10 @@ class WithSmallBooms extends Config((site, here, up) => {
       ))}
    case BoomKey => up(BoomKey, site).copy(
       numRobEntries = 24,
-      issueWidths = Seq(1, 1, 1), // Mem, Int, FP
-      numIssueSlotEntries = Seq(4, 4, 4), // Mem, Int, FP
+      issueParams = Seq(
+         IssueParams(issueWidth=1, numEntries=4, iqType=IQT_MEM.litValue),
+         IssueParams(issueWidth=1, numEntries=4, iqType=IQT_INT.litValue),
+         IssueParams(issueWidth=1, numEntries=4, iqType=IQT_FP.litValue)),
       numIntPhysRegisters = 56,
       numFpPhysRegisters = 48,
       numLsuEntries = 4,
@@ -78,8 +77,10 @@ class WithMediumBooms extends Config((site, here, up) => {
       fWidth = 2))}
    case BoomKey => up(BoomKey, site).copy(
       numRobEntries = 48,
-      issueWidths = Seq(1, 2, 1), // Mem, Int, FP
-      numIssueSlotEntries = Seq(16, 16, 16), // Mem, Int, FP
+      issueParams = Seq(
+         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
+         IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
+         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue)),
       numIntPhysRegisters = 80,
       numFpPhysRegisters = 56,
       numLsuEntries = 16,
@@ -94,8 +95,10 @@ class WithMegaBooms extends Config((site, here, up) => {
       fWidth = 4))}
    case BoomKey => up(BoomKey, site).copy(
       numRobEntries = 128,
-      issueWidths = Seq(1, 2, 2), // Mem, Int, FP
-      numIssueSlotEntries = Seq(20, 16, 20), // Mem, Int, FP
+      issueParams = Seq(
+         IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue),
+         IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue),
+         IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)),
       numIntPhysRegisters = 128,
       numFpPhysRegisters = 64,
       numLsuEntries = 32,

--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -30,7 +30,7 @@ trait BOOMDebugConstants
    val DEBUG_PRINTF_LSU    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_ROB    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_TAGE   = true && DEBUG_PRINTF
-   val DEBUG_PRINTF_BROB   = true && DEBUG_PRINTF
+   val DEBUG_PRINTF_BROB   = false && DEBUG_PRINTF
 
    // BPD asserts can be too heavy-handed for something that we're okay giving incorrect answers.
    val ENABLE_BPD_ASSERTS  = false

--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -61,6 +61,7 @@ trait ScalarOpConstants
    //************************************
    // Control Signals
 
+   // Issue slot.
    val s_invalid :: s_valid_1 :: s_valid_2 :: Nil = Enum(UInt(),3)
 
    // PC Select Signal

--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -30,7 +30,10 @@ trait BOOMDebugConstants
    val DEBUG_PRINTF_LSU    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_ROB    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_TAGE   = true && DEBUG_PRINTF
-   val DEBUG_PRINTF_BROB   = false && DEBUG_PRINTF
+   val DEBUG_PRINTF_BROB   = true && DEBUG_PRINTF
+
+   // BPD asserts can be too heavy-handed for something that we're okay giving incorrect answers.
+   val ENABLE_BPD_ASSERTS  = false
 
    if (O3PIPEVIEW_PRINTF) require (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF)
 }

--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -30,6 +30,7 @@ trait BOOMDebugConstants
    val DEBUG_PRINTF_LSU    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_ROB    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_TAGE   = true && DEBUG_PRINTF
+   val DEBUG_PRINTF_BROB   = false && DEBUG_PRINTF
 
    if (O3PIPEVIEW_PRINTF) require (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF)
 }

--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -40,6 +40,14 @@ trait BrPredConstants
    val TAKEN = Bool(true)
 }
 
+trait IQType
+{
+   val IQT_SZ  = 2
+   val IQT_INT = UInt(0, IQT_SZ)
+   val IQT_MEM = UInt(1, IQT_SZ)
+   val IQT_FP  = UInt(2, IQT_SZ)
+}
+
 trait ScalarOpConstants
 {
    val X = BitPat("b?")

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -228,7 +228,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 
    io.imem.ras_update <> bpd_stage.io.ras_update
    bpd_stage.io.br_unit := br_unit
-   bpd_stage.io.flush := rob.io.flush.valid
+   bpd_stage.io.flush := rob.io.flush.valid //|| rob.io.clear_brob
    bpd_stage.io.status_prv := csr.io.status.prv
    bpd_stage.io.req.ready := !fetch_unit.io.stalled
 
@@ -1037,9 +1037,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
       val numBrobWhitespace = if (DEBUG_PRINTF_BROB) NUM_BROB_ENTRIES else 0
 ////      var whitespace = (63 - 18 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH)
 //      var whitespace = (78-6 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH)
-//      var whitespace = (104-8 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
-//      var whitespace = (111-8 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
-      var whitespace = (85-7 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH)
+      var whitespace = (104-8 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
+//      var whitespace = (85-7 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
      )
 
       println("Whitespace padded: " + whitespace)

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -394,15 +394,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    rename_stage.io.flush_pipeline := rob.io.flush.valid
    rename_stage.io.debug_rob_empty := rob.io.empty
 
-   for (w <- 0 until DECODE_WIDTH)
-   {
-      rename_stage.io.dec_mask(w) := dec_will_fire(w)
-   }
-
+   rename_stage.io.dec_will_fire := dec_will_fire
    rename_stage.io.dec_uops := dec_uops
-
-
-
 
 
    var wu_idx = 0

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -1039,7 +1039,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 //      var whitespace = (78-6 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH)
 //      var whitespace = (104-8 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
 //      var whitespace = (111-8 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
-      var whitespace = (85-6 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH)
+      var whitespace = (85-7 - 10 + 4 - NUM_LSU_ENTRIES- numIssueSlotEntries.sum - numIssueSlotEntries.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH)
      )
 
       println("Whitespace padded: " + whitespace)

--- a/src/main/scala/decode.scala
+++ b/src/main/scala/decode.scala
@@ -237,13 +237,13 @@ object FDecode extends DecodeConstants
    FSW     -> List(Y, Y, Y, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N), // sort of a lie; broken into two micro-ops
    FSD     -> List(Y, Y, N, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCLASS_D-> List(Y, Y, N, uopFCLASS_D,IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCLASS_D-> List(Y, Y, N, uopFCLASS_D,IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
    FMV_D_X -> List(Y, Y, N, uopFMV_D_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMV_X_D -> List(Y, Y, N, uopFMV_X_D, IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_X_D -> List(Y, Y, N, uopFMV_X_D, IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    FSGNJ_S -> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
    FSGNJ_D -> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
@@ -268,24 +268,24 @@ object FDecode extends DecodeConstants
    FCVT_D_LU->List(Y, Y, N, uopFCVT_D_LU,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // FP to Int
-   FCVT_W_S-> List(Y, Y, Y, uopFCVT_W_S ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_WU_S->List(Y, Y, Y, uopFCVT_WU_S,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_L_S-> List(Y, Y, Y, uopFCVT_L_S ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_LU_S->List(Y, Y, Y, uopFCVT_LU_S,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_W_S-> List(Y, Y, Y, uopFCVT_W_S ,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_WU_S->List(Y, Y, Y, uopFCVT_WU_S,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_L_S-> List(Y, Y, Y, uopFCVT_L_S ,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_LU_S->List(Y, Y, Y, uopFCVT_LU_S,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FCVT_W_D-> List(Y, Y, N, uopFCVT_W_D ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_WU_D->List(Y, Y, N, uopFCVT_WU_D,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_L_D-> List(Y, Y, N, uopFCVT_L_D ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_LU_D->List(Y, Y, N, uopFCVT_LU_D,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_W_D-> List(Y, Y, N, uopFCVT_W_D ,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_WU_D->List(Y, Y, N, uopFCVT_WU_D,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_L_D-> List(Y, Y, N, uopFCVT_L_D ,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_LU_D->List(Y, Y, N, uopFCVT_LU_D,IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // "fp_single" is used for wb_data formatting (and debugging)
-   FEQ_S    ->List(Y, Y, Y, uopFEQ_S  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLT_S    ->List(Y, Y, Y, uopFLT_S  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLE_S    ->List(Y, Y, Y, uopFLE_S  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FEQ_S    ->List(Y, Y, Y, uopFEQ_S  , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLT_S    ->List(Y, Y, Y, uopFLT_S  , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLE_S    ->List(Y, Y, Y, uopFLE_S  , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FEQ_D    ->List(Y, Y, N, uopFEQ_D  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLT_D    ->List(Y, Y, N, uopFLT_D  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLE_D    ->List(Y, Y, N, uopFLE_D  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FEQ_D    ->List(Y, Y, N, uopFEQ_D  , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLT_D    ->List(Y, Y, N, uopFLT_D  , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLE_D    ->List(Y, Y, N, uopFLE_D  , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    FMIN_S   ->List(Y, Y, Y, uopFMIN_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
    FMAX_S   ->List(Y, Y, Y, uopFMAX_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),

--- a/src/main/scala/decode.scala
+++ b/src/main/scala/decode.scala
@@ -22,17 +22,17 @@ abstract trait DecodeConstants
   val xpr64 = Y // TODO inform this from xLen
 
   def decode_default: List[BitPat] =
-            //                                                         frs3_en                                wakeup_delay
-            //     is val inst?                                        |  imm sel                             |                    bypassable (aka, known/fixed latency)
-            //     |  is fp inst?                                      |  |     is_load                       |                    |  br/jmp
-            //     |  |  is single-prec?               rs1 regtype     |  |     |  is_store                   |                    |  |  is jal
-            //     |  |  |  micro-code                 |       rs2 type|  |     |  |  is_amo                  |                    |  |  |  allocate_brtag
-            //     |  |  |  |         func unit        |       |       |  |     |  |  |  is_fence             |                    |  |  |  |
-            //     |  |  |  |         |                |       |       |  |     |  |  |  |  is_fencei         |                    |  |  |  |
-            //     |  |  |  |         |        dst     |       |       |  |     |  |  |  |  |  mem    mem     |                    |  |  |  |  is unique? (clear pipeline for it)
-            //     |  |  |  |         |        regtype |       |       |  |     |  |  |  |  |  cmd    msk     |                    |  |  |  |  |  flush on commit
-            //     |  |  |  |         |        |       |       |       |  |     |  |  |  |  |  |      |       |                    |  |  |  |  |  |  csr cmd
-              List(N, N, X, uopX    , FU_X   ,RT_X,BitPat.DC(2),BitPat.DC(2),X,IS_X,X,X,X,X,N, M_X,   MSK_X,  BitPat.DC(2),        X, X, X, X, N, X, CSR.X)
+            //                                                                 frs3_en                                wakeup_delay
+            //     is val inst?                                                |  imm sel                             |                    bypassable (aka, known/fixed latency)
+            //     |  is fp inst?                                              |  |     is_load                       |                    |  br/jmp
+            //     |  |  is single-prec?                      rs1 regtype      |  |     |  is_store                   |                    |  |  is jal
+            //     |  |  |  micro-code                         |       rs2 type|  |     |  |  is_amo                  |                    |  |  |  allocate_brtag
+            //     |  |  |  |                 func unit        |       |       |  |     |  |  |  is_fence             |                    |  |  |  |
+            //     |  |  |  |                 |                |       |       |  |     |  |  |  |  is_fencei         |                    |  |  |  |
+            //     |  |  |  |                 |        dst     |       |       |  |     |  |  |  |  |  mem    mem     |                    |  |  |  |  is unique? (clear pipeline for it)
+            //     |  |  |  |                 |        regtype |       |       |  |     |  |  |  |  |  cmd    msk     |                    |  |  |  |  |  flush on commit
+            //     |  |  |  |                 |        |       |       |       |  |     |  |  |  |  |  |      |       |                    |  |  |  |  |  |  csr cmd
+              List(N, N, X, uopX   , IQT_INT, FU_X   ,RT_X,BitPat.DC(2),BitPat.DC(2),X,IS_X,X,X,X,X,N, M_X,   MSK_X,  BitPat.DC(2),        X, X, X, X, N, X, CSR.X)
 
   val table: Array[(BitPat, List[BitPat])]
 // scalastyle:on
@@ -44,6 +44,7 @@ class CtrlSigs extends Bundle
    val fp_val          = Bool()
    val fp_single       = Bool()
    val uopc            = UInt(width = UOPC_SZ)
+   val iqtype          = UInt(width = IQT_SZ)
    val fu_code         = UInt(width = FUC_SZ)
    val dst_type        = UInt(width=2)
    val rs1_type        = UInt(width=2)
@@ -70,7 +71,7 @@ class CtrlSigs extends Bundle
    def decode(inst: UInt, table: Iterable[(BitPat, List[BitPat])]) = {
       val decoder = rocket.DecodeLogic(inst, XDecode.decode_default, table)
       val sigs =
-         Seq(legal, fp_val, fp_single, uopc, fu_code, dst_type, rs1_type
+         Seq(legal, fp_val, fp_single, uopc, iqtype, fu_code, dst_type, rs1_type
          , rs2_type, frs3_en, imm_sel, is_load, is_store, is_amo
          , is_fence, is_fencei, mem_cmd, mem_typ, wakeup_delay, bypassable
          , br_or_jmp, is_jal, allocate_brtag, inst_unique, flush_on_commit, csr_cmd)
@@ -84,135 +85,135 @@ class CtrlSigs extends Bundle
 object XDecode extends DecodeConstants
 {
 // scalastyle:off
-            //                                                         frs3_en                                wakeup_delay
-            //     is val inst?                                        |  imm sel                             |        bypassable (aka, known/fixed latency)
-            //     |  is fp inst?                                      |  |     is_load                       |        |  br/jmp
-            //     |  |  is single-prec?               rs1 regtype     |  |     |  is_store                   |        |  |  is jal
-            //     |  |  |  micro-code                 |       rs2 type|  |     |  |  is_amo                  |        |  |  |  allocate_brtag
-            //     |  |  |  |         func unit        |       |       |  |     |  |  |  is_fence             |        |  |  |  |
-            //     |  |  |  |         |                |       |       |  |     |  |  |  |  is_fencei         |        |  |  |  |
-            //     |  |  |  |         |        dst     |       |       |  |     |  |  |  |  |  mem    mem     |        |  |  |  |  is unique? (clear pipeline for it)
-            //     |  |  |  |         |        regtype |       |       |  |     |  |  |  |  |  cmd    msk     |        |  |  |  |  |  flush on commit
-            //     |  |  |  |         |        |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  csr cmd
-   val table: Array[(BitPat, List[BitPat])] = Array(// |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  |
-   LD      -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_D , UInt(3), N, N, N, N, N, N, CSR.N),
-   LW      -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_W , UInt(3), N, N, N, N, N, N, CSR.N),
-   LWU     -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_WU, UInt(3), N, N, N, N, N, N, CSR.N),
-   LH      -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_H , UInt(3), N, N, N, N, N, N, CSR.N),
-   LHU     -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_HU, UInt(3), N, N, N, N, N, N, CSR.N),
-   LB      -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_B , UInt(3), N, N, N, N, N, N, CSR.N),
-   LBU     -> List(Y, N, X, uopLD   , FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_BU, UInt(3), N, N, N, N, N, N, CSR.N),
+            //                                                                  frs3_en                                wakeup_delay
+            //     is val inst?                                                 |  imm sel                             |        bypassable (aka, known/fixed latency)
+            //     |  is fp inst?                                               |  |     is_load                       |        |  br/jmp
+            //     |  |  is single-prec?                        rs1 regtype     |  |     |  is_store                   |        |  |  is jal
+            //     |  |  |  micro-code                          |       rs2 type|  |     |  |  is_amo                  |        |  |  |  allocate_brtag
+            //     |  |  |  |         iq-type  func unit        |       |       |  |     |  |  |  is_fence             |        |  |  |  |
+            //     |  |  |  |         |        |                |       |       |  |     |  |  |  |  is_fencei         |        |  |  |  |
+            //     |  |  |  |         |        |        dst     |       |       |  |     |  |  |  |  |  mem    mem     |        |  |  |  |  is unique? (clear pipeline for it)
+            //     |  |  |  |         |        |        regtype |       |       |  |     |  |  |  |  |  cmd    msk     |        |  |  |  |  |  flush on commit
+            //     |  |  |  |         |        |        |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  csr cmd
+   val table: Array[(BitPat, List[BitPat])] = Array(//  |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  |
+   LD      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_D , UInt(3), N, N, N, N, N, N, CSR.N),
+   LW      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_W , UInt(3), N, N, N, N, N, N, CSR.N),
+   LWU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_WU, UInt(3), N, N, N, N, N, N, CSR.N),
+   LH      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_H , UInt(3), N, N, N, N, N, N, CSR.N),
+   LHU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_HU, UInt(3), N, N, N, N, N, N, CSR.N),
+   LB      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_B , UInt(3), N, N, N, N, N, N, CSR.N),
+   LBU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_BU, UInt(3), N, N, N, N, N, N, CSR.N),
 
-   SD      -> List(Y, N, X, uopSTA  , FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
-   SW      -> List(Y, N, X, uopSTA  , FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N),
-   SH      -> List(Y, N, X, uopSTA  , FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_H , UInt(0), N, N, N, N, N, N, CSR.N),
-   SB      -> List(Y, N, X, uopSTA  , FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_B , UInt(0), N, N, N, N, N, N, CSR.N),
+   SD      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
+   SW      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N),
+   SH      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_H , UInt(0), N, N, N, N, N, N, CSR.N),
+   SB      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MSK_B , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   LUI     -> List(Y, N, X, uopLUI  , FU_ALU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   LUI     -> List(Y, N, X, uopLUI  , IQT_INT, FU_ALU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
 
-   ADDI    -> List(Y, N, X, uopADDI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   ANDI    -> List(Y, N, X, uopANDI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   ORI     -> List(Y, N, X, uopORI  , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   XORI    -> List(Y, N, X, uopXORI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLTI    -> List(Y, N, X, uopSLTI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLTIU   -> List(Y, N, X, uopSLTIU, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLLI    -> List(Y, N, X, uopSLLI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRAI    -> List(Y, N, X, uopSRAI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRLI    -> List(Y, N, X, uopSRLI , FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   ADDI    -> List(Y, N, X, uopADDI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   ANDI    -> List(Y, N, X, uopANDI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   ORI     -> List(Y, N, X, uopORI  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   XORI    -> List(Y, N, X, uopXORI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLTI    -> List(Y, N, X, uopSLTI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLTIU   -> List(Y, N, X, uopSLTIU, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLLI    -> List(Y, N, X, uopSLLI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRAI    -> List(Y, N, X, uopSRAI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRLI    -> List(Y, N, X, uopSRLI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
 
-   ADDIW   -> List(Y, N, X, uopADDIW, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLLIW   -> List(Y, N, X, uopSLLIW, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRAIW   -> List(Y, N, X, uopSRAIW, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRLIW   -> List(Y, N, X, uopSRLIW, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   ADDIW   -> List(Y, N, X, uopADDIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLLIW   -> List(Y, N, X, uopSLLIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRAIW   -> List(Y, N, X, uopSRAIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRLIW   -> List(Y, N, X, uopSRLIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
 
-   SLL     -> List(Y, N, X, uopSLL  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   ADD     -> List(Y, N, X, uopADD  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SUB     -> List(Y, N, X, uopSUB  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLT     -> List(Y, N, X, uopSLT  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLTU    -> List(Y, N, X, uopSLTU , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   AND     -> List(Y, N, X, uopAND  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   OR      -> List(Y, N, X, uopOR   , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   XOR     -> List(Y, N, X, uopXOR  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRA     -> List(Y, N, X, uopSRA  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRL     -> List(Y, N, X, uopSRL  , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLL     -> List(Y, N, X, uopSLL  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   ADD     -> List(Y, N, X, uopADD  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SUB     -> List(Y, N, X, uopSUB  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLT     -> List(Y, N, X, uopSLT  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLTU    -> List(Y, N, X, uopSLTU , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   AND     -> List(Y, N, X, uopAND  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   OR      -> List(Y, N, X, uopOR   , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   XOR     -> List(Y, N, X, uopXOR  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRA     -> List(Y, N, X, uopSRA  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRL     -> List(Y, N, X, uopSRL  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
 
-   ADDW    -> List(Y, N, X, uopADDW , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SUBW    -> List(Y, N, X, uopSUBW , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SLLW    -> List(Y, N, X, uopSLLW , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRAW    -> List(Y, N, X, uopSRAW , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
-   SRLW    -> List(Y, N, X, uopSRLW , FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   ADDW    -> List(Y, N, X, uopADDW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SUBW    -> List(Y, N, X, uopSUBW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SLLW    -> List(Y, N, X, uopSLLW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRAW    -> List(Y, N, X, uopSRAW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
+   SRLW    -> List(Y, N, X, uopSRLW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(1), Y, N, N, N, N, N, CSR.N),
 
-   MUL     -> List(Y, N, X, uopMUL  , FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   MULH    -> List(Y, N, X, uopMULH , FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   MULHU   -> List(Y, N, X, uopMULHU, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   MULHSU  -> List(Y, N, X, uopMULHSU,FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   MULW    -> List(Y, N, X, uopMULW , FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   MUL     -> List(Y, N, X, uopMUL  , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   MULH    -> List(Y, N, X, uopMULH , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   MULHU   -> List(Y, N, X, uopMULHU, IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   MULHSU  -> List(Y, N, X, uopMULHSU,IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   MULW    -> List(Y, N, X, uopMULW , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   DIV     -> List(Y, N, X, uopDIV  , FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   DIVU    -> List(Y, N, X, uopDIVU , FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   REM     -> List(Y, N, X, uopREM  , FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   REMU    -> List(Y, N, X, uopREMU , FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   DIVW    -> List(Y, N, X, uopDIVW , FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   DIVUW   -> List(Y, N, X, uopDIVUW, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   REMW    -> List(Y, N, X, uopREMW , FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   REMUW   -> List(Y, N, X, uopREMUW, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   DIV     -> List(Y, N, X, uopDIV  , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   DIVU    -> List(Y, N, X, uopDIVU , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   REM     -> List(Y, N, X, uopREM  , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   REMU    -> List(Y, N, X, uopREMU , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   DIVW    -> List(Y, N, X, uopDIVW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   DIVUW   -> List(Y, N, X, uopDIVUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   REMW    -> List(Y, N, X, uopREMW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   REMUW   -> List(Y, N, X, uopREMUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   AUIPC   -> List(Y, N, X, uopAUIPC, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MSK_X , UInt(1), N, N, N, N, N, N, CSR.N), // use BRU for the PC read
-   JAL     -> List(Y, N, X, uopJAL  , FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_J, N, N, N, N, N, M_X  , MSK_X , UInt(1), N, Y, Y, N, N, N, CSR.N),
-   JALR    -> List(Y, N, X, uopJALR , FU_BRU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), N, Y, N, Y, N, N, CSR.N),
-   BEQ     -> List(Y, N, X, uopBEQ  , FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
-   BNE     -> List(Y, N, X, uopBNE  , FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
-   BGE     -> List(Y, N, X, uopBGE  , FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
-   BGEU    -> List(Y, N, X, uopBGEU , FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
-   BLT     -> List(Y, N, X, uopBLT  , FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
-   BLTU    -> List(Y, N, X, uopBLTU , FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
+   AUIPC   -> List(Y, N, X, uopAUIPC, IQT_INT, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MSK_X , UInt(1), N, N, N, N, N, N, CSR.N), // use BRU for the PC read
+   JAL     -> List(Y, N, X, uopJAL  , IQT_INT, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_J, N, N, N, N, N, M_X  , MSK_X , UInt(1), N, Y, Y, N, N, N, CSR.N),
+   JALR    -> List(Y, N, X, uopJALR , IQT_INT, FU_BRU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(1), N, Y, N, Y, N, N, CSR.N),
+   BEQ     -> List(Y, N, X, uopBEQ  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
+   BNE     -> List(Y, N, X, uopBNE  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
+   BGE     -> List(Y, N, X, uopBGE  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
+   BGEU    -> List(Y, N, X, uopBGEU , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
+   BLT     -> List(Y, N, X, uopBLT  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
+   BLTU    -> List(Y, N, X, uopBLTU , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, Y, N, Y, N, N, CSR.N),
 
    // I-type, the immediate12 holds the CSR register.
-   CSRRW   -> List(Y, N, X, uopCSRRW, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.W),
-   CSRRS   -> List(Y, N, X, uopCSRRS, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.S),
-   CSRRC   -> List(Y, N, X, uopCSRRC, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.C),
+   CSRRW   -> List(Y, N, X, uopCSRRW, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.W),
+   CSRRS   -> List(Y, N, X, uopCSRRS, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.S),
+   CSRRC   -> List(Y, N, X, uopCSRRC, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.C),
 
-   CSRRWI  -> List(Y, N, X, uopCSRRWI,FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.W),
-   CSRRSI  -> List(Y, N, X, uopCSRRSI,FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.S),
-   CSRRCI  -> List(Y, N, X, uopCSRRCI,FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.C),
+   CSRRWI  -> List(Y, N, X, uopCSRRWI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.W),
+   CSRRSI  -> List(Y, N, X, uopCSRRSI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.S),
+   CSRRCI  -> List(Y, N, X, uopCSRRCI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.C),
 
-   SFENCE_VM->List(Y, N, X, uopSYSTEM,FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
-   SCALL   -> List(Y, N, X, uopSYSTEM,FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
-   SBREAK  -> List(Y, N, X, uopSYSTEM,FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
-   SRET    -> List(Y, N, X, uopSYSTEM,FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
-   MRET    -> List(Y, N, X, uopSYSTEM,FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
-   DRET    -> List(Y, N, X, uopSYSTEM,FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
+   SFENCE_VM->List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
+   SCALL   -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
+   SBREAK  -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
+   SRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
+   MRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
+   DRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, N, CSR.I),
 
-   WFI     -> List(Y, N, X, uopNOP   ,FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.N), // implemented as a NOP; TODO
+   WFI     -> List(Y, N, X, uopNOP   ,IQT_INT, FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.N), // implemented as a NOP; TODO
 
-   FENCE_I -> List(Y, N, X, uopNOP  , FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, Y, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.N),
-   FENCE   -> List(Y, N, X, uopFENCE, FU_MEM , RT_X  , RT_X  , RT_X  , N, IS_X, N, Y, N, Y, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.N), // TODO PERF make fence higher performance
+   FENCE_I -> List(Y, N, X, uopNOP  , IQT_INT, FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, Y, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.N),
+   FENCE   -> List(Y, N, X, uopFENCE, IQT_INT, FU_MEM , RT_X  , RT_X  , RT_X  , N, IS_X, N, Y, N, Y, N, M_X  , MSK_X , UInt(0), N, N, N, N, Y, Y, CSR.N), // TODO PERF make fence higher performance
                                                                                                                                                  // currently serializes pipeline
    // A-type
-   AMOADD_W-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N), // TODO make AMOs higherperformance
-   AMOXOR_W-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOSWAP_W->List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOAND_W-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOOR_W -> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMIN_W-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMINU_W->List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMAX_W-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMAXU_W->List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOADD_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N), // TODO make AMOs higherperformance
+   AMOXOR_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOSWAP_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOAND_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOOR_W -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMIN_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMINU_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMAX_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMAXU_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N),
 
-   AMOADD_D-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOXOR_D-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOSWAP_D->List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOAND_D-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOOR_D -> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMIN_D-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMINU_D->List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMAX_D-> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
-   AMOMAXU_D->List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOADD_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOXOR_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOSWAP_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOAND_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOOR_D -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMIN_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMINU_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMAX_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
+   AMOMAXU_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N),
 
-   LR_W    -> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N), // TODO optimize LR, SC
-   LR_D    -> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N), // note LR generates 2 micro-ops,
-   SC_W    -> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N), // one which isn't needed
-   SC_D    -> List(Y, N, X, uopAMO_AG, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N)
+   LR_W    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N), // TODO optimize LR, SC
+   LR_D    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N), // note LR generates 2 micro-ops,
+   SC_W    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MSK_W,UInt(0),N, N, N, N, Y, Y, CSR.N), // one which isn't needed
+   SC_D    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MSK_D,UInt(0),N, N, N, N, Y, Y, CSR.N)
    )
 // scalastyle:on
 }
@@ -221,91 +222,91 @@ object FDecode extends DecodeConstants
 {
 // scalastyle:off
   val table: Array[(BitPat, List[BitPat])] = Array(
-             //                                                          frs3_en                                wakeup_delay
-             //                                                          |  imm sel                             |        bypassable (aka, known/fixed latency)
-             //                                                          |  |     is_load                       |        |  br/jmp
-             //     is val inst?                         rs1 regtype     |  |     |  is_store                   |        |  |  is jal
-             //     |  is fp inst?                       |       rs2 type|  |     |  |  is_amo                  |        |  |  |  allocate_brtag
-             //     |  |  is dst single-prec?            |       |       |  |     |  |  |  is_fence             |        |  |  |  |
-             //     |  |  |  micro-opcode                |       |       |  |     |  |  |  |  is_fencei         |        |  |  |  |
-             //     |  |  |  |           func    dst     |       |       |  |     |  |  |  |  |  mem    mem     |        |  |  |  |  is unique? (clear pipeline for it)
-             //     |  |  |  |           unit    regtype |       |       |  |     |  |  |  |  |  cmd    msk     |        |  |  |  |  |  flush on commit
-             //     |  |  |  |           |       |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  csr cmd
-   FLW      -> List(Y, Y, Y, uopLD     , FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLD      -> List(Y, Y, N, uopLD     , FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSW      -> List(Y, Y, Y, uopSTA    , FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSD      -> List(Y, Y, N, uopSTA    , FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
+             //                                                                  frs3_en                                wakeup_delay
+             //                                                                  |  imm sel                             |        bypassable (aka, known/fixed latency)
+             //                                                                  |  |     is_load                       |        |  br/jmp
+             //    is val inst?                                  rs1 regtype     |  |     |  is_store                   |        |  |  is jal
+             //    |  is fp inst?                                |       rs2 type|  |     |  |  is_amo                  |        |  |  |  allocate_brtag
+             //    |  |  is dst single-prec?                     |       |       |  |     |  |  |  is_fence             |        |  |  |  |
+             //    |  |  |  micro-opcode                         |       |       |  |     |  |  |  |  is_fencei         |        |  |  |  |
+             //    |  |  |  |           iq_type  func    dst     |       |       |  |     |  |  |  |  |  mem    mem     |        |  |  |  |  is unique? (clear pipeline for it)
+             //    |  |  |  |           |        unit    regtype |       |       |  |     |  |  |  |  |  cmd    msk     |        |  |  |  |  |  flush on commit
+             //    |  |  |  |           |        |       |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  csr cmd
+   FLW     -> List(Y, Y, Y, uopLD     , IQT_MEM, FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLD     -> List(Y, Y, N, uopLD     , IQT_MEM, FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSW     -> List(Y, Y, Y, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MSK_W , UInt(0), N, N, N, N, N, N, CSR.N), // sort of a lie; broken into two micro-ops
+   FSD     -> List(Y, Y, N, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MSK_D , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCLASS_D-> List(Y, Y, N, uopFCLASS_D,FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCLASS_D-> List(Y, Y, N, uopFCLASS_D,IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMV_D_X -> List(Y, Y, N, uopFMV_D_X, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMV_X_D -> List(Y, Y, N, uopFMV_X_D, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, IQT_FP , FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_D_X -> List(Y, Y, N, uopFMV_D_X, IQT_FP , FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_X_D -> List(Y, Y, N, uopFMV_X_D, IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FSGNJ_S -> List(Y, Y, Y, uopFSGNJ_S, FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSGNJ_D -> List(Y, Y, N, uopFSGNJ_D, FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSGNJX_S-> List(Y, Y, Y, uopFSGNJ_S, FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSGNJX_D-> List(Y, Y, N, uopFSGNJ_D, FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSGNJN_S-> List(Y, Y, Y, uopFSGNJ_S, FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSGNJN_D-> List(Y, Y, N, uopFSGNJ_D, FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSGNJ_S -> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSGNJ_D -> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSGNJX_S-> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSGNJX_D-> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSGNJN_S-> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSGNJN_D-> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // FP to FP
-   FCVT_S_D-> List(Y, Y, Y, uopFCVT_S_D,FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_S-> List(Y, Y, N, uopFCVT_D_S,FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_D-> List(Y, Y, Y, uopFCVT_S_D,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_S-> List(Y, Y, N, uopFCVT_D_S,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // Int to FP
-   FCVT_S_W-> List(Y, Y, Y, uopFCVT_S_W ,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_S_WU->List(Y, Y, Y, uopFCVT_S_WU,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_S_L-> List(Y, Y, Y, uopFCVT_S_L ,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_S_LU->List(Y, Y, Y, uopFCVT_S_LU,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_W-> List(Y, Y, Y, uopFCVT_S_W ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_WU->List(Y, Y, Y, uopFCVT_S_WU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_L-> List(Y, Y, Y, uopFCVT_S_L ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_LU->List(Y, Y, Y, uopFCVT_S_LU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FCVT_D_W-> List(Y, Y, N, uopFCVT_D_W ,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_WU->List(Y, Y, N, uopFCVT_D_WU,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_L-> List(Y, Y, N, uopFCVT_D_L ,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_LU->List(Y, Y, N, uopFCVT_D_LU,FU_FPU,RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_W-> List(Y, Y, N, uopFCVT_D_W ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_WU->List(Y, Y, N, uopFCVT_D_WU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_L-> List(Y, Y, N, uopFCVT_D_L ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_LU->List(Y, Y, N, uopFCVT_D_LU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // FP to Int
-   FCVT_W_S-> List(Y, Y, Y, uopFCVT_W_S ,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_WU_S->List(Y, Y, Y, uopFCVT_WU_S,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_L_S-> List(Y, Y, Y, uopFCVT_L_S ,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_LU_S->List(Y, Y, Y, uopFCVT_LU_S,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_W_S-> List(Y, Y, Y, uopFCVT_W_S ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_WU_S->List(Y, Y, Y, uopFCVT_WU_S,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_L_S-> List(Y, Y, Y, uopFCVT_L_S ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_LU_S->List(Y, Y, Y, uopFCVT_LU_S,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FCVT_W_D-> List(Y, Y, N, uopFCVT_W_D ,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_WU_D->List(Y, Y, N, uopFCVT_WU_D,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_L_D-> List(Y, Y, N, uopFCVT_L_D ,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_LU_D->List(Y, Y, N, uopFCVT_LU_D,FU_FPU,RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_W_D-> List(Y, Y, N, uopFCVT_W_D ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_WU_D->List(Y, Y, N, uopFCVT_WU_D,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_L_D-> List(Y, Y, N, uopFCVT_L_D ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_LU_D->List(Y, Y, N, uopFCVT_LU_D,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // "fp_single" is used for wb_data formatting (and debugging)
-   FEQ_S    ->List(Y, Y, Y, uopFEQ_S  , FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLT_S    ->List(Y, Y, Y, uopFLT_S  , FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLE_S    ->List(Y, Y, Y, uopFLE_S  , FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FEQ_S    ->List(Y, Y, Y, uopFEQ_S  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLT_S    ->List(Y, Y, Y, uopFLT_S  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLE_S    ->List(Y, Y, Y, uopFLE_S  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FEQ_D    ->List(Y, Y, N, uopFEQ_D  , FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLT_D    ->List(Y, Y, N, uopFLT_D  , FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FLE_D    ->List(Y, Y, N, uopFLE_D  , FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FEQ_D    ->List(Y, Y, N, uopFEQ_D  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLT_D    ->List(Y, Y, N, uopFLT_D  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FLE_D    ->List(Y, Y, N, uopFLE_D  , IQT_FP,  FU_FPU, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FMIN_S   ->List(Y, Y, Y, uopFMIN_S , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMAX_S   ->List(Y, Y, Y, uopFMAX_S , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMIN_D   ->List(Y, Y, N, uopFMIN_D , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMAX_D   ->List(Y, Y, N, uopFMAX_D , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMIN_S   ->List(Y, Y, Y, uopFMIN_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMAX_S   ->List(Y, Y, Y, uopFMAX_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMIN_D   ->List(Y, Y, N, uopFMIN_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMAX_D   ->List(Y, Y, N, uopFMAX_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FADD_S   ->List(Y, Y, Y, uopFADD_S , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSUB_S   ->List(Y, Y, Y, uopFSUB_S , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMUL_S   ->List(Y, Y, Y, uopFMUL_S , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FADD_D   ->List(Y, Y, N, uopFADD_D , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSUB_D   ->List(Y, Y, N, uopFSUB_D , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMUL_D   ->List(Y, Y, N, uopFMUL_D , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FADD_S   ->List(Y, Y, Y, uopFADD_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSUB_S   ->List(Y, Y, Y, uopFSUB_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMUL_S   ->List(Y, Y, Y, uopFMUL_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FADD_D   ->List(Y, Y, N, uopFADD_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSUB_D   ->List(Y, Y, N, uopFSUB_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMUL_D   ->List(Y, Y, N, uopFMUL_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FMADD_S  ->List(Y, Y, Y, uopFMADD_S, FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMSUB_S  ->List(Y, Y, Y, uopFMSUB_S, FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FNMADD_S ->List(Y, Y, Y, uopFNMADD_S,FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FNMSUB_S ->List(Y, Y, Y, uopFNMSUB_S,FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMADD_D  ->List(Y, Y, N, uopFMADD_D, FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMSUB_D  ->List(Y, Y, N, uopFMSUB_D, FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FNMADD_D ->List(Y, Y, N, uopFNMADD_D,FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FNMSUB_D ->List(Y, Y, N, uopFNMSUB_D,FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N)
+   FMADD_S  ->List(Y, Y, Y, uopFMADD_S, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMSUB_S  ->List(Y, Y, Y, uopFMSUB_S, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FNMADD_S ->List(Y, Y, Y, uopFNMADD_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FNMSUB_S ->List(Y, Y, Y, uopFNMSUB_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMADD_D  ->List(Y, Y, N, uopFMADD_D, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMSUB_D  ->List(Y, Y, N, uopFMSUB_D, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FNMADD_D ->List(Y, Y, N, uopFNMADD_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FNMSUB_D ->List(Y, Y, N, uopFNMSUB_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N)
    )
 
 // scalastyle:on
@@ -315,20 +316,20 @@ object FDivSqrtDecode extends DecodeConstants
 {
 // scalastyle:off
   val table: Array[(BitPat, List[BitPat])] = Array(
-             //                                                          frs3_en                                wakeup_delay
-             //                                                          |  imm sel                             |        bypassable (aka, known/fixed latency)
-             //                                                          |  |     is_load                       |        |  br/jmp
-             //     is val inst?                         rs1 regtype     |  |     |  is_store                   |        |  |  is jal
-             //     |  is fp inst?                       |       rs2 type|  |     |  |  is_amo                  |        |  |  |  allocate_brtag
-             //     |  |  is dst single-prec?            |       |       |  |     |  |  |  is_fence             |        |  |  |  |
-             //     |  |  |  micro-opcode                |       |       |  |     |  |  |  |  is_fencei         |        |  |  |  |
-             //     |  |  |  |           func    dst     |       |       |  |     |  |  |  |  |  mem    mem     |        |  |  |  |  is unique? (clear pipeline for it)
-             //     |  |  |  |           unit    regtype |       |       |  |     |  |  |  |  |  cmd    msk     |        |  |  |  |  |  flush on commit
-             //     |  |  |  |           |       |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  csr cmd
-   FDIV_S    ->List(Y, Y, Y, uopFDIV_S , FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FDIV_D    ->List(Y, Y, N, uopFDIV_D , FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSQRT_S   ->List(Y, Y, Y, uopFSQRT_S, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FSQRT_D   ->List(Y, Y, N, uopFSQRT_D, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N)
+             //                                                                   frs3_en                                wakeup_delay
+             //                                                                   |  imm sel                             |        bypassable (aka, known/fixed latency)
+             //                                                                   |  |     is_load                       |        |  br/jmp
+             //     is val inst?                                  rs1 regtype     |  |     |  is_store                   |        |  |  is jal
+             //     |  is fp inst?                                |       rs2 type|  |     |  |  is_amo                  |        |  |  |  allocate_brtag
+             //     |  |  is dst single-prec?                     |       |       |  |     |  |  |  is_fence             |        |  |  |  |
+             //     |  |  |  micro-opcode                         |       |       |  |     |  |  |  |  is_fencei         |        |  |  |  |
+             //     |  |  |  |           iq-type  func    dst     |       |       |  |     |  |  |  |  |  mem    mem     |        |  |  |  |  is unique? (clear pipeline for it)
+             //     |  |  |  |           |        unit    regtype |       |       |  |     |  |  |  |  |  cmd    msk     |        |  |  |  |  |  flush on commit
+             //     |  |  |  |           |        |       |       |       |       |  |     |  |  |  |  |  |      |       |        |  |  |  |  |  |  csr cmd
+   FDIV_S    ->List(Y, Y, Y, uopFDIV_S , IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FDIV_D    ->List(Y, Y, N, uopFDIV_D , IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSQRT_S   ->List(Y, Y, Y, uopFSQRT_S, IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FSQRT_D   ->List(Y, Y, N, uopFSQRT_D, IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N)
    )
 // scalastyle:on
 }
@@ -381,6 +382,7 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    //-------------------------------------------------------------
 
    uop.uopc       := cs.uopc
+   uop.iqtype     := cs.iqtype
    uop.fu_code    := cs.fu_code
 
    // x-registers placed in 0-31, f-registers placed in 32-63.

--- a/src/main/scala/decode.scala
+++ b/src/main/scala/decode.scala
@@ -240,8 +240,8 @@ object FDecode extends DecodeConstants
    FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
    FCLASS_D-> List(Y, Y, N, uopFCLASS_D,IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, IQT_FP , FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FMV_D_X -> List(Y, Y, N, uopFMV_D_X, IQT_FP , FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FMV_D_X -> List(Y, Y, N, uopFMV_D_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
    FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
    FMV_X_D -> List(Y, Y, N, uopFMV_X_D, IQT_FP , FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
@@ -257,15 +257,15 @@ object FDecode extends DecodeConstants
    FCVT_D_S-> List(Y, Y, N, uopFCVT_D_S,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // Int to FP
-   FCVT_S_W-> List(Y, Y, Y, uopFCVT_S_W ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_S_WU->List(Y, Y, Y, uopFCVT_S_WU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_S_L-> List(Y, Y, Y, uopFCVT_S_L ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_S_LU->List(Y, Y, Y, uopFCVT_S_LU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_W-> List(Y, Y, Y, uopFCVT_S_W ,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_WU->List(Y, Y, Y, uopFCVT_S_WU,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_L-> List(Y, Y, Y, uopFCVT_S_L ,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_S_LU->List(Y, Y, Y, uopFCVT_S_LU,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
-   FCVT_D_W-> List(Y, Y, N, uopFCVT_D_W ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_WU->List(Y, Y, N, uopFCVT_D_WU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_L-> List(Y, Y, N, uopFCVT_D_L ,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
-   FCVT_D_LU->List(Y, Y, N, uopFCVT_D_LU,IQT_FP, FU_FPU, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_W-> List(Y, Y, N, uopFCVT_D_W ,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_WU->List(Y, Y, N, uopFCVT_D_WU,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_L-> List(Y, Y, N, uopFCVT_D_L ,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
+   FCVT_D_LU->List(Y, Y, N, uopFCVT_D_LU,IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),
 
    // FP to Int
    FCVT_W_S-> List(Y, Y, Y, uopFCVT_W_S ,IQT_FP, FU_FPU, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MSK_X , UInt(0), N, N, N, N, N, N, CSR.N),

--- a/src/main/scala/decode.scala
+++ b/src/main/scala/decode.scala
@@ -388,12 +388,12 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    // x-registers placed in 0-31, f-registers placed in 32-63.
    // This allows us to straight-up compare register specifiers and not need to
    // verify the rtypes (e.g., bypassing in rename).
-   uop.ldst       := Cat(cs.dst_type === RT_FLT, uop.inst(RD_MSB,RD_LSB))
-   uop.lrs1       := Cat(cs.rs1_type === RT_FLT, uop.inst(RS1_MSB,RS1_LSB))
-   uop.lrs2       := Cat(cs.rs2_type === RT_FLT, uop.inst(RS2_MSB,RS2_LSB))
-   uop.lrs3       := Cat(Bool(true),             uop.inst(RS3_MSB,RS3_LSB))
+   uop.ldst       := uop.inst(RD_MSB,RD_LSB)
+   uop.lrs1       := uop.inst(RS1_MSB,RS1_LSB)
+   uop.lrs2       := uop.inst(RS2_MSB,RS2_LSB)
+   uop.lrs3       := uop.inst(RS3_MSB,RS3_LSB)
 
-   uop.ldst_val   := (cs.dst_type =/= RT_X && uop.ldst =/= UInt(0))
+   uop.ldst_val   := cs.dst_type =/= RT_X && !(uop.ldst === UInt(0) && uop.dst_rtype === RT_FIX)
    uop.dst_rtype  := cs.dst_type
    uop.lrs1_rtype := cs.rs1_type
    uop.lrs2_rtype := cs.rs2_type

--- a/src/main/scala/execute.scala
+++ b/src/main/scala/execute.scala
@@ -153,6 +153,7 @@ class ALUExeUnit(
    else if (has_mul && use_slow_mul) println ("       - Mul (unpipelined)")
    else if (has_div) println ("       - Div")
    if (has_fdiv) println ("       - FDiv/FSqrt")
+   if (has_ifpu) println ("       - IFPU (for read port access)")
 
    val muldiv_busy = Wire(init=Bool(false))
    val fdiv_busy = Wire(init=Bool(false))

--- a/src/main/scala/execute.scala
+++ b/src/main/scala/execute.scala
@@ -94,6 +94,12 @@ abstract class ExecutionUnit(val num_rf_read_ports: Int
    def hasBranchUnit : Boolean = is_branch_unit
    def isBypassable  : Boolean = bypassable
    def hasFFlags     : Boolean = has_fpu || has_fdiv
+   def usesFRF       : Boolean = (has_fpu || has_fdiv) && !(has_alu || has_mul)
+   def usesIRF       : Boolean = !(has_fpu || has_fdiv) && (has_alu || has_mul || is_mem_unit)
+
+   require ((has_fpu || has_fdiv) ^ (has_alu || has_mul || is_mem_unit),
+      "[execute] we no longer support mixing FP and Integer functional units in the same exe unit.")
+
 
    def supportedFuncUnits =
    {

--- a/src/main/scala/execution_units.scala
+++ b/src/main/scala/execution_units.scala
@@ -101,9 +101,12 @@ class ExecutionUnits(fpu: Boolean = false)(implicit val p: Parameters) extends H
                                           , has_mul          = true
                                           , use_slow_mul     = true // TODO
                                           , has_div          = true
-                                          , has_ifpu         = true
+                                          , has_ifpu         = issueWidths(1)==1
                                           ))
-      for (w <- 0 until issueWidths(1)-1) exe_units += Module(new ALUExeUnit())
+      for (w <- 0 until issueWidths(1)-1) {
+         val is_last = w == (issueWidths(1)-2)
+         exe_units += Module(new ALUExeUnit(has_ifpu = is_last))
+      }
    } else {                                     
       require (usingFPU)
       require (issueWidths(2) <= 1) // TODO, hacks to fix include uopSTD_fp needing a proper func unit.
@@ -137,5 +140,4 @@ class ExecutionUnits(fpu: Boolean = false)(implicit val p: Parameters) extends H
    val num_fpu_ports = exe_units.withFilter(_.hasFFlags).map(_.num_rf_write_ports).foldLeft(0)(_+_)
 
    val num_wakeup_ports = num_slow_wakeup_ports + num_fast_wakeup_ports
-   val rf_cost = (num_rf_read_ports+num_rf_write_ports)*(num_rf_read_ports+2*num_rf_write_ports)
 }

--- a/src/main/scala/execution_units.scala
+++ b/src/main/scala/execution_units.scala
@@ -98,7 +98,7 @@ class ExecutionUnits(fpu: Boolean = false)(implicit val p: Parameters) extends H
       exe_units += Module(new ALUExeUnit(is_branch_unit      = true
                                           , shares_csr_wport = true
                                           , has_mul          = true
-                                          , use_slow_mul     = true // TODO
+                                          , use_slow_mul     = false
                                           , has_div          = true
                                           , has_ifpu         = int_width==1
                                           ))

--- a/src/main/scala/fppipeline.scala
+++ b/src/main/scala/fppipeline.scala
@@ -23,9 +23,10 @@ class FpPipeline(
 {
    val fpIssueParams = issueParams.find(_.iqType == IQT_FP.litValue).get
    // TODO roll i2f into mem port.
-   val num_i2f_ports = 1 // hard-wired
-   val num_mem_ports = 1 // hard-wired
-   val num_wakeup_ports = fpIssueParams.issueWidth+ + num_mem_ports + num_i2f_ports
+   val num_ll_ports = 1 // hard-wired; used by mem port and i2f port.
+//   val num_i2f_ports = 1 // hard-wired
+//   val num_mem_ports = 1 // hard-wired
+   val num_wakeup_ports = fpIssueParams.issueWidth + num_ll_ports
    val fp_preg_sz = log2Up(numFpPhysRegs)
 
    val io = new Bundle
@@ -39,18 +40,10 @@ class FpPipeline(
       val dis_readys       = Vec(DISPATCH_WIDTH, Bool()).asOutput
 
       // +1 for recoding.
-      val ll_wport         = Valid(new RegisterFileWritePort(fp_preg_sz, fLen+1)).flip
-      val ll_wport_uop     = (new MicroOp()).asInput // TODO consolidate this with ll_wport
+      val ll_wport         = Valid(new ExeUnitResp(fLen+1)).flip
       val fromint          = Valid(new FuncUnitReq(fLen+1)).flip
       val tosdq            = Valid(new MicroOpWithData(fLen))
-      val toint            = Decoupled(new RegisterFileWritePort(log2Up(numIntPhysRegs), xLen))
-//      val toint            = Decoupled(new Bundle {
-//                              val port = new RegisterFileWritePortIO(log2Up(numIntPhysRegs), xLen).flip
-//                              val uop = new MicroOp()
-//                              )}
-//      need to turn this into a decoupled
-      val toint_uop        = (new MicroOp()).asOutput
-
+      val toint            = Decoupled(new ExeUnitResp(xLen))
       val wakeups          = Vec(num_wakeup_ports, Valid(new ExeUnitResp(fLen+1)))
       val wb_valids        = Vec(num_wakeup_ports, Bool()).asInput
       val wb_pdsts         = Vec(num_wakeup_ports, UInt(width=fp_preg_sz)).asInput
@@ -66,7 +59,9 @@ class FpPipeline(
    // Add a write-port for long latency operations (HACK XXX two - one for mem, the other for ifpu).
    val fregfile         = Module(new RegisterFile(numFpPhysRegs,
                                  exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_read_ports).sum,
-                                 exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum + 2,
+                                 // TODO get rid of -1, as that's a write-port going to IRF
+                                 exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum - 1 +
+                                    num_ll_ports, //num_mem_ports + num_i2f_ports,
                                  fLen+1,
                                  ENABLE_REGFILE_BYPASSING))// TODO disable for FP
    val fregister_read   = Module(new RegisterRead(
@@ -80,15 +75,16 @@ class FpPipeline(
    require (exe_units.withFilter(_.uses_iss_unit).map(x=>x).length == issue_unit.issue_width)
 
    // we're playing fast and loose on the number of wakeup and write ports.
-   require (exe_units.map(_.num_rf_write_ports).sum+1 == num_wakeup_ports)
-   require (exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum + 2 == num_wakeup_ports)
+   // TODO XXX and the -1 is for the F2I port; -1 for I2F port.
+   println (exe_units.map(_.num_rf_write_ports).sum)
+   require (exe_units.map(_.num_rf_write_ports).sum -1-1  + num_ll_ports == num_wakeup_ports)
+   require (exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum -1 + num_ll_ports == num_wakeup_ports)
 
    override def toString: String =
       fregfile.toString +
-      "   Num Slow Wakeup Ports : " + exe_units.num_slow_wakeup_ports +
-      "\n   Num Fast Wakeup Ports : " + exe_units.num_fast_wakeup_ports +
+      "\n   Num Wakeup Ports      : " + num_wakeup_ports +
       "\n   Num Bypass Ports      : " + exe_units.num_total_bypass_ports + "\n"
- 
+
 
    //***********************************
    // Pipeline State Registers and Wires
@@ -98,13 +94,13 @@ class FpPipeline(
    val iss_uops       = Wire(Vec(exe_units.withFilter(_.uses_iss_unit).map(x=>x).length, new MicroOp()))
 
    require (exe_units.num_total_bypass_ports == 0)
- 
+
    //-------------------------------------------------------------
    //-------------------------------------------------------------
    // **** Dispatch Stage ****
    //-------------------------------------------------------------
    //-------------------------------------------------------------
- 
+
    // Input (Dispatch)
    for (w <- 0 until DISPATCH_WIDTH)
    {
@@ -125,9 +121,8 @@ class FpPipeline(
    issue_unit.io.tsc_reg := io.debug_tsc_reg
    issue_unit.io.brinfo := io.brinfo
    issue_unit.io.flush_pipeline := io.flush_pipeline
-   
+
    // Output (Issue)
-//   for ((eu, w) <- 0 until exe_units.withFilter(_.uses_iss_unit).map(e => e).zipWithIndex)
    for (i <- 0 until issue_unit.issue_width)
    {
       iss_valids(i) := issue_unit.io.iss_valids(i)
@@ -160,7 +155,7 @@ class FpPipeline(
    fregister_read.io.brinfo := io.brinfo
    fregister_read.io.kill   := io.flush_pipeline
 
- 
+
    //-------------------------------------------------------------
    //-------------------------------------------------------------
    // **** Execute Stage ****
@@ -176,7 +171,7 @@ class FpPipeline(
       require (!ex.isBypassable)
 
       // TODO HACK only let one FPU issue port issue these.
-      require (w == 0) 
+      require (w == 0)
       when (fregister_read.io.exe_reqs(w).bits.uop.uopc === uopSTD) {
          ex.io.req.valid :=  Bool(false)
       }
@@ -184,17 +179,17 @@ class FpPipeline(
       io.tosdq.valid    := fregister_read.io.exe_reqs(w).bits.uop.uopc === uopSTD
       io.tosdq.bits.uop := fregister_read.io.exe_reqs(w).bits.uop
       val sdata = fregister_read.io.exe_reqs(w).bits.rs2_data
-      
+
       val unrec_s = hardfloat.fNFromRecFN(8, 24, sdata)
       val unrec_d = hardfloat.fNFromRecFN(11, 53, sdata)
       val unrec_out = Mux(io.tosdq.bits.uop.fp_single, Cat(Fill(32, unrec_s(31)), unrec_s), unrec_d)
-      
+
       io.tosdq.bits.data := unrec_out
    }
    require (exe_units.num_total_bypass_ports == 0)
 
    exe_units.ifpu_unit.io.req <> io.fromint
-    
+
    //-------------------------------------------------------------
    //-------------------------------------------------------------
    // **** Writeback Stage ****
@@ -202,8 +197,16 @@ class FpPipeline(
    //-------------------------------------------------------------
 
    // TODO add fdivsqrt to this port
-   // TODO XXX add ifpu to ll_wport, instead of giving all exe_units a dedicated port.
-   fregfile.io.write_ports(0) <> io.ll_wport
+   val ifpu_resp = exe_units.ifpu_unit.io.resp(0)
+   val ll_wbarb = Module(new Arbiter(new ExeUnitResp(fLen+1), 2))
+   ll_wbarb.io.in(0) <> io.ll_wport
+   ll_wbarb.io.in(1) <> ifpu_resp
+
+   fregfile.io.write_ports(0) <> WritePort(ll_wbarb.io.out, FPREG_SZ, fLen+1)
+
+   assert (ll_wbarb.io.in(0).ready) // never backpressure the memory unit.
+   when (ifpu_resp.valid) { assert (ifpu_resp.bits.uop.ctrl.rf_wen && ifpu_resp.bits.uop.dst_rtype === RT_FLT) }
+
 
    var w_cnt = 1
    for (i <- 0 until exe_units.length)
@@ -211,28 +214,30 @@ class FpPipeline(
       for (j <- 0 until exe_units(i).num_rf_write_ports)
       {
          val wbresp = exe_units(i).io.resp(j)
+         println("ExeUnit(" + i + "), Resp Port: " + j + " writes FRF: " + !wbresp.bits.writesToIRF + ", fromInt:" +
+            exe_units(i).has_ifpu)
 
          val toint = wbresp.bits.uop.dst_rtype === RT_FIX
 
-         fregfile.io.write_ports(w_cnt).valid :=
-            wbresp.valid &&
-            wbresp.bits.uop.ctrl.rf_wen &&
-            !toint
-         fregfile.io.write_ports(w_cnt).bits.addr :=
-            wbresp.bits.uop.pdst
-         fregfile.io.write_ports(w_cnt).bits.data :=
-            wbresp.bits.data
-
-
-         if (i==0 && j==0) {
-            io.toint.valid     := wbresp.valid && toint
-            io.toint.bits.addr := wbresp.bits.uop.pdst
-            io.toint.bits.data := wbresp.bits.data
-            io.toint_uop       := wbresp.bits.uop
+         if (wbresp.bits.writesToIRF) {
+            require(i==0 && j==1) // TODO super hacky... delete me once everything works
+            assert(!(wbresp.valid && !toint))
+            io.toint <> wbresp
+         } else if (exe_units(i).has_ifpu) {
+            // share with ll unit
+         } else {
+            assert (!(wbresp.valid && toint))
+            fregfile.io.write_ports(w_cnt).valid :=
+               wbresp.valid &&
+               wbresp.bits.uop.ctrl.rf_wen
+            fregfile.io.write_ports(w_cnt).bits.addr := wbresp.bits.uop.pdst
+            fregfile.io.write_ports(w_cnt).bits.data := wbresp.bits.data
+            wbresp.ready := fregfile.io.write_ports(w_cnt).ready
          }
+
          // need to make sure toint uops only ever come out of this wbresp port.
          // TODO add check on write port to check if it supports toint moves.
-         require ((i==0 && j==0) || !(exe_units(i).uses_iss_unit))
+         require ((i==0 && (j==0 || j==1)) || !(exe_units(i).uses_iss_unit))
 
          assert (!(wbresp.valid &&
             !wbresp.bits.uop.ctrl.rf_wen &&
@@ -244,8 +249,8 @@ class FpPipeline(
             wbresp.bits.uop.dst_rtype =/= RT_FLT &&
             !toint),
             "[fppipeline] A writeback is being attempted to the FP RF with dst != FP type.")
-         
-         w_cnt += 1
+
+         if (!wbresp.bits.writesToIRF && !exe_units(i).has_ifpu) w_cnt += 1
       }
    }
    require (w_cnt == fregfile.io.write_ports.length)
@@ -257,36 +262,35 @@ class FpPipeline(
    //-------------------------------------------------------------
    //-------------------------------------------------------------
 
-   // TODO the wakeup is being handled in core.scala for memory, but not other ll stuff.
-   io.wakeups(0).valid := io.ll_wport.valid
-   io.wakeups(0).bits.uop := io.ll_wport_uop
-   io.wakeups(0).bits.data := io.ll_wport.bits.data
-   io.wakeups(0).bits.fflags.valid := Bool(false)
+   io.wakeups(0) <> ll_wbarb.io.out
+   ll_wbarb.io.out.ready := Bool(true)
 
    w_cnt = 1
    for (eu <- exe_units)
    {
-      // exe_units == 2
-      //    exe_resp == 1
-      // wakeups == 3 (2+mem)
       for (exe_resp <- eu.io.resp)
       {
          println("FP exe-resp, w=" + w_cnt)
          val wb_uop = exe_resp.bits.uop
-         val wport = io.wakeups(w_cnt)
-         wport <> exe_resp
-         wport.valid := exe_resp.valid && wb_uop.dst_rtype === RT_FLT
-         w_cnt += 1
 
-         assert(!(exe_resp.valid && wb_uop.is_store))
-         assert(!(exe_resp.valid && wb_uop.is_load))
-         assert(!(exe_resp.valid && wb_uop.is_amo))
+         if (!exe_resp.bits.writesToIRF && !eu.has_ifpu) {
+            println("Hooking up to FRF, not a ll")
+            val wport = io.wakeups(w_cnt)
+            wport <> exe_resp
+            wport.valid := exe_resp.valid && wb_uop.dst_rtype === RT_FLT
+
+            w_cnt += 1
+
+            assert(!(exe_resp.valid && wb_uop.is_store))
+            assert(!(exe_resp.valid && wb_uop.is_load))
+            assert(!(exe_resp.valid && wb_uop.is_amo))
+         }
       }
    }
-    
+
 
    exe_units.map(_.io.fcsr_rm := io.fcsr_rm)
- 
+
    //-------------------------------------------------------------
    // **** Flush Pipeline ****
    //-------------------------------------------------------------
@@ -296,5 +300,5 @@ class FpPipeline(
    {
       exe_units(w).io.req.bits.kill := io.flush_pipeline
    }
-    
+
 }

--- a/src/main/scala/fppipeline.scala
+++ b/src/main/scala/fppipeline.scala
@@ -64,7 +64,6 @@ class FpPipeline(
                                  exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum + 2,
                                  fLen+1,
                                  ENABLE_REGFILE_BYPASSING))// TODO disable for FP
-   println("fp: rrd")
    val fregister_read   = Module(new RegisterRead(
                                  issue_unit.issue_width,
                                  exe_units.withFilter(_.uses_iss_unit).map(_.supportedFuncUnits),
@@ -73,7 +72,6 @@ class FpPipeline(
                                  exe_units.num_total_bypass_ports,
                                  fLen+1))
 
-   println("fp: done building")
    require (exe_units.withFilter(_.uses_iss_unit).map(x=>x).length == issue_unit.issue_width)
 
    // we're playing fast and loose on the number of wakeup and write ports.
@@ -81,10 +79,7 @@ class FpPipeline(
    require (exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum + 2 == num_wakeup_ports)
 
    override def toString: String =
-      "\n   Floating Point Regfile: " +
-      "\n   Num RF Read Ports     : " + exe_units.num_rf_read_ports +
-      "\n   Num RF Write Ports    : " + exe_units.num_rf_write_ports + 
-      "\n   RF Cost (R+W)*(R+2W)  : " + exe_units.rf_cost + 
+      print(fregfile) +
       "\n   Num Slow Wakeup Ports : " + exe_units.num_slow_wakeup_ports +
       "\n   Num Fast Wakeup Ports : " + exe_units.num_fast_wakeup_ports +
       "\n   Num Bypass Ports      : " + exe_units.num_total_bypass_ports + "\n"

--- a/src/main/scala/fppipeline.scala
+++ b/src/main/scala/fppipeline.scala
@@ -162,11 +162,12 @@ class FpPipeline(
    //-------------------------------------------------------------
    //-------------------------------------------------------------
 
+   exe_units.map(_.io.brinfo := io.brinfo)
+   exe_units.map(_.io.com_exception := io.flush_pipeline)
+
    for ((ex,w) <- exe_units.withFilter(_.uses_iss_unit).map(x=>x).zipWithIndex)
    {
       ex.io.req <> fregister_read.io.exe_reqs(w)
-      ex.io.brinfo := io.brinfo
-      ex.io.com_exception := io.flush_pipeline
       require (!ex.isBypassable)
 
       // TODO HACK only let one FPU issue port issue these.

--- a/src/main/scala/fppipeline.scala
+++ b/src/main/scala/fppipeline.scala
@@ -1,0 +1,301 @@
+//******************************************************************************
+// Copyright (c) 2015, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Floating Point Datapath Pipeline
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//
+// Christopher Celio
+
+// The floating point issue window, regfile, and arithmetic units are all handled here.
+
+
+package boom
+
+import Chisel._
+import config.Parameters
+
+
+class FpPipeline(
+)(implicit p: Parameters) extends BoomModule()(p)
+{
+   val num_wakeup_ports = issueWidths(2)+2
+   val fp_preg_sz = log2Up(numFpPhysRegs)
+
+   val io = new Bundle
+   {
+      val brinfo           = new BrResolutionInfo().asInput
+      val flush_pipeline   = Bool(INPUT)
+      val fcsr_rm          = UInt(INPUT, tile.FPConstants.RM_SZ)
+
+      val dis_valids       = Vec(DISPATCH_WIDTH, Bool()).asInput
+      val dis_uops         = Vec(DISPATCH_WIDTH, new MicroOp()).asInput
+      val dis_readys       = Vec(DISPATCH_WIDTH, Bool()).asOutput
+
+      // +1 for recoding.
+      val ll_wport         = new RegisterFileWritePortIO(fp_preg_sz, fLen+1)
+      val ll_wport_uop     = (new MicroOp()).asInput // TODO consolidate this with ll_wport
+      val fromint          = Valid(new FuncUnitReq(fLen+1)).flip
+      val tosdq            = Valid(new MicroOpWithData(fLen))
+      val toint            = new RegisterFileWritePortIO(log2Up(numIntPhysRegs), xLen).flip
+      val toint_uop        = (new MicroOp()).asOutput
+
+      val wakeups          = Vec(num_wakeup_ports, Valid(new ExeUnitResp(fLen+1)))
+      val wb_valids        = Vec(num_wakeup_ports, Bool()).asInput
+      val wb_pdsts         = Vec(num_wakeup_ports, UInt(width=fp_preg_sz)).asInput
+
+      //TODO -- hook up commit log stuff.
+      val debug_tsc_reg    = UInt(INPUT, xLen)
+
+//      val events
+   }
+
+   val exe_units        = new boom.ExecutionUnits(fpu=true)
+   val issue_unit       = Module(new IssueUnitCollasping(
+                           numIssueSlotEntries(2), 
+                           issueWidths(2), 
+                           num_wakeup_ports, 
+                           IQT_FP.litValue.intValue))
+   // Add a write-port for long latency operations (HACK XXX two - one for mem, the other for ifpu).
+   val fregfile         = Module(new RegisterFile(numFpPhysRegs,
+                                 exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_read_ports).sum,
+                                 exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum + 2,
+                                 fLen+1,
+                                 ENABLE_REGFILE_BYPASSING))// TODO disable for FP
+   println("fp: rrd")
+   val fregister_read   = Module(new RegisterRead(
+                                 issue_unit.issue_width,
+                                 exe_units.withFilter(_.uses_iss_unit).map(_.supportedFuncUnits),
+                                 exe_units.withFilter(_.uses_iss_unit).map(_.num_rf_read_ports).sum,
+                                 exe_units.withFilter(_.uses_iss_unit).map(_.num_rf_read_ports),
+                                 exe_units.num_total_bypass_ports,
+                                 fLen+1))
+
+   println("fp: done building")
+   require (exe_units.withFilter(_.uses_iss_unit).map(x=>x).length == issue_unit.issue_width)
+
+   // we're playing fast and loose on the number of wakeup and write ports.
+   require (exe_units.map(_.num_rf_write_ports).sum+1 == num_wakeup_ports)
+   require (exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum + 2 == num_wakeup_ports)
+
+   override def toString: String =
+      "\n   Floating Point Regfile: " +
+      "\n   Num RF Read Ports     : " + exe_units.num_rf_read_ports +
+      "\n   Num RF Write Ports    : " + exe_units.num_rf_write_ports + 
+      "\n   RF Cost (R+W)*(R+2W)  : " + exe_units.rf_cost + 
+      "\n   Num Slow Wakeup Ports : " + exe_units.num_slow_wakeup_ports +
+      "\n   Num Fast Wakeup Ports : " + exe_units.num_fast_wakeup_ports +
+      "\n   Num Bypass Ports      : " + exe_units.num_total_bypass_ports + "\n"
+ 
+
+   //***********************************
+   // Pipeline State Registers and Wires
+
+   // Issue Stage/Register Read
+   val iss_valids     = Wire(Vec(exe_units.withFilter(_.uses_iss_unit).map(x=>x).length, Bool()))
+   val iss_uops       = Wire(Vec(exe_units.withFilter(_.uses_iss_unit).map(x=>x).length, new MicroOp()))
+
+   require (exe_units.num_total_bypass_ports == 0)
+ 
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+   // **** Dispatch Stage ****
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+ 
+   // Input (Dispatch)
+   for (w <- 0 until DISPATCH_WIDTH)
+   {
+      issue_unit.io.dis_valids(w) := io.dis_valids(w) && io.dis_uops(w).iqtype === UInt(issue_unit.iqType)
+      issue_unit.io.dis_uops(w) := io.dis_uops(w)
+
+      // Or... add STDataGen micro-op for FP stores.
+      when (io.dis_uops(w).uopc === uopSTA && io.dis_uops(w).lrs2_rtype === RT_FLT) {
+         issue_unit.io.dis_valids(w) := io.dis_valids(w)
+         issue_unit.io.dis_uops(w).uopc := uopSTD
+         issue_unit.io.dis_uops(w).fu_code := FUConstants.FU_FPU
+         issue_unit.io.dis_uops(w).lrs1_rtype := RT_X
+         issue_unit.io.dis_uops(w).prs1_busy := Bool(false)
+      }
+   }
+   io.dis_readys := issue_unit.io.dis_readys
+
+   issue_unit.io.tsc_reg := io.debug_tsc_reg
+   issue_unit.io.brinfo := io.brinfo
+   issue_unit.io.flush_pipeline := io.flush_pipeline
+   
+   // Output (Issue)
+//   for ((eu, w) <- 0 until exe_units.withFilter(_.uses_iss_unit).map(e => e).zipWithIndex)
+   for (i <- 0 until issue_unit.issue_width)
+   {
+      iss_valids(i) := issue_unit.io.iss_valids(i)
+      iss_uops(i) := issue_unit.io.iss_uops(i)
+      issue_unit.io.fu_types(i) := exe_units(i).io.fu_types
+
+      require (exe_units(i).uses_iss_unit)
+   }
+
+
+   // Wakeup
+   for ((writeback, issue_wakeup) <- io.wakeups zip issue_unit.io.wakeup_pdsts)
+   {
+      issue_wakeup.valid := writeback.valid
+      issue_wakeup.bits  := writeback.bits.uop.pdst
+   }
+
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+   // **** Register Read Stage ****
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+
+   // Register Read <- Issue (rrd <- iss)
+   fregister_read.io.rf_read_ports <> fregfile.io.read_ports
+
+   fregister_read.io.iss_valids <> iss_valids
+   fregister_read.io.iss_uops := iss_uops
+
+   fregister_read.io.brinfo := io.brinfo
+   fregister_read.io.kill   := io.flush_pipeline
+
+ 
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+   // **** Execute Stage ****
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+
+   for ((ex,w) <- exe_units.withFilter(_.uses_iss_unit).map(x=>x).zipWithIndex)
+   {
+      ex.io.req <> fregister_read.io.exe_reqs(w)
+      ex.io.brinfo := io.brinfo
+      ex.io.com_exception := io.flush_pipeline
+      require (!ex.isBypassable)
+
+      // TODO HACK only let one FPU issue port issue these.
+      require (w == 0) 
+      when (fregister_read.io.exe_reqs(w).bits.uop.uopc === uopSTD) {
+         ex.io.req.valid :=  Bool(false)
+      }
+
+      io.tosdq.valid    := fregister_read.io.exe_reqs(w).bits.uop.uopc === uopSTD
+      io.tosdq.bits.uop := fregister_read.io.exe_reqs(w).bits.uop
+      val sdata = fregister_read.io.exe_reqs(w).bits.rs2_data
+      
+      val unrec_s = hardfloat.fNFromRecFN(8, 24, sdata)
+      val unrec_d = hardfloat.fNFromRecFN(11, 53, sdata)
+      val unrec_out = Mux(io.tosdq.bits.uop.fp_single, Cat(Fill(32, unrec_s(31)), unrec_s), unrec_d)
+      
+      io.tosdq.bits.data := unrec_out
+   }
+   require (exe_units.num_total_bypass_ports == 0)
+
+   exe_units.ifpu_unit.io.req <> io.fromint
+    
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+   // **** Writeback Stage ****
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+
+   // TODO add fdivsqrt to this port
+   // TODO XXX add ifpu to ll_wport, instead of giving all exe_units a dedicated port.
+   io.ll_wport <> fregfile.io.write_ports(0)
+
+   var w_cnt = 1
+   for (i <- 0 until exe_units.length)
+   {
+      for (j <- 0 until exe_units(i).num_rf_write_ports)
+      {
+         val wbresp = exe_units(i).io.resp(j)
+
+         val toint = wbresp.bits.uop.dst_rtype === RT_FIX
+
+         fregfile.io.write_ports(w_cnt).wen :=
+            wbresp.valid &&
+            wbresp.bits.uop.ctrl.rf_wen &&
+            !toint
+         fregfile.io.write_ports(w_cnt).addr :=
+            wbresp.bits.uop.pdst
+         fregfile.io.write_ports(w_cnt).data :=
+            wbresp.bits.data
+
+
+//         io.toint.valid := wbresp.valid && toint
+//         io.toint.bits  := wbresp.bits
+         if (i==0 && j==0) {
+            io.toint.wen  := wbresp.valid && toint
+            io.toint.addr := wbresp.bits.uop.pdst
+            io.toint.data := wbresp.bits.data
+            io.toint_uop  := wbresp.bits.uop
+         }
+         // need to make sure toint uops only ever come out of this wbresp port.
+         // TODO add check on write port to check if it supports toint moves.
+         require ((i==0 && j==0) || !(exe_units(i).uses_iss_unit))
+
+         assert (!(wbresp.valid &&
+            !wbresp.bits.uop.ctrl.rf_wen &&
+            wbresp.bits.uop.dst_rtype === RT_FLT),
+            "[fppipeline] An FP writeback is being attempted with rf_wen disabled.")
+
+         assert (!(wbresp.valid &&
+            wbresp.bits.uop.ctrl.rf_wen &&
+            wbresp.bits.uop.dst_rtype =/= RT_FLT &&
+            !toint),
+            "[fppipeline] A writeback is being attempted to the FP RF with dst != FP type.")
+         
+         w_cnt += 1
+      }
+   }
+   require (w_cnt == fregfile.io.write_ports.length)
+
+
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+   // **** Commit Stage ****
+   //-------------------------------------------------------------
+   //-------------------------------------------------------------
+
+   // TODO the wakeup is being handled in core.scala for memory, but not other ll stuff.
+   io.wakeups(0).valid := io.ll_wport.wen
+   io.wakeups(0).bits.uop := io.ll_wport_uop
+   io.wakeups(0).bits.data := io.ll_wport.data
+   io.wakeups(0).bits.fflags.valid := Bool(false)
+
+   w_cnt = 1
+   for (eu <- exe_units)
+   {
+      // exe_units == 2
+      //    exe_resp == 1
+      // wakeups == 3 (2+mem)
+      for (exe_resp <- eu.io.resp)
+      {
+         println("FP exe-resp, w=" + w_cnt)
+         val wb_uop = exe_resp.bits.uop
+         val wport = io.wakeups(w_cnt)
+         wport <> exe_resp
+         wport.valid := exe_resp.valid && wb_uop.dst_rtype === RT_FLT
+         w_cnt += 1
+
+         assert(!(exe_resp.valid && wb_uop.is_store))
+         assert(!(exe_resp.valid && wb_uop.is_load))
+         assert(!(exe_resp.valid && wb_uop.is_amo))
+      }
+   }
+    
+
+   exe_units.map(_.io.fcsr_rm := io.fcsr_rm)
+ 
+   //-------------------------------------------------------------
+   // **** Flush Pipeline ****
+   //-------------------------------------------------------------
+   // flush on exceptions, miniexeptions, and after some special instructions
+
+   for (w <- 0 until exe_units.length)
+   {
+      exe_units(w).io.req.bits.kill := io.flush_pipeline
+   }
+    
+}

--- a/src/main/scala/fpu.scala
+++ b/src/main/scala/fpu.scala
@@ -163,11 +163,13 @@ class FPU(implicit p: Parameters) extends BoomModule()(p)
    sfma.io.in.bits := req
 
 
-   val ifpu = Module(new tile.IntToFP(fpu_latency)) // 3 for rocket
-   ifpu.io.in.valid := io.req.valid && fp_ctrl.fromint
-   ifpu.io.in.bits := req
-   assert (!(io.req.valid && fp_ctrl.fromint && req.in1(64).toBool),
-            "IntToFP integer input has 65th high-order bit set!")
+   // ifpu no longer supported here due to splitting of FP and Integer registers.
+   // Instead, ifpu is handled in a separate unit.
+   //val ifpu = Module(new tile.IntToFP(fpu_latency)) // 3 for rocket
+   //ifpu.io.in.valid := io.req.valid && fp_ctrl.fromint
+   //ifpu.io.in.bits := req
+   //assert (!(io.req.valid && fp_ctrl.fromint && req.in1(64).toBool),
+   //         "IntToFP integer input has 65th high-order bit set!")
 
 
    val fpiu = Module(new tile.FPToInt)
@@ -188,16 +190,16 @@ class FPU(implicit p: Parameters) extends BoomModule()(p)
    fpmu.io.lt := fpiu.io.out.bits.lt
 
    // Response (all FP units have been padded out to the same latency)
-   io.resp.valid := ifpu.io.out.valid ||
+   io.resp.valid := //ifpu.io.out.valid ||
                     fpiu_out.valid ||
                     fpmu.io.out.valid ||
                     sfma.io.out.valid ||
                     dfma.io.out.valid
    val fpu_out   = Mux(dfma.io.out.valid, dfma.io.out.bits,
                    Mux(sfma.io.out.valid, sfma.io.out.bits,
-                   Mux(ifpu.io.out.valid, ifpu.io.out.bits,
+//                   Mux(ifpu.io.out.valid, ifpu.io.out.bits,
                    Mux(fpiu_out.valid,    fpiu_result,
-                                          fpmu.io.out.bits))))
+                                          fpmu.io.out.bits)))
 
    io.resp.bits.data              := fpu_out.data
    io.resp.bits.fflags.valid      := io.resp.valid

--- a/src/main/scala/fudecode.scala
+++ b/src/main/scala/fudecode.scala
@@ -192,8 +192,8 @@ object FpuRRdDecode extends RRdDecodeConstants
          BitPat(uopFCLASS_S)->List(BR_N, Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFCLASS_D)->List(BR_N, Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
 
-         BitPat(uopFMV_S_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
-         BitPat(uopFMV_D_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+//         BitPat(uopFMV_S_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+//         BitPat(uopFMV_D_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFMV_X_S)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFMV_X_D)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFSGNJ_S)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
@@ -202,6 +202,7 @@ object FpuRRdDecode extends RRdDecodeConstants
          BitPat(uopFCVT_S_D) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFCVT_D_S) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
 
+// TODO comment out I2F instructions.
          BitPat(uopFCVT_S_W) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFCVT_S_WU)->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFCVT_S_L) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
@@ -248,7 +249,32 @@ object FpuRRdDecode extends RRdDecodeConstants
          BitPat(uopFNMADD_D)->List(BR_N, Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
          BitPat(uopFNMSUB_D)->List(BR_N, Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N))
 }
+ 
 
+object IfmvRRdDecode extends RRdDecodeConstants
+{
+   val table: Array[(BitPat, List[BitPat])] =
+              Array[(BitPat, List[BitPat])](
+                               // br type
+                               // |      use alu pipe              op1 sel   op2 sel
+                               // |      |  use muldiv pipe        |         |         immsel       csr_cmd
+                               // |      |  |  use mem pipe        |         |         |     rf wen |
+                               // |      |  |  |  alu fcn  wd/word?|         |         |     |      |
+                               // |      |  |  |  |        |       |         |         |     |      |
+         BitPat(uopFMV_S_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFMV_D_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+
+         BitPat(uopFCVT_S_W) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_S_WU)->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_S_L) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_S_LU)->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_D_W) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_D_WU)->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_D_L) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N),
+         BitPat(uopFCVT_D_LU)->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, rocket.CSR.N))
+}
+
+ 
 
 object FDivRRdDecode extends RRdDecodeConstants
 {
@@ -288,6 +314,7 @@ class RegisterReadDecode(supported_units: SupportedFuncUnits)(implicit p: Parame
    if (supported_units.csr) dec_table ++= CsrRRdDecode.table
    if (supported_units.fpu) dec_table ++= FpuRRdDecode.table
    if (supported_units.fdiv) dec_table ++= FDivRRdDecode.table
+   if (supported_units.ifpu) dec_table ++= IfmvRRdDecode.table
    val rrd_cs = Wire(new RRdCtrlSigs()).decode(io.rrd_uop.uopc, dec_table)
 
    // rrd_use_alupipe is unused
@@ -300,7 +327,7 @@ class RegisterReadDecode(supported_units: SupportedFuncUnits)(implicit p: Parame
    io.rrd_uop.ctrl.fcn_dw  := rrd_cs.fcn_dw.toBool
    io.rrd_uop.ctrl.is_load := io.rrd_uop.uopc === uopLD
    io.rrd_uop.ctrl.is_sta  := io.rrd_uop.uopc === uopSTA || io.rrd_uop.uopc === uopAMO_AG
-   io.rrd_uop.ctrl.is_std  := io.rrd_uop.uopc === uopSTD || (io.rrd_uop.ctrl.is_sta && io.rrd_uop.lrs2_rtype =/= RT_X)
+   io.rrd_uop.ctrl.is_std  := io.rrd_uop.uopc === uopSTD || (io.rrd_uop.ctrl.is_sta && io.rrd_uop.lrs2_rtype === RT_FIX)
 
    when (io.rrd_uop.uopc === uopAMO_AG)
    {

--- a/src/main/scala/functional_unit.scala
+++ b/src/main/scala/functional_unit.scala
@@ -669,10 +669,9 @@ class IntToFPUnit(implicit p: Parameters) extends PipelinedFunctionalUnit(
       "[func] Only support fromInt micro-ops.")
 
    val ifpu = Module(new tile.IntToFP(intToFpLatency))
-   ifpu.io.in.valid := io.req.valid //&& fp_ctrl.fromint
+   ifpu.io.in.valid := io.req.valid
    ifpu.io.in.bits := req
 
-   io.resp.valid                  := ifpu.io.out.valid // TODO XXX why is this not present in FPUUnit?
    io.resp.bits.data              := ifpu.io.out.bits.data
    io.resp.bits.fflags.valid      := ifpu.io.out.valid
    io.resp.bits.fflags.bits.uop   := io.resp.bits.uop
@@ -730,7 +729,7 @@ class MulDivUnit(implicit p: Parameters) extends UnPipelinedFunctionalUnit()(p)
    muldiv.io.kill         := this.do_kill
 
    // response
-   io.resp.valid          := muldiv.io.resp.valid
+   io.resp.valid          := muldiv.io.resp.valid && !this.do_kill
    muldiv.io.resp.ready   := io.resp.ready
    io.resp.bits.data      := muldiv.io.resp.bits.data
 }

--- a/src/main/scala/functional_unit.scala
+++ b/src/main/scala/functional_unit.scala
@@ -16,7 +16,6 @@
 // TODO: explore possibility of conditional IO fields? if a branch unit... how to add extra to IO in subclass?
 
 package boom
-{
 
 import Chisel._
 import config.Parameters
@@ -29,17 +28,18 @@ import uncore.constants.MemoryOpConstants._
 object FUConstants
 {
    // bit mask, since a given execution pipeline may support multiple functional units
-   val FUC_SZ = 9
+   val FUC_SZ = 10
    val FU_X   = BitPat.DC(FUC_SZ)
    val FU_ALU = UInt(  1, FUC_SZ)
    val FU_BRU = UInt(  2, FUC_SZ)
    val FU_MEM = UInt(  4, FUC_SZ)
    val FU_MUL = UInt(  8, FUC_SZ)
    val FU_DIV = UInt( 16, FUC_SZ)
-   val FU_FPU = UInt( 32, FUC_SZ)
-   val FU_CSR = UInt( 64, FUC_SZ)
+   val FU_CSR = UInt( 32, FUC_SZ)
+   val FU_FPU = UInt( 64, FUC_SZ)
    val FU_FDV = UInt(128, FUC_SZ)
    val FU_I2F = UInt(256, FUC_SZ)
+   val FU_F2I = UInt(512, FUC_SZ)
 }
 import FUConstants._
 
@@ -188,7 +188,7 @@ abstract class PipelinedFunctionalUnit(val num_stages: Int,
                                                               , data_width = data_width
                                                               , has_branch_unit = is_branch_unit)(p)
 {
-   // pipelined functional unit is always ready
+   // Pipelined functional unit is always ready.
    io.req.ready := Bool(true)
 
 
@@ -680,9 +680,9 @@ class IntToFPUnit(implicit p: Parameters) extends PipelinedFunctionalUnit(
  
 
 
-// unpipelined, can only hold a single MicroOp at a time
+// Iterative/unpipelined, can only hold a single MicroOp at a time TODO allow up to N micro-ops simultaneously.
 // assumes at least one register between request and response
-abstract class UnPipelinedFunctionalUnit(implicit p: Parameters)
+abstract class IterativeFunctionalUnit(implicit p: Parameters)
                                        extends FunctionalUnit(is_pipelined = false
                                                             , num_stages = 1
                                                             , num_bypass_stages = 0
@@ -713,7 +713,7 @@ abstract class UnPipelinedFunctionalUnit(implicit p: Parameters)
 }
 
 
-class MulDivUnit(implicit p: Parameters) extends UnPipelinedFunctionalUnit()(p)
+class MulDivUnit(implicit p: Parameters) extends IterativeFunctionalUnit()(p)
 {
    val muldiv = Module(new rocket.MulDiv(mulDivParams, width = xLen))
 
@@ -750,7 +750,5 @@ class PipelinedMulUnit(num_stages: Int)(implicit p: Parameters)
 
    // response
    io.resp.bits.data      := imul.io.out
-}
-
 }
 

--- a/src/main/scala/issue.scala
+++ b/src/main/scala/issue.scala
@@ -46,10 +46,10 @@ class IssueUnitIO(issue_width: Int, num_wakeup_ports: Int)(implicit p: Parameter
 }
 
 abstract class IssueUnit(
-   num_issue_slots: Int,
+   val num_issue_slots: Int,
    val issue_width: Int,
    num_wakeup_ports: Int,
-   val iqType: Int)
+   val iqType: BigInt)
    (implicit p: Parameters)
    extends BoomModule()(p)
 {
@@ -163,9 +163,8 @@ class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters) extends HasB
    require (enableAgePriorityIssue) // unordered is currently unsupported.
 
 //      issue_Units =issueConfigs colect {if iqType=....)
-//   iss_units += Module(new IssueUnitCollasping(boomParams.issueParams(0))
-   iss_units += Module(new IssueUnitCollasping(numIssueSlotEntries(0), issueWidths(0), num_wakeup_ports, IQT_MEM.litValue.intValue))
-   iss_units += Module(new IssueUnitCollasping(numIssueSlotEntries(1), issueWidths(1), num_wakeup_ports, IQT_INT.litValue.intValue))
+   iss_units += Module(new IssueUnitCollasping(issueParams.find(_.iqType == IQT_MEM.litValue).get, num_wakeup_ports))
+   iss_units += Module(new IssueUnitCollasping(issueParams.find(_.iqType == IQT_INT.litValue).get, num_wakeup_ports))
 
 }
 

--- a/src/main/scala/issue.scala
+++ b/src/main/scala/issue.scala
@@ -20,6 +20,12 @@ import scala.collection.mutable.ArrayBuffer
 //-------------------------------------------------------------
 //-------------------------------------------------------------
 
+case class IssueParams(
+   issueWidth: Int = 1,
+   numEntries: Int = 8,
+   iqType: BigInt
+)
+
 class IssueUnitIO(issue_width: Int, num_wakeup_ports: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val dis_valids     = Vec(DISPATCH_WIDTH, Bool()).asInput
@@ -58,7 +64,7 @@ abstract class IssueUnit(
    {
       dis_uops(w) := io.dis_uops(w)
       dis_uops(w).iw_state := s_valid_1
-      when (dis_uops(w).uopc === uopSTA || dis_uops(w).uopc === uopAMO_AG)
+      when ((dis_uops(w).uopc === uopSTA && dis_uops(w).lrs2_rtype === RT_FIX) || dis_uops(w).uopc === uopAMO_AG)
       {
          dis_uops(w).iw_state := s_valid_2
       }
@@ -156,11 +162,10 @@ class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters) extends HasB
 
    require (enableAgePriorityIssue) // unordered is currently unsupported.
 
+//      issue_Units =issueConfigs colect {if iqType=....)
+//   iss_units += Module(new IssueUnitCollasping(boomParams.issueParams(0))
    iss_units += Module(new IssueUnitCollasping(numIssueSlotEntries(0), issueWidths(0), num_wakeup_ports, IQT_MEM.litValue.intValue))
    iss_units += Module(new IssueUnitCollasping(numIssueSlotEntries(1), issueWidths(1), num_wakeup_ports, IQT_INT.litValue.intValue))
-
-
-
 
 }
 

--- a/src/main/scala/issue.scala
+++ b/src/main/scala/issue.scala
@@ -97,8 +97,6 @@ abstract class IssueUnit(
                " 0x%x: %d] ri:%d bm=%d imm=0x%x\n"
             , UInt(i, log2Up(num_issue_slots))
             , Mux(issue_slots(i).valid, Str("V"), Str("-"))
-//            , Mux(issue_slots(i).request, Str(u_red + "R" + end), Str(grn + "-" + end))
-//            , Mux(issue_slots(i).in_uop.valid, Str(u_wht + "W" + end),  Str(grn + " " + end))
             , Mux(issue_slots(i).request, Str("R"), Str("-"))
             , Mux(issue_slots(i).in_uop.valid, Str("W"),  Str(" "))
             , Mux(issue_slots(i).debug.p1, Str("!"), Str(" "))
@@ -120,10 +118,10 @@ abstract class IssueUnit(
             , issue_slots(i).uop.imm_packed
             )
       }
+      printf("-----------------------------------------------------------------------------------------\n")
    }
 }
 
-//class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters) extends Traversable[IssueUnit] with HasBoomCoreParameters
 class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters) extends HasBoomCoreParameters
 {
    //*******************************

--- a/src/main/scala/issue_ageordered.scala
+++ b/src/main/scala/issue_ageordered.scala
@@ -20,8 +20,13 @@ import scala.collection.mutable.ArrayBuffer
 //-------------------------------------------------------------
 //-------------------------------------------------------------
 
-class IssueUnitCollasping(num_issue_slots: Int, issue_width: Int, num_wakeup_ports: Int)(implicit p: Parameters)
-   extends IssueUnit(num_issue_slots, issue_width, num_wakeup_ports)
+class IssueUnitCollasping(
+   num_issue_slots: Int,
+   issue_width: Int,
+   num_wakeup_ports: Int,
+   iqType: Int)
+   (implicit p: Parameters)
+   extends IssueUnit(num_issue_slots, issue_width, num_wakeup_ports, iqType)
 {
    //-------------------------------------------------------------
    // Figure out how much to shift entries by

--- a/src/main/scala/issue_ageordered.scala
+++ b/src/main/scala/issue_ageordered.scala
@@ -21,12 +21,10 @@ import scala.collection.mutable.ArrayBuffer
 //-------------------------------------------------------------
 
 class IssueUnitCollasping(
-   num_issue_slots: Int,
-   issue_width: Int,
-   num_wakeup_ports: Int,
-   iqType: Int)
+   params: IssueParams,
+   num_wakeup_ports: Int)
    (implicit p: Parameters)
-   extends IssueUnit(num_issue_slots, issue_width, num_wakeup_ports, iqType)
+   extends IssueUnit(params.numEntries, params.issueWidth, num_wakeup_ports, params.iqType)
 {
    //-------------------------------------------------------------
    // Figure out how much to shift entries by

--- a/src/main/scala/issue_slot.scala
+++ b/src/main/scala/issue_slot.scala
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 //
 // Note: stores (and AMOs) are "broken down" into 2 uops, but stored within a single issue-slot.
+// TODO XXX make a separate issueSlot for MemoryIssueSlots, and only they break apart stores.
 
 package boom
 

--- a/src/main/scala/issue_slot.scala
+++ b/src/main/scala/issue_slot.scala
@@ -57,6 +57,8 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters) extends Boom
 
    val updated_state = Wire(UInt()) // the next state of this slot (which might then get moved to a new slot)
    val updated_uopc  = Wire(Bits()) // the next uopc of this slot (which might then get moved to a new slot)
+   val updated_lrs1_rtype = Wire(Bits()) // the next reg type of this slot (which might then get moved to a new slot)
+   val updated_lrs2_rtype = Wire(Bits()) // the next reg type of this slot (which might then get moved to a new slot)
    val next_p1  = Wire(Bool())
    val next_p2  = Wire(Bool())
    val next_p3  = Wire(Bool())
@@ -101,6 +103,8 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters) extends Boom
    // defaults
    updated_state := slot_state
    updated_uopc := slotUop.uopc
+   updated_lrs1_rtype := slotUop.lrs1_rtype
+   updated_lrs2_rtype := slotUop.lrs2_rtype
 
    when (io.kill ||
          (io.grant && (slot_state === s_valid_1)) ||
@@ -116,10 +120,13 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters) extends Boom
          slotUop.uopc := uopSTD
          updated_uopc := uopSTD
          slotUop.lrs1_rtype := RT_X
+         updated_lrs1_rtype := RT_X
+
       }
       .otherwise
       {
          slotUop.lrs2_rtype := RT_X
+         updated_lrs2_rtype := RT_X
       }
    }
 
@@ -190,8 +197,8 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters) extends Boom
    // Request Logic
    io.request := isValid && slot_p1 && slot_p2 && slot_p3 && !io.kill
    val high_priority = slotUop.is_br_or_jmp
-   io.request_hp := io.request && high_priority
-//   io.request_hp := Bool(false)
+//   io.request_hp := io.request && high_priority
+   io.request_hp := Bool(false)
 
    when (slot_state === s_valid_1)
    {
@@ -216,6 +223,8 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters) extends Boom
    io.updated_uop           := slotUop
    io.updated_uop.iw_state  := updated_state
    io.updated_uop.uopc      := updated_uopc
+   io.updated_uop.lrs1_rtype:= updated_lrs1_rtype
+   io.updated_uop.lrs2_rtype:= updated_lrs2_rtype
    io.updated_uop.br_mask   := out_br_mask
    io.updated_uop.prs1_busy := !out_p1
    io.updated_uop.prs2_busy := !out_p2

--- a/src/main/scala/issue_unordered.scala
+++ b/src/main/scala/issue_unordered.scala
@@ -17,8 +17,11 @@ import FUConstants._
 import util.Str
 import scala.collection.mutable.ArrayBuffer
 
-class IssueUnitStatic(num_issue_slots: Int, issue_width: Int, num_wakeup_ports: Int, iqtype: Int)(implicit p: Parameters)
-   extends IssueUnit(num_issue_slots, issue_width, num_wakeup_ports, iqtype)
+class IssueUnitStatic(
+   params: IssueParams,
+   num_wakeup_ports: Int)
+   (implicit p: Parameters)
+   extends IssueUnit(params.numEntries, params.issueWidth, num_wakeup_ports, params.iqType)
 {
    //-------------------------------------------------------------
    // Issue Table

--- a/src/main/scala/issue_unordered.scala
+++ b/src/main/scala/issue_unordered.scala
@@ -17,8 +17,8 @@ import FUConstants._
 import util.Str
 import scala.collection.mutable.ArrayBuffer
 
-class IssueUnitStatic(num_issue_slots: Int, issue_width: Int, num_wakeup_ports: Int)(implicit p: Parameters)
-   extends IssueUnit(num_issue_slots, issue_width, num_wakeup_ports)
+class IssueUnitStatic(num_issue_slots: Int, issue_width: Int, num_wakeup_ports: Int, iqtype: Int)(implicit p: Parameters)
+   extends IssueUnit(num_issue_slots, issue_width, num_wakeup_ports, iqtype)
 {
    //-------------------------------------------------------------
    // Issue Table

--- a/src/main/scala/lsu.scala
+++ b/src/main/scala/lsu.scala
@@ -66,6 +66,7 @@ class LoadStoreUnitIO(pl_width: Int)(implicit p: Parameters) extends BoomBundle(
 
    // Execute Stage
    val exe_resp           = (new ValidIO(new FuncUnitResp(xLen))).flip
+   val fp_stdata          = Valid(new MicroOpWithData(fLen)).flip
 
    // Commit Stage
    val commit_store_mask  = Vec(pl_width, Bool()).asInput
@@ -97,8 +98,11 @@ class LoadStoreUnitIO(pl_width: Int)(implicit p: Parameters) extends BoomBundle(
    val stq_full           = Bool(OUTPUT)
 
    val exception          = Bool(INPUT)
-   val lsu_clr_bsy_valid  = Bool(OUTPUT) // HACK: let the stores clear out the busy bit in the ROB
-   val lsu_clr_bsy_rob_idx= UInt(OUTPUT, width=ROB_ADDR_SZ)
+   // Let the stores clear out the busy bit in the ROB.
+   // Two ports, one for integer and the other for FP.
+   // Otherwise, we must back-pressure incoming FP store-data micro-ops.
+   val lsu_clr_bsy_valid  = Vec(2, Bool()).asOutput 
+   val lsu_clr_bsy_rob_idx= Vec(2, UInt(width=ROB_ADDR_SZ)).asOutput
    val lsu_fencei_rdy     = Bool(OUTPUT)
 
    val xcpt = new ValidIO(new Exception)
@@ -296,6 +300,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
    val tlb_avail = Wire(init = Bool(true))
    val rob_avail = Wire(init = Bool(true))
    val lcam_avail= Wire(init = Bool(true))
+//   val std_avail = Wire(init = Bool(true)) // can the FP std come in?
 
    // give first priority to incoming uops
    when (io.exe_resp.valid)
@@ -313,11 +318,13 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
          tlb_avail  := Bool(false)
          rob_avail  := Bool(false)
          lcam_avail := Bool(false)
+//         std_avail := Bool(false)
       }
       when (io.exe_resp.bits.uop.ctrl.is_std)
       {
          will_fire_std_incoming := Bool(true)
          rob_avail := Bool(false)
+//         std_avail := Bool(false)
       }
    }
 
@@ -327,6 +334,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
       {
          will_fire_sta_retry := Bool(true)
          lcam_avail := Bool(false)
+//         std_avail := Bool(false)
       }
       .elsewhen (can_fire_load_retry)
       {
@@ -543,13 +551,31 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
       saq_is_virtual(exe_tlb_uop.stq_idx)      := tlb_miss
    }
 
+   // use two ports on STD to handle Integer and FP store data.
    when (will_fire_std_incoming)
    {
-      sdq_val (io.exe_resp.bits.uop.stq_idx) := Bool(true)
-      sdq_data(io.exe_resp.bits.uop.stq_idx) := io.exe_resp.bits.data.toBits
+      val sidx = io.exe_resp.bits.uop.stq_idx
+      sdq_val (sidx) := Bool(true)
+      sdq_data(sidx) := io.exe_resp.bits.data.toBits
    }
+   
+   //--------------------------------------------
+   // FP Data
+   // Store Data Generation MicroOps come in directly from the FP registerfile,
+   // and not through the exe_resp datapath.
 
-
+   when (io.fp_stdata.valid)
+   {
+      val sidx = io.fp_stdata.bits.uop.stq_idx
+      sdq_val (sidx) := Bool(true)
+      sdq_data(sidx) := io.fp_stdata.bits.data.toBits
+   }
+   assert(!(io.fp_stdata.valid && io.exe_resp.valid && io.exe_resp.bits.uop.ctrl.is_std && 
+      io.fp_stdata.bits.uop.stq_idx === io.exe_resp.bits.uop.stq_idx), 
+      "[lsu] FP and INT data is fighting over the same sdq entry.")
+       
+   require (xLen >= fLen) // otherwise the SDQ is missized.
+ 
    //-------------------------------------------------------------
    //-------------------------------------------------------------
    // Cache Access Cycle (Mem)
@@ -575,7 +601,8 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
                                     will_fire_load_retry ||
                                     will_fire_load_wakeup))
    val mem_fired_sta = Reg(next=(will_fire_sta_incoming || will_fire_sta_retry), init=Bool(false))
-   val mem_fired_std = Reg(next=will_fire_std_incoming, init=Bool(false))
+   val mem_fired_stdi = Reg(next=will_fire_std_incoming, init=Bool(false))
+   val mem_fired_stdf = Reg(next=io.fp_stdata.valid, init=Bool(false))
 
    mem_ld_killed := Bool(false)
    when (Reg(next=
@@ -592,12 +619,11 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
    val clr_bsy_valid = Reg(init=Bool(false))
    val clr_bsy_robidx = Reg(UInt(width=ROB_ADDR_SZ))
    val clr_bsy_brmask = Reg(UInt(width=MAX_BR_COUNT))
-
-   clr_bsy_valid := Bool(false)
+   clr_bsy_valid  := Bool(false)
    clr_bsy_robidx := mem_tlb_uop.rob_idx
    clr_bsy_brmask := GetNewBrMask(io.brinfo, mem_tlb_uop)
-
-   when (mem_fired_sta && !mem_tlb_miss && mem_fired_std)
+   
+   when (mem_fired_sta && !mem_tlb_miss && mem_fired_stdi)
    {
       clr_bsy_valid := !mem_tlb_uop.is_amo
       clr_bsy_robidx := mem_tlb_uop.rob_idx
@@ -610,7 +636,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
       clr_bsy_robidx := mem_tlb_uop.rob_idx
       clr_bsy_brmask := GetNewBrMask(io.brinfo, mem_tlb_uop)
    }
-   .elsewhen (mem_fired_std)
+   .elsewhen (mem_fired_stdi)
    {
       val mem_std_uop = RegNext(io.exe_resp.bits.uop)
       clr_bsy_valid := saq_val(mem_std_uop.stq_idx) &&
@@ -619,9 +645,20 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
       clr_bsy_robidx := mem_std_uop.rob_idx
       clr_bsy_brmask := GetNewBrMask(io.brinfo, mem_std_uop)
    }
+   
+   
+   val mem_uop_stdf = RegNext(io.fp_stdata.bits.uop)
+   val stdf_clr_bsy_valid = RegNext(mem_fired_stdf &&
+                           saq_val(mem_uop_stdf.stq_idx) &&
+                           !saq_is_virtual(mem_uop_stdf.stq_idx) &&
+                           !mem_uop_stdf.is_amo)
+   val stdf_clr_bsy_robidx = RegEnable(mem_uop_stdf.rob_idx, mem_fired_stdf)
+   val stdf_clr_bsy_brmask = RegEnable(GetNewBrMask(io.brinfo, mem_uop_stdf), mem_fired_stdf)
 
-   io.lsu_clr_bsy_valid := clr_bsy_valid && !io.exception && !IsKilledByBranch(io.brinfo, clr_bsy_brmask)
-   io.lsu_clr_bsy_rob_idx := clr_bsy_robidx
+   io.lsu_clr_bsy_valid(0)   := clr_bsy_valid && !io.exception && !IsKilledByBranch(io.brinfo, clr_bsy_brmask)
+   io.lsu_clr_bsy_rob_idx(0) := clr_bsy_robidx
+   io.lsu_clr_bsy_valid(1)   := stdf_clr_bsy_valid && !io.exception && !IsKilledByBranch(io.brinfo, stdf_clr_bsy_brmask)
+   io.lsu_clr_bsy_rob_idx(1) := stdf_clr_bsy_robidx
 
    //-------------------------------------------------------------
    // Load Issue Datapath (ALL loads need to use this path,

--- a/src/main/scala/microop.scala
+++ b/src/main/scala/microop.scala
@@ -132,3 +132,10 @@ class DebugStageEvents extends Bundle()
    // Track the sequence number of each instruction fetched.
    val fetch_seq        = UInt(width = 32)
 }
+
+class MicroOpWithData(data_sz: Int)(implicit p: Parameters) extends BoomBundle()(p)
+{
+   val uop = new MicroOp()
+   val data = UInt(width = data_sz)
+   override def cloneType = new MicroOpWithData(data_sz)(p).asInstanceOf[this.type]
+}

--- a/src/main/scala/microop.scala
+++ b/src/main/scala/microop.scala
@@ -23,6 +23,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val uopc             = UInt(width = UOPC_SZ)       // micro-op code
    val inst             = UInt(width = 32)
    val pc               = UInt(width = coreMaxAddrBits)
+   val iqtype           = UInt(width = IQT_SZ) // which issue unit do we use?
    val fu_code          = UInt(width = FUConstants.FUC_SZ) // which functional unit do we use?
    val ctrl             = new CtrlSignals
 

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -8,7 +8,8 @@ package object boom extends
    boom.constants.BrPredConstants with
    boom.constants.ScalarOpConstants with
    boom.constants.ExcCauseConstants with
-   boom.constants.RISCVConstants
+   boom.constants.RISCVConstants with
+   boom.constants.IQType
 {
    val START_ADDR = 0x100
 }

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -35,7 +35,8 @@ case class BoomCoreParams(
    tage: Option[TageParameters] = None,
    gshare: Option[GShareParameters] = None,
    gskew: Option[GSkewParameters] = None,
-   intToFpLatency: Int = 2
+   intToFpLatency: Int = 2,
+   imulLatency: Int = 3
 )
 
 trait HasBoomCoreParameters extends tile.HasCoreParameters
@@ -81,7 +82,7 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    //************************************
    // Pipelining
 
-   val IMUL_STAGES = if (rocketParams.fpu.isDefined) rocketParams.fpu.get.dfmaLatency else 3
+   val imulLatency = boomParams.imulLatency
    val dfmaLatency = if (rocketParams.fpu.isDefined) rocketParams.fpu.get.dfmaLatency else 3
    val sfmaLatency = if (rocketParams.fpu.isDefined) rocketParams.fpu.get.sfmaLatency else 3
    // All FPU ops padded out to same delay for writeport scheduling.

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -32,7 +32,8 @@ case class BoomCoreParams(
    enableBpdUSModeHistory: Boolean = false,
    tage: Option[TageParameters] = None,
    gshare: Option[GShareParameters] = None,
-   gskew: Option[GSkewParameters] = None
+   gskew: Option[GSkewParameters] = None,
+   intToFpLatency: Int = 2
 )
 
 trait HasBoomCoreParameters extends tile.HasCoreParameters
@@ -83,6 +84,8 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    val sfmaLatency = if (rocketParams.fpu.isDefined) rocketParams.fpu.get.sfmaLatency else 3
    // All FPU ops padded out to same delay for writeport scheduling.
    require (sfmaLatency == dfmaLatency)
+
+   val intToFpLatency = boomParams.intToFpLatency
 
    val enableBrResolutionRegister = boomParams.enableBrResolutionRegister
 

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -36,7 +36,8 @@ case class BoomCoreParams(
    gshare: Option[GShareParameters] = None,
    gskew: Option[GSkewParameters] = None,
    intToFpLatency: Int = 2,
-   imulLatency: Int = 3
+   imulLatency: Int = 3,
+   renameLatency: Int = 2
 )
 
 trait HasBoomCoreParameters extends tile.HasCoreParameters
@@ -89,6 +90,8 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    require (sfmaLatency == dfmaLatency)
 
    val intToFpLatency = boomParams.intToFpLatency
+
+   val renameLatency = boomParams.renameLatency
 
    val enableBrResolutionRegister = boomParams.enableBrResolutionRegister
 

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -14,8 +14,10 @@ case object BoomKey extends Field[BoomCoreParams]
 
 case class BoomCoreParams(
    numRobEntries: Int = 16,
-   issueWidths: Seq[Int] = Seq(1,2,0), // Mem, Int, FP
-   numIssueSlotEntries: Seq[Int] = Seq(8,8,8), // Mem, Int, FP
+   issueParams: Seq[IssueParams] = Seq(
+         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
+         IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
+         IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue)),
    numLsuEntries: Int = 8,
    numIntPhysRegisters: Int = 96,
    numFpPhysRegisters: Int = 64,
@@ -92,9 +94,13 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    //************************************
    // Issue Units
 
-   val issueWidths: Seq[Int] = boomParams.issueWidths // (Mem, Int, FP)
-   val numIssueSlotEntries = boomParams.numIssueSlotEntries
+   val issueParams: Seq[IssueParams] = boomParams.issueParams
    val enableAgePriorityIssue = boomParams.enableAgePriorityIssue
+   
+   // currently, only support one of each.
+   require (issueParams.count(_.iqType == IQT_FP.litValue) == 1)
+   require (issueParams.count(_.iqType == IQT_MEM.litValue) == 1)
+   require (issueParams.count(_.iqType == IQT_INT.litValue) == 1)
 
    //************************************
    // Load/Store Unit

--- a/src/main/scala/regfile.scala
+++ b/src/main/scala/regfile.scala
@@ -12,7 +12,6 @@
 
 
 package boom
-{
 
 import Chisel._
 import config.Parameters
@@ -51,6 +50,7 @@ class RegisterFile( num_registers: Int
    val regfile = Mem(num_registers, Bits(width=register_width))
 
    // --------------------------------------------------------------
+   // Read ports.
 
    val read_data = Wire(Vec(num_read_ports, Bits(width = register_width)))
 
@@ -60,8 +60,9 @@ class RegisterFile( num_registers: Int
                                                             regfile(io.read_ports(i).addr))
    }
 
+
    // --------------------------------------------------------------
-   // bypass out of the ALU's write ports
+   // Bypass out of the ALU's write ports.
 
    if (enable_bypassing)
    {
@@ -84,7 +85,9 @@ class RegisterFile( num_registers: Int
       }
    }
 
+
    // --------------------------------------------------------------
+   // Write ports.
 
    for (i <- 0 until num_write_ports)
    {
@@ -92,15 +95,19 @@ class RegisterFile( num_registers: Int
       {
          regfile(io.write_ports(i).addr) := io.write_ports(i).data
       }
-//      if (DEBUG_PRINTF)
-//      {
-//         printf("writeport[%d], %s -> p%d = 0x%x\n", UInt(i), Mux(io.write_ports(i).wen, Str("WEN"), Str(" "))
-//            , io.write_ports(i).addr
-//            , io.write_ports(i).data
-//            )
-//      }
    }
-}
 
 
+   // --------------------------------------------------------------
+
+   private val rf_cost = (num_read_ports+num_write_ports)*(num_read_ports+2*num_write_ports)
+   private val type_str = if (register_width == fLen+1) "Floating Point" else "Integer"
+   override def toString: String = 
+      "\n\n   ==" + type_str + " Regfile==" +
+      "\n   Num RF Read Ports     : " + num_read_ports +
+      "\n   Num RF Write Ports    : " + num_write_ports +
+      "\n   RF Cost (R+W)*(R+2W)  : " + rf_cost + 
+      "\n"
+
 }
+

--- a/src/main/scala/regfile.scala
+++ b/src/main/scala/regfile.scala
@@ -38,7 +38,7 @@ class RegisterFile( num_registers: Int
                   , num_write_ports: Int
                   , register_width: Int
                   , enable_bypassing: Boolean)
-                  (implicit p: Parameters) extends BoomModule()(p)
+       (implicit p: Parameters) extends BoomModule()(p)
 {
    val io = new BoomBundle()(p)
    {

--- a/src/main/scala/regfile.scala
+++ b/src/main/scala/regfile.scala
@@ -103,7 +103,7 @@ class RegisterFile( num_registers: Int
    private val rf_cost = (num_read_ports+num_write_ports)*(num_read_ports+2*num_write_ports)
    private val type_str = if (register_width == fLen+1) "Floating Point" else "Integer"
    override def toString: String = 
-      "\n\n   ==" + type_str + " Regfile==" +
+      "\n   ==" + type_str + " Regfile==" +
       "\n   Num RF Read Ports     : " + num_read_ports +
       "\n   Num RF Write Ports    : " + num_write_ports +
       "\n   RF Cost (R+W)*(R+2W)  : " + rf_cost + 

--- a/src/main/scala/regfile.scala
+++ b/src/main/scala/regfile.scala
@@ -31,6 +31,23 @@ class RegisterFileWritePort(addr_width: Int, data_width: Int)(implicit p: Parame
 }
 
 
+// utility function to turn ExeUnitResps to match the regfile's WritePort I/Os.
+object WritePort
+{
+   def apply(enq: DecoupledIO[ExeUnitResp], addr_width: Int, data_width: Int)
+   (implicit p: Parameters): DecoupledIO[RegisterFileWritePort] =
+   {
+      val wport = Wire(Decoupled(new RegisterFileWritePort(addr_width, data_width)))
+      wport.valid := enq.valid
+      wport.bits.addr := enq.bits.uop.pdst
+      wport.bits.data := enq.bits.data
+      enq.ready := wport.ready
+
+      wport
+   }
+}
+
+
 class RegisterFile( num_registers: Int
                   , num_read_ports: Int
                   , num_write_ports: Int
@@ -41,7 +58,7 @@ class RegisterFile( num_registers: Int
    val io = new BoomBundle()(p)
    {
       val read_ports = Vec(num_read_ports, new RegisterFileReadPortIO(PREG_SZ, register_width))
-      val write_ports = Vec(num_write_ports, Valid(new RegisterFileWritePort(PREG_SZ, register_width))).flip
+      val write_ports = Vec(num_write_ports, Decoupled(new RegisterFileWritePort(PREG_SZ, register_width))).flip
    }
 
    // --------------------------------------------------------------
@@ -90,6 +107,7 @@ class RegisterFile( num_registers: Int
 
    for (wport <- io.write_ports)
    {
+      wport.ready := Bool(true)
       when (wport.valid && (wport.bits.addr =/= UInt(0)))
       {
          regfile(wport.bits.addr) := wport.bits.data
@@ -101,7 +119,7 @@ class RegisterFile( num_registers: Int
 
    private val rf_cost = (num_read_ports+num_write_ports)*(num_read_ports+2*num_write_ports)
    private val type_str = if (register_width == fLen+1) "Floating Point" else "Integer"
-   override def toString: String = 
+   override def toString: String =
       "\n   ==" + type_str + " Regfile==" +
       "\n   Num RF Read Ports     : " + num_read_ports +
       "\n   Num RF Write Ports    : " + num_write_ports +

--- a/src/main/scala/registerread.scala
+++ b/src/main/scala/registerread.scala
@@ -76,7 +76,9 @@ class RegisterRead(
 
    for (w <- 0 until issue_width)
    {
+      println("Building Decoder(" + w + ")")
       val rrd_decode_unit = Module(new RegisterReadDecode(supported_units_array(w)))
+      println("Finished Decoder")
       rrd_decode_unit.io.iss_valid := io.iss_valids(w)
       rrd_decode_unit.io.iss_uop   := io.iss_uops(w)
 
@@ -134,8 +136,9 @@ class RegisterRead(
 
    // NOTES: this code is fairly hard-coded. Sorry.
    // ASSUMPTIONS:
-   //    -rs3 is used for FPU ops which are NOT bypassed (so don't check
+   //    - rs3 is used for FPU ops which are NOT bypassed (so don't check
    //       them!).
+   //    - only bypass integer registers.
 
    val bypassed_rs1_data = Wire(Vec(issue_width, Bits(width = register_width)))
    val bypassed_rs2_data = Wire(Vec(issue_width, Bits(width = register_width)))
@@ -155,9 +158,9 @@ class RegisterRead(
       {
          // can't use "io.bypass.valid(b) since it would create a combinational loop on branch kills"
          rs1_cases ++= Array((io.bypass.valid(b) && (pop1 === io.bypass.uop(b).pdst) && io.bypass.uop(b).ctrl.rf_wen
-            && (lrs1_rtype === RT_FIX || lrs1_rtype === RT_FLT) && (pop1 =/= UInt(0)), io.bypass.data(b)))
+            && io.bypass.uop(b).dst_rtype === RT_FIX && lrs1_rtype === RT_FIX && (pop1 =/= UInt(0)), io.bypass.data(b)))
          rs2_cases ++= Array((io.bypass.valid(b) && (pop2 === io.bypass.uop(b).pdst) && io.bypass.uop(b).ctrl.rf_wen
-            && (lrs2_rtype === RT_FIX || lrs2_rtype === RT_FLT) && (pop2 =/= UInt(0)), io.bypass.data(b)))
+            && io.bypass.uop(b).dst_rtype === RT_FIX && lrs2_rtype === RT_FIX && (pop2 =/= UInt(0)), io.bypass.data(b)))
       }
 
       if (num_read_ports > 0) bypassed_rs1_data(w) := MuxCase(rrd_rs1_data(w), rs1_cases)

--- a/src/main/scala/registerread.scala
+++ b/src/main/scala/registerread.scala
@@ -32,7 +32,6 @@ class RegisterReadIO(
 
    // interface with register file's read ports
    val rf_read_ports = Vec(num_total_read_ports, new RegisterFileReadPortIO(PREG_SZ, register_width)).flip
-//   val rf_read_ports = Vec(num_total_read_ports, new RegisterFileReadPortIO(PREG_SZ, register_width).flip)
 
    val bypass = new BypassData(num_total_bypass_ports, register_width).asInput
 

--- a/src/main/scala/registerread.scala
+++ b/src/main/scala/registerread.scala
@@ -76,9 +76,7 @@ class RegisterRead(
 
    for (w <- 0 until issue_width)
    {
-      println("Building Decoder(" + w + ")")
       val rrd_decode_unit = Module(new RegisterReadDecode(supported_units_array(w)))
-      println("Finished Decoder")
       rrd_decode_unit.io.iss_valid := io.iss_valids(w)
       rrd_decode_unit.io.iss_uop   := io.iss_uops(w)
 

--- a/src/main/scala/rename-busytable.scala
+++ b/src/main/scala/rename-busytable.scala
@@ -1,0 +1,173 @@
+//******************************************************************************
+// Copyright (c) 2015, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Rename BusyTable
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//
+// Christopher Celio
+
+package boom
+
+import Chisel._
+import config.Parameters
+
+// internally bypasses newly busy registers (.write) to the read ports (.read)
+// num_operands is the maximum number of operands per instruction (.e.g., 2 normally, but 3 if FMAs are supported)
+class BusyTableIo(
+   pipeline_width:Int,
+   num_pregs: Int,
+   num_read_ports:Int,
+   num_wb_ports:Int)
+   (implicit p: Parameters) extends BoomBundle()(p)
+{
+   private val preg_sz = log2Up(num_pregs)
+
+   // reading out the busy bits
+   val p_rs           = Vec(num_read_ports, UInt(width=preg_sz)).asInput
+   val p_rs_busy      = Vec(num_read_ports, Bool()).asOutput
+
+   def prs(i:Int, w:Int):UInt      = p_rs     (w+i*pipeline_width)
+   def prs_busy(i:Int, w:Int):Bool = p_rs_busy(w+i*pipeline_width)
+
+   // marking new registers as busy
+   val allocated_pdst = Vec(pipeline_width, new ValidIO(UInt(width=preg_sz))).flip
+
+   // marking registers being written back as unbusy
+   val unbusy_pdst    = Vec(num_wb_ports, new ValidIO(UInt(width = preg_sz))).flip
+
+   val debug = new Bundle { val busytable= Bits(width=num_pregs).asOutput }
+}
+
+// Register P0 is always NOT_BUSY, and cannot be set to BUSY
+// Note: I do NOT bypass from newly busied registers to the read ports.
+// That bypass check should be done elsewhere (this is to get it off the
+// critical path).
+class BusyTableHelper(
+   pipeline_width:Int,
+   num_pregs: Int,
+   num_read_ports:Int,
+   num_wb_ports:Int)
+   (implicit p: Parameters) extends BoomModule()(p)
+{
+   val io = new BusyTableIo(pipeline_width, num_pregs, num_read_ports, num_wb_ports)
+
+   def BUSY     = Bool(true)
+   def NOT_BUSY = Bool(false)
+
+   //TODO BUG chisel3
+   val table_bsy = Reg(init=Vec.fill(num_pregs){Bool(false)})
+
+   for (wb_idx <- 0 until num_wb_ports)
+   {
+      when (io.unbusy_pdst(wb_idx).valid)
+      {
+         table_bsy(io.unbusy_pdst(wb_idx).bits) := NOT_BUSY
+      }
+   }
+
+   for (w <- 0 until pipeline_width)
+   {
+      when (io.allocated_pdst(w).valid && io.allocated_pdst(w).bits =/= UInt(0))
+      {
+         table_bsy(io.allocated_pdst(w).bits) := BUSY
+      }
+   }
+
+   // handle bypassing a clearing of the busy-bit
+   for (ridx <- 0 until num_read_ports)
+   {
+      val just_cleared = io.unbusy_pdst.map(p => p.valid && (p.bits === io.p_rs(ridx))).reduce(_|_)
+      // note: no bypassing of the newly busied (that is done outside this module)
+      io.p_rs_busy(ridx) := (table_bsy(io.p_rs(ridx)) && !just_cleared)
+   }
+
+   io.debug.busytable := table_bsy.toBits
+}
+
+
+class BusyTableOutput extends Bundle
+{
+   val prs1_busy = Bool()
+   val prs2_busy = Bool()
+   val prs3_busy = Bool()
+}
+
+
+class BusyTable(
+   pl_width:Int,
+   rtype: BigInt,
+   num_pregs: Int,
+   num_read_ports:Int,
+   num_wb_ports:Int)
+   (implicit p: Parameters) extends BoomModule()(p)
+{
+   private val preg_sz = log2Up(num_pregs)
+
+   val io = new Bundle
+   {
+      // Inputs
+      val ren_mask              = Vec(pl_width, Bool()).asInput
+      val ren_uops              = Vec(pl_width, new MicroOp()).asInput
+
+      val freelist_can_allocate = Vec(pl_width, Bool()).asInput
+      val map_table             = Vec(pl_width, new MapTableOutput(preg_sz)).asInput
+
+      val wb_valids             = Vec(num_wb_ports, Bool()).asInput
+      val wb_pdsts              = Vec(num_wb_ports, UInt(width=preg_sz)).asInput
+
+      // Outputs
+      val values                = Vec(pl_width, new BusyTableOutput()).asOutput
+
+      val debug                 = new Bundle { val busytable= Bits(width=num_pregs).asOutput }
+   }
+
+   val busy_table = Module(new BusyTableHelper(
+      pipeline_width = pl_width,
+      num_pregs = num_pregs,
+      num_read_ports = num_read_ports,
+      num_wb_ports = num_wb_ports))
+
+
+   for (w <- 0 until pl_width)
+   {
+      // Reading the Busy Bits
+      // for critical path reasons, we speculatively read out the busy-bits assuming no dependencies between uops
+      // then verify if the uop actually uses a register and if it depends on a newly unfreed register
+      busy_table.io.prs(0,w) := io.map_table(w).prs1
+      busy_table.io.prs(1,w) := io.map_table(w).prs2
+
+      io.values(w).prs1_busy := io.ren_uops(w).lrs1_rtype === UInt(rtype) && (busy_table.io.prs_busy(0,w) || io.map_table(w).prs1_was_bypassed)
+      io.values(w).prs2_busy := io.ren_uops(w).lrs2_rtype === UInt(rtype) && (busy_table.io.prs_busy(1,w) || io.map_table(w).prs2_was_bypassed)
+
+      if (rtype == RT_FLT.litValue)
+      {
+         busy_table.io.prs(2,w) := io.map_table(w).prs3
+         io.values(w).prs3_busy := (io.ren_uops(w).frs3_en) && (busy_table.io.prs_busy(2,w) || io.map_table(w).prs3_was_bypassed)
+      }
+      else
+      {
+         io.values(w).prs3_busy := Bool(false)
+      }
+
+
+       // Updating the Table (new busy register)
+      busy_table.io.allocated_pdst(w).valid := io.freelist_can_allocate(w) &&
+                                               io.ren_mask(w) &&
+                                               io.ren_uops(w).ldst_val &&
+                                               io.ren_uops(w).dst_rtype === UInt(rtype)
+      busy_table.io.allocated_pdst(w).bits  := io.ren_uops(w).pdst
+   }
+
+   // Clear Busy-bit
+   for (i <- 0 until num_wb_ports)
+   {
+      busy_table.io.unbusy_pdst(i).valid := io.wb_valids(i)
+      busy_table.io.unbusy_pdst(i).bits  := io.wb_pdsts(i)
+   }
+
+   // scalastyle:on
+   io.debug := busy_table.io.debug
+}

--- a/src/main/scala/rename-busytable.scala
+++ b/src/main/scala/rename-busytable.scala
@@ -112,7 +112,6 @@ class BusyTable(
       val ren_mask              = Vec(pl_width, Bool()).asInput
       val ren_uops              = Vec(pl_width, new MicroOp()).asInput
 
-      val freelist_can_allocate = Vec(pl_width, Bool()).asInput
       val map_table             = Vec(pl_width, new MapTableOutput(preg_sz)).asInput
 
       val wb_valids             = Vec(num_wb_ports, Bool()).asInput
@@ -154,8 +153,7 @@ class BusyTable(
 
 
        // Updating the Table (new busy register)
-      busy_table.io.allocated_pdst(w).valid := io.freelist_can_allocate(w) &&
-                                               io.ren_mask(w) &&
+      busy_table.io.allocated_pdst(w).valid := io.ren_mask(w) &&
                                                io.ren_uops(w).ldst_val &&
                                                io.ren_uops(w).dst_rtype === UInt(rtype)
       busy_table.io.allocated_pdst(w).bits  := io.ren_uops(w).pdst

--- a/src/main/scala/rename-freelist.scala
+++ b/src/main/scala/rename-freelist.scala
@@ -1,0 +1,328 @@
+//******************************************************************************
+// Copyright (c) 2015, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Rename FreeList
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+package boom
+
+import Chisel._
+import config.Parameters
+
+
+class FreeListIo(num_phys_registers: Int, pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+{
+   private val preg_sz = log2Up(num_phys_registers)
+
+   val req_preg_vals = Vec(pl_width, Bool()).asInput
+   val req_pregs     = Vec(pl_width, UInt(width=preg_sz)).asOutput
+
+   // committed and newly freed register
+   val enq_vals      = Vec(pl_width, Bool()).asInput
+   val enq_pregs     = Vec(pl_width, UInt(width=preg_sz)).asInput
+
+   // do we have space to service incoming requests? (per inst granularity)
+   val can_allocate  = Vec(pl_width, Bool()).asOutput
+
+   // handle branches (save copy of freelist on branch, merge on mispredict)
+   val ren_br_vals   = Vec(pl_width, Bool()).asInput
+   val ren_br_tags   = Vec(pl_width, UInt(width=BR_TAG_SZ)).asInput
+
+   // handle mispredicts
+   val br_mispredict_val = Bool(INPUT)
+   val br_mispredict_tag = UInt(INPUT, BR_TAG_SZ)
+
+   // rollback (on exceptions)
+   val rollback_wens  = Vec(pl_width, Bool()).asInput
+   val rollback_pdsts = Vec(pl_width, UInt(width=preg_sz)).asInput
+
+   // or...
+   // TODO there are TWO free-list IOs now, based on constants. What is the best way to handle these two designs?
+   // perhaps freelist.scala, and instantiate which-ever one I want?
+   // TODO naming is inconsistent
+   // TODO combine with rollback, whatever?
+   val flush_pipeline = Bool(INPUT)
+   val com_wens       = Vec(pl_width, Bool()).asInput
+   val com_uops       = Vec(pl_width, new MicroOp()).asInput
+
+   val debug = new DebugFreeListIO(num_phys_registers).asOutput
+}
+
+class DebugFreeListIO(num_phys_registers: Int) extends Bundle
+{
+   val freelist = Bits(width=num_phys_registers)
+   val isprlist = Bits(width=num_phys_registers)
+   override def cloneType: this.type = new DebugFreeListIO(num_phys_registers).asInstanceOf[this.type]
+}
+
+// provide a fixed set of renamed destination registers
+// i.e., it doesn't matter if a previous UOP needs a pdst or not
+// this prevents a dependency chain from existing between UOPs when trying to
+// compute a pdst to give away (as well as computing if an available free
+// register exists
+class RenameFreeListHelper(
+   num_phys_registers: Int, // number of physical registers
+   pl_width: Int)           // pipeline width ("dispatch group size")
+   (implicit p: Parameters) extends BoomModule()(p)
+{
+   val io = new FreeListIo(num_phys_registers, pl_width)
+
+   // ** FREE LIST TABLE ** //
+   val free_list = Reg(init=(~Bits(1,num_phys_registers)))
+
+   // track all allocations that have occurred since branch passed by
+   // can quickly reset pipeline on branch mispredict
+   val allocation_lists = Reg(Vec(MAX_BR_COUNT, Bits(width = num_phys_registers)))
+
+   // TODO why is this a Vec? can I do this all on one bit-vector?
+   val enq_mask = Wire(Vec(pl_width, Bits(width = num_phys_registers)))
+
+   // ------------------------------------------
+   // find new,free physical registers
+
+   val requested_pregs_oh_array = Array.fill(pl_width,num_phys_registers){Bool(false)}
+   val requested_pregs_oh       = Wire(Vec(pl_width, Bits(width=num_phys_registers)))
+   val requested_pregs          = Wire(Vec(pl_width, UInt(width=log2Up(num_phys_registers))))
+   var allocated                = Wire(Vec(pl_width, Bool())) // did each inst get allocated a register?
+
+   // init
+   for (w <- 0 until pl_width)
+   {
+      allocated(w) := Bool(false)
+   }
+
+
+   for (i <- 1 until num_phys_registers) // note: p0 stays zero BUG XXX
+   {
+      val next_allocated = Wire(Vec(pl_width, Bool()))
+      var can_allocate = free_list(i)
+
+      for (w <- 0 until pl_width)
+      {
+         requested_pregs_oh_array(w)(i) = can_allocate && !allocated(w)
+
+         next_allocated(w) := can_allocate | allocated(w)
+         can_allocate = can_allocate && allocated(w)
+      }
+
+      allocated = next_allocated
+   }
+
+   for (w <- 0 until pl_width)
+   {
+      requested_pregs_oh(w) := Vec(requested_pregs_oh_array(w)).toBits
+      requested_pregs(w) := PriorityEncoder(requested_pregs_oh(w))
+   }
+
+
+   // ------------------------------------------
+   // Calculate next Free List
+   val req_free_list = Wire(Bits(width = num_phys_registers))
+   val enq_free_list = Wire(Bits(width = num_phys_registers))
+   req_free_list := free_list
+   enq_free_list := free_list
+
+   // ** Set requested PREG to "Not Free" ** //
+
+   // bit vector of newly allocated physical registers
+   var just_allocated_mask = Bits(0, num_phys_registers)
+
+   // track which allocation_lists just got cleared out by a branch,
+   // to enforce a write priority to allocation_lists()
+   val br_cleared = Wire(Vec(MAX_BR_COUNT, Bool()))
+   for (i <- 0 until MAX_BR_COUNT) { br_cleared(i) := Bool(false) }
+
+   for (w <- pl_width-1 to 0 by -1)
+   {
+      // When branching, start a fresh copy of the allocation_list
+      // but don't forget to bypass in the allocations within our bundle
+      when (io.ren_br_vals(w))
+      {
+         allocation_lists(io.ren_br_tags(w)) := just_allocated_mask
+         br_cleared(io.ren_br_tags(w)) := Bool(true)
+      }
+
+      // check that we both request a register and was able to allocate a register
+      just_allocated_mask = Mux(io.req_preg_vals(w) && allocated(w), requested_pregs_oh(w) | just_allocated_mask,
+                                                                     just_allocated_mask)
+   }
+
+   for (i <- 0 until MAX_BR_COUNT)
+   {
+      when (!br_cleared(i))
+      {
+         allocation_lists(i) := allocation_lists(i) | just_allocated_mask
+      }
+   }
+
+
+   // ** Set enqueued PREG to "Free" ** //
+   for (w <- 0 until pl_width)
+   {
+      enq_mask(w) := Bits(0,num_phys_registers)
+      when (io.enq_vals(w))
+      {
+         enq_mask(w) := UInt(1) << io.enq_pregs(w)
+      }
+      .elsewhen (io.rollback_wens(w))
+      {
+         enq_mask(w) := UInt(1) << io.rollback_pdsts(w)
+      }
+   }
+
+
+   // Update the Free List
+   when (!io.br_mispredict_val)
+   {
+      free_list := (free_list & ~(just_allocated_mask)) | (enq_mask.reduce(_|_))
+   }
+
+   // Handle Misprediction
+   //merge misspeculated allocation_list with free_list
+   val allocation_list = Wire(Bits(width = num_phys_registers))
+   allocation_list := allocation_lists(io.br_mispredict_tag)
+
+   when (io.br_mispredict_val)
+   {
+      // include newly freed register as well!
+      free_list := allocation_list | free_list | (enq_mask.reduce(_|_))
+
+      // set other branch allocation_lists to zero where allocation_list(j) == 1...
+      for (i <- 0 until MAX_BR_COUNT)
+      {
+         allocation_lists(i) := allocation_lists(i) & ~allocation_list
+      }
+   }
+
+
+   // OPTIONALLY: handle single-cycle resets
+   // Committed Free List tracks what the free list is at the commit point,
+   // allowing for a single-cycle reset of the rename state on a pipeline flush.
+   if (ENABLE_COMMIT_MAP_TABLE)
+   {
+      val committed_free_list = Reg(init=(~Bits(1,num_phys_registers)))
+
+      val com_mask = Wire(Vec(pl_width, Bits(width=num_phys_registers)))
+      val stale_mask = Wire(Vec(pl_width, Bits(width=num_phys_registers)))
+      for (w <- 0 until pl_width)
+      {
+         com_mask(w) := Bits(0,width=num_phys_registers)
+         stale_mask(w) := Bits(0,width=num_phys_registers)
+         when (io.com_wens(w))
+         {
+            com_mask(w) := UInt(1) << io.com_uops(w).pdst
+            stale_mask(w) := UInt(1) << io.com_uops(w).stale_pdst
+         }
+      }
+
+      committed_free_list := (committed_free_list & ~(com_mask.reduce(_|_))) | stale_mask.reduce(_|_)
+
+      when (io.flush_pipeline)
+      {
+         free_list := committed_free_list
+      }
+      io.debug.isprlist := committed_free_list
+   }
+
+
+
+   // ** SET OUTPUTS ** //
+   io.req_pregs := requested_pregs
+
+   io.can_allocate := allocated
+
+   io.debug.freelist := free_list
+}
+
+
+class RenameFreeList(
+   pl_width: Int,           // Pipeline width ("dispatch group size").
+   rtype: BigInt,           // What type of register are we in charge of?
+   num_phys_registers: Int) // Number of physical registers.
+   (implicit p: Parameters) extends BoomModule()(p)
+{
+   private val preg_sz = log2Up(num_phys_registers)
+
+   val io = new Bundle
+   {
+      // Inputs
+      val brinfo           = new BrResolutionInfo().asInput
+      val kill             = Bool(INPUT)
+
+      val ren_mask         = Vec(pl_width, Bool()).asInput
+      val ren_uops         = Vec(pl_width, new MicroOp()).asInput
+      val ren_br_vals      = Vec(pl_width, Bool()).asInput
+
+      val inst_can_proceed = Vec(pl_width, Bool()).asInput
+
+
+      val com_valids       = Vec(pl_width, Bool()).asInput
+      val com_uops         = Vec(pl_width, new MicroOp()).asInput
+      val com_rbk_valids   = Vec(pl_width, Bool()).asInput
+
+
+      val flush_pipeline   = Bool(INPUT)
+
+      // Outputs
+      val can_allocate     = Vec(pl_width, Bool()).asOutput
+      val req_pregs        = Vec(pl_width, UInt(width=preg_sz)).asOutput
+
+      val debug            = new DebugFreeListIO(num_phys_registers).asOutput
+      val debug_rob_empty  = Bool(INPUT)
+   }
+
+   val freelist = Module(new RenameFreeListHelper(
+      num_phys_registers,
+      pl_width))
+
+
+   freelist.io.br_mispredict_val := io.brinfo.mispredict
+   freelist.io.br_mispredict_tag := io.brinfo.tag
+   freelist.io.flush_pipeline    := io.flush_pipeline
+
+   for (w <- 0 until pl_width)
+   {
+      freelist.io.req_preg_vals(w)  := io.inst_can_proceed(w) &&
+                                       !io.kill &&
+                                       io.ren_mask(w) &&
+                                       io.ren_uops(w).ldst_val &&
+                                       io.ren_uops(w).dst_rtype === UInt(rtype)
+
+      freelist.io.enq_vals(w)       := io.com_valids(w) &&
+                                       io.com_uops(w).dst_rtype === UInt(rtype) &&
+                                       (io.com_uops(w).stale_pdst =/= UInt(0) || UInt(rtype) === RT_FLT)
+      freelist.io.enq_pregs(w)      := io.com_uops(w).stale_pdst
+
+      freelist.io.ren_br_vals(w)    := io.ren_br_vals(w)
+      freelist.io.ren_br_tags(w)    := io.ren_uops(w).br_tag
+
+
+      freelist.io.rollback_wens(w)  := io.com_rbk_valids(w) &&
+                                       (io.com_uops(w).pdst =/= UInt(0) || UInt(rtype) === RT_FLT) &&
+                                       io.com_uops(w).dst_rtype === UInt(rtype)
+      freelist.io.rollback_pdsts(w) := io.com_uops(w).pdst
+
+      freelist.io.com_wens(w)       := io.com_valids(w) &&
+                                       (io.com_uops(w).pdst =/= UInt(0) || UInt(rtype) === RT_FLT) &&
+                                       io.com_uops(w).dst_rtype === UInt(rtype)
+      freelist.io.com_uops(w)       := io.com_uops(w)
+
+      if (rtype == RT_FIX.litValue) {
+         // x0 is a special-case and should not be renamed
+         io.req_pregs(w) := Mux(io.ren_uops(w).ldst === UInt(0), UInt(0), freelist.io.req_pregs(w))
+      } else {
+         io.req_pregs(w) := freelist.io.req_pregs(w)
+      }
+   }
+
+   io.can_allocate := freelist.io.can_allocate
+   io.debug := freelist.io.debug
+
+   when (io.debug_rob_empty) {
+      assert (PopCount(freelist.io.debug.freelist) >= UInt(num_phys_registers - 32),
+         "[freelist] We're leaking physical registers")
+   }
+}

--- a/src/main/scala/rename-freelist.scala
+++ b/src/main/scala/rename-freelist.scala
@@ -62,7 +62,9 @@ class DebugFreeListIO(num_phys_registers: Int) extends Bundle
 // i.e., it doesn't matter if a previous UOP needs a pdst or not
 // this prevents a dependency chain from existing between UOPs when trying to
 // compute a pdst to give away (as well as computing if an available free
-// register exists
+// register exists.
+// NOTE: we never give out p0 -- that is the "unitialized" state of the map-table,
+// and the pipeline will give any reader of p0 0x0 as read data.
 class RenameFreeListHelper(
    num_phys_registers: Int, // number of physical registers
    pl_width: Int)           // pipeline width ("dispatch group size")
@@ -95,7 +97,8 @@ class RenameFreeListHelper(
    }
 
 
-   for (i <- 1 until num_phys_registers) // note: p0 stays zero BUG XXX
+   // don't give out p0
+   for (i <- 1 until num_phys_registers)
    {
       val next_allocated = Wire(Vec(pl_width, Bool()))
       var can_allocate = free_list(i)
@@ -277,7 +280,6 @@ class RenameFreeList(
    val freelist = Module(new RenameFreeListHelper(
       num_phys_registers,
       pl_width))
-
 
    freelist.io.br_mispredict_val := io.brinfo.mispredict
    freelist.io.br_mispredict_tag := io.brinfo.tag

--- a/src/main/scala/rename-freelist.scala
+++ b/src/main/scala/rename-freelist.scala
@@ -255,11 +255,9 @@ class RenameFreeList(
       val brinfo           = new BrResolutionInfo().asInput
       val kill             = Bool(INPUT)
 
-      val ren_mask         = Vec(pl_width, Bool()).asInput
+      val ren_will_fire    = Vec(pl_width, Bool()).asInput
       val ren_uops         = Vec(pl_width, new MicroOp()).asInput
       val ren_br_vals      = Vec(pl_width, Bool()).asInput
-
-      val inst_can_proceed = Vec(pl_width, Bool()).asInput
 
 
       val com_valids       = Vec(pl_width, Bool()).asInput
@@ -287,9 +285,8 @@ class RenameFreeList(
 
    for (w <- 0 until pl_width)
    {
-      freelist.io.req_preg_vals(w)  := io.inst_can_proceed(w) &&
-                                       !io.kill &&
-                                       io.ren_mask(w) &&
+      freelist.io.req_preg_vals(w)  := !io.kill &&
+                                       io.ren_will_fire(w) &&
                                        io.ren_uops(w).ldst_val &&
                                        io.ren_uops(w).dst_rtype === UInt(rtype)
 

--- a/src/main/scala/rename-maptable.scala
+++ b/src/main/scala/rename-maptable.scala
@@ -208,7 +208,7 @@ class RenameMapTable(
    for (w <- pl_width-1 to 0 by -1)
    {
       val ldst = io.com_uops(w).ldst
-      when (io.com_rbk_valids(w))
+      when (io.com_rbk_valids(w) && io.com_uops(w).dst_rtype === UInt(rtype))
       {
          map_table_io(ldst).rollback_wen        := Bool(true)
          map_table_io(ldst).rollback_stale_pdst := io.com_uops(w).stale_pdst
@@ -282,9 +282,14 @@ class RenameMapTable(
       }
 
       // add default case where we can just read the map table for our information
-      rs1_cases ++= Array((io.ren_uops(w).lrs1_rtype === UInt(rtype) && (io.ren_uops(w).lrs1 =/= UInt(0)), map_table_prs1(w)))
-      rs2_cases ++= Array((io.ren_uops(w).lrs2_rtype === UInt(rtype) && (io.ren_uops(w).lrs2 =/= UInt(0)), map_table_prs2(w)))
-      rs3_cases ++= Array((io.ren_uops(w).frs3_en  && io.ren_uops(w).lrs3 =/= UInt(0), map_table_prs3(w)))
+      if (rtype == RT_FIX.litValue) {
+         rs1_cases ++= Array((io.ren_uops(w).lrs1_rtype === UInt(rtype) && (io.ren_uops(w).lrs1 =/= UInt(0)), map_table_prs1(w)))
+         rs2_cases ++= Array((io.ren_uops(w).lrs2_rtype === UInt(rtype) && (io.ren_uops(w).lrs2 =/= UInt(0)), map_table_prs2(w)))
+      } else {
+         rs1_cases ++= Array((io.ren_uops(w).lrs1_rtype === UInt(rtype), map_table_prs1(w)))
+         rs2_cases ++= Array((io.ren_uops(w).lrs2_rtype === UInt(rtype), map_table_prs2(w)))
+      }
+      rs3_cases ++= Array((io.ren_uops(w).frs3_en, map_table_prs3(w)))
 
       // Set outputs.
       io.values(w).prs1       := MuxCase(io.ren_uops(w).lrs1, rs1_cases)

--- a/src/main/scala/rename-maptable.scala
+++ b/src/main/scala/rename-maptable.scala
@@ -1,0 +1,306 @@
+//******************************************************************************
+// Copyright (c) 2015, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Rename Map Table
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+package boom
+
+import Chisel._
+import config.Parameters
+
+
+class RenameMapTableElementIo(pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+{
+   val element            = UInt(OUTPUT, PREG_SZ)
+
+   val wens               = Vec(pl_width, Bool()).asInput
+   val ren_pdsts          = Vec(pl_width, UInt(width=PREG_SZ)).asInput
+
+   val ren_br_vals        = Vec(pl_width, Bool()).asInput
+   val ren_br_tags        = Vec(pl_width, UInt(width=BR_TAG_SZ)).asInput
+
+   val br_mispredict      = Bool(INPUT)
+   val br_mispredict_tag  = UInt(INPUT, BR_TAG_SZ)
+
+   // rollback (on exceptions)
+   // TODO REMOVE THIS ROLLBACK PORT, since wens is mutually exclusive with rollback_wens
+   val rollback_wen        = Bool(INPUT)
+   val rollback_stale_pdst = UInt(INPUT, PREG_SZ)
+
+   // TODO scr option
+   val flush_pipeline      = Bool(INPUT)
+   val commit_wen          = Bool(INPUT)
+   val commit_pdst         = UInt(INPUT, PREG_SZ)
+   val committed_element   = UInt(OUTPUT, PREG_SZ)
+
+   override def cloneType: this.type = new RenameMapTableElementIo(pl_width).asInstanceOf[this.type]
+}
+
+class RenameMapTableElement(pipeline_width: Int, always_zero: Boolean)(implicit p: Parameters) extends BoomModule()(p)
+{
+   val io = new RenameMapTableElementIo(pipeline_width)
+
+   // Note: I don't use a "valid" signal, since it's annoying to deal with and
+   // only necessary until the map tables are filled. So instead I reset the
+   // map table to all point to P0. I'm not sure which is less expensive.  The
+   // corner-case to deal with is the "stale" register needs to be correct and
+   // valid, so that freeing it won't free an actual register that was handed
+   // out in the meantime. A software solution is also possible, but I'm
+   // unwilling to trust that.
+
+   val element = Reg(init = UInt(0, PREG_SZ))
+
+   // handle branch speculation
+   val element_br_copies = Mem(MAX_BR_COUNT, UInt(width = PREG_SZ))
+
+
+   // this is possibly the hardest piece of code I have ever had to reason about in my LIFE.
+   // Or maybe that's the 5am talking.
+   // on every branch, make a copy of the rename map table state
+   // if jal/jalr, we want to capture our own setting of this register
+   // We need to know the AGE of the branch!
+   // 1st, is "wen" (incoming)
+   // 2nd, is older instructions in same bundle
+   // 3rd, current element
+
+   for (w <- 0 until pipeline_width)
+   {
+      var elm_cases = Array((Bool(false),  UInt(0,PREG_SZ)))
+
+      for (xx <- w to 0 by -1)
+      {
+         elm_cases ++= Array((io.wens(xx),  io.ren_pdsts(xx)))
+      }
+
+      when (io.ren_br_vals(w))
+      {
+         element_br_copies(io.ren_br_tags(w)) := MuxCase(element, elm_cases)
+      }
+   }
+
+
+   // reset table on mispredict
+   when(io.br_mispredict)
+   {
+      element := element_br_copies(io.br_mispredict_tag)
+   }
+   // rollback to the previous mapping
+   .elsewhen (io.rollback_wen)
+   {
+      element := io.rollback_stale_pdst
+   }
+   // free list is giving us a new pdst
+   .elsewhen (io.wens.reduce(_|_))
+   {
+      // give write priority to the last instruction in the bundle
+      element := PriorityMux(io.wens.reverse, io.ren_pdsts.reverse)
+   }
+
+   if (ENABLE_COMMIT_MAP_TABLE)
+   {
+      val committed_element = Reg(init=UInt(0,PREG_SZ))
+      when (io.commit_wen)
+      {
+         committed_element := io.commit_pdst
+      }
+      when (io.flush_pipeline)
+      {
+         element := committed_element
+      }
+      io.committed_element := committed_element
+   }
+
+   // outputs
+   io.element := element
+
+   if (always_zero) io.element := UInt(0)
+}
+
+
+// Pass out the new physical register specifiers.
+// Also tell the BusyTable if a bypass occurred from a new instruction,
+// so that the BusyTable can set the busy-bit to True.
+class MapTableOutput(preg_sz: Int) extends Bundle
+{
+   val prs1              = UInt(width = preg_sz)
+   val prs2              = UInt(width = preg_sz)
+   val prs3              = UInt(width = preg_sz)
+   val stale_pdst        = UInt(width = preg_sz)
+   val prs1_was_bypassed = Bool()
+   val prs2_was_bypassed = Bool()
+   val prs3_was_bypassed = Bool()
+   override def cloneType: this.type = new MapTableOutput(preg_sz).asInstanceOf[this.type]
+}
+
+class RenameMapTable(
+   pl_width: Int,
+   rtype: BigInt,
+   num_logical_registers: Int,
+   num_physical_registers: Int
+   )(implicit p: Parameters) extends BoomModule()(p)
+   with HasBoomCoreParameters
+{
+   private val preg_sz = log2Up(num_physical_registers)
+
+   val io = new BoomBundle()(p)
+   {
+      // Inputs
+      val brinfo           = new BrResolutionInfo().asInput
+      val kill             = Bool(INPUT)
+
+      val ren_mask         = Vec(pl_width, Bool()).asInput
+      val ren_uops         = Vec(pl_width, new MicroOp()).asInput
+      val ren_br_vals      = Vec(pl_width, Bool()).asInput
+
+      val com_valids       = Vec(pl_width, Bool()).asInput
+      val com_uops         = Vec(pl_width, new MicroOp()).asInput
+      val com_rbk_valids   = Vec(pl_width, Bool()).asInput
+      val flush_pipeline   = Bool(INPUT) // only used for SCR (single-cycle reset)
+
+      val inst_can_proceed = Vec(pl_width, Bool()).asInput
+      val freelist_can_allocate = Vec(pl_width, Bool()).asInput
+
+      // Outputs
+      val values           = Vec(pl_width, new MapTableOutput(preg_sz)).asOutput
+   }
+
+
+   val entries = for (i <- 0 until num_logical_registers) yield
+   {
+      val entry = Module(new RenameMapTableElement(pl_width, always_zero = (i==0 && rtype == RT_FIX.litValue)))
+      entry
+   }
+   val map_table_io = Vec(entries.map(_.io))
+
+   map_table_io.zipWithIndex.map{ case (entry, i) =>
+   {
+      // TODO get rid of this extra, init logic
+      entry.rollback_wen := Bool(false)
+      entry.rollback_stale_pdst := io.com_uops(0).stale_pdst
+      entry.commit_wen := Bool(false)
+      entry.commit_pdst := io.com_uops(0).pdst
+
+      for (w <- 0 until pl_width)
+      {
+         entry.wens(w)        := io.ren_uops(w).ldst === UInt(i) &&
+                                           io.ren_mask(w) &&
+                                           io.ren_uops(w).ldst_val &&
+                                           io.ren_uops(w).dst_rtype === UInt(rtype) &&
+                                           !io.kill &&
+                                           io.inst_can_proceed(w) &&
+                                           io.freelist_can_allocate(w)
+         entry.ren_pdsts(w)   := io.ren_uops(w).pdst
+         entry.ren_br_tags(w) := io.ren_uops(w).br_tag
+      }
+      entry.ren_br_vals := io.ren_br_vals
+
+      entry.br_mispredict     := io.brinfo.mispredict
+      entry.br_mispredict_tag := io.brinfo.tag
+
+      entry.flush_pipeline    := io.flush_pipeline
+   }}
+
+   // backwards, because rollback must give highest priority to 0 (the oldest instruction)
+   for (w <- pl_width-1 to 0 by -1)
+   {
+      val ldst = io.com_uops(w).ldst
+      when (io.com_rbk_valids(w))
+      {
+         map_table_io(ldst).rollback_wen        := Bool(true)
+         map_table_io(ldst).rollback_stale_pdst := io.com_uops(w).stale_pdst
+      }
+   }
+
+   if (ENABLE_COMMIT_MAP_TABLE)
+   {
+      for (w <- 0 until pl_width)
+      {
+         val ldst = io.com_uops(w).ldst
+         when (io.com_valids(w) && (io.com_uops(w).dst_rtype === UInt(rtype)))
+         {
+            map_table_io(ldst).commit_wen := Bool(true)
+            map_table_io(ldst).commit_pdst := io.com_uops(w).pdst
+         }
+      }
+   }
+
+   // Read out the map-table entries ASAP, then deal with bypassing busy-bits later.
+   private val map_table_output = Seq.fill(pl_width*3)(Wire(UInt(width=PREG_SZ)))
+   def map_table_prs1(w:Int) = map_table_output(w+0*pl_width)
+   def map_table_prs2(w:Int) = map_table_output(w+1*pl_width)
+   def map_table_prs3(w:Int) = map_table_output(w+2*pl_width)
+
+   for (w <- 0 until pl_width)
+   {
+      map_table_prs1(w) := map_table_io(io.ren_uops(w).lrs1).element
+      map_table_prs2(w) := map_table_io(io.ren_uops(w).lrs2).element
+      if (rtype == RT_FLT.litValue) {
+         map_table_prs3(w) := map_table_io(io.ren_uops(w).lrs3).element
+      } else {
+         map_table_prs3(w) := UInt(0)
+      }
+   }
+
+
+   // Bypass the physical register mappings
+   for (w <- 0 until pl_width)
+   {
+      var rs1_cases =  Array((Bool(false),  UInt(0,PREG_SZ)))
+      var rs2_cases =  Array((Bool(false),  UInt(0,PREG_SZ)))
+      var rs3_cases =  Array((Bool(false),  UInt(0,PREG_SZ)))
+      var stale_cases= Array((Bool(false),  UInt(0,PREG_SZ)))
+
+      io.values(w).prs1_was_bypassed := Bool(false)
+      io.values(w).prs2_was_bypassed := Bool(false)
+      io.values(w).prs3_was_bypassed := Bool(false)
+
+      // Handle bypassing new physical destinations to operands (and stale destination)
+      // scalastyle:off
+      for (xx <- w-1 to 0 by -1)
+      {
+         rs1_cases  ++= Array((io.ren_uops(w).lrs1_rtype === UInt(rtype) && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).lrs1 === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
+         rs2_cases  ++= Array((io.ren_uops(w).lrs2_rtype === UInt(rtype) && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).lrs2 === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
+         stale_cases++= Array((io.ren_uops(w).dst_rtype === UInt(rtype)  && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).ldst === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
+
+         when (io.ren_uops(w).lrs1_rtype === UInt(rtype) && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).lrs1 === io.ren_uops(xx).ldst))
+            { io.values(w).prs1_was_bypassed := Bool(true) }
+         when (io.ren_uops(w).lrs2_rtype === UInt(rtype) && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).lrs2 === io.ren_uops(xx).ldst))
+            { io.values(w).prs2_was_bypassed := Bool(true) }
+
+
+         if (rtype == RT_FLT.litValue) {
+            rs3_cases  ++= Array((
+                  io.ren_uops(w).frs3_en && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).lrs3 === io.ren_uops(xx).ldst),
+                  (io.ren_uops(xx).pdst)))
+            when (io.ren_uops(w).frs3_en && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && io.ren_uops(xx).dst_rtype === UInt(rtype) && (io.ren_uops(w).lrs3 === io.ren_uops(xx).ldst))
+               { io.values(w).prs3_was_bypassed := Bool(true) }
+         }
+      }
+
+      // add default case where we can just read the map table for our information
+      rs1_cases ++= Array((io.ren_uops(w).lrs1_rtype === UInt(rtype) && (io.ren_uops(w).lrs1 =/= UInt(0)), map_table_prs1(w)))
+      rs2_cases ++= Array((io.ren_uops(w).lrs2_rtype === UInt(rtype) && (io.ren_uops(w).lrs2 =/= UInt(0)), map_table_prs2(w)))
+      rs3_cases ++= Array((io.ren_uops(w).frs3_en  && io.ren_uops(w).lrs3 =/= UInt(0), map_table_prs3(w)))
+
+      // Set outputs.
+      io.values(w).prs1       := MuxCase(io.ren_uops(w).lrs1, rs1_cases)
+      io.values(w).prs2       := MuxCase(io.ren_uops(w).lrs2, rs2_cases)
+      if (rtype == RT_FLT.litValue)
+         {io.values(w).prs3 := MuxCase(io.ren_uops(w).lrs3, rs3_cases)}
+      io.values(w).stale_pdst := MuxCase(map_table_io(io.ren_uops(w).ldst).element, stale_cases)
+
+
+      if (rtype == RT_FIX.litValue) {
+         assert (!(io.ren_uops(w).lrs1 === UInt(0) && io.ren_uops(w).lrs1_rtype === RT_FIX && io.values(w).prs1 =/= UInt(0)), "lrs1==0 but maptable(" + w + ") returning non-zero.")
+         assert (!(io.ren_uops(w).lrs2 === UInt(0) && io.ren_uops(w).lrs2_rtype === RT_FIX && io.values(w).prs2 =/= UInt(0)), "lrs2==0 but maptable(" + w + ") returning non-zero.")
+         assert (!(io.ren_uops(w).lrs1 === UInt(0) && io.ren_uops(w).lrs1_rtype === RT_FIX && map_table_prs1(w) =/= UInt(0)), "lrs1==0 but maptable(" + w + ") returning non-zero.")
+         assert (!(io.ren_uops(w).lrs2 === UInt(0) && io.ren_uops(w).lrs2_rtype === RT_FIX && map_table_prs2(w) =/= UInt(0)), "lrs2==0 but maptable(" + w + ") returning non-zero.")
+      }
+      // scalastyle:on
+   }
+}
+

--- a/src/main/scala/rename.scala
+++ b/src/main/scala/rename.scala
@@ -50,7 +50,7 @@ class RenameStageIO(
    val int_wb_valids = Vec(num_int_wb_ports, Bool()).asInput
    val int_wb_pdsts  = Vec(num_int_wb_ports, UInt(width=int_preg_sz)).asInput
    val fp_wb_valids = Vec(num_fp_wb_ports, Bool()).asInput
-   val fp_wb_pdsts  = Vec(num_fp_wb_ports, UInt(width=num_fp_pregs)).asInput
+   val fp_wb_pdsts  = Vec(num_fp_wb_ports, UInt(width=fp_reg_sz)).asInput
 
    // commit stage
    val com_valids = Vec(pl_width, Bool()).asInput

--- a/src/main/scala/rename.scala
+++ b/src/main/scala/rename.scala
@@ -9,6 +9,12 @@
 //
 // Christopher Celio
 // 2012 Feb 14
+//
+// Supports 1-cycle and 2-cycle latencies. (aka, passthrough versus registers between ren1 and ren2).
+//    - ren1: read the map tables and allocate a new physical register from the freelist.
+//    - ren2: read the busy table for the physical operands.
+//
+// Ren1 data is provided as an output to be fed directly into the ROB.
 
 
 package boom
@@ -34,9 +40,14 @@ class RenameStageIO(
 
    val dec_will_fire = Vec(pl_width, Bool()).asInput // will commit state updates
    val dec_uops  = Vec(pl_width, new MicroOp()).asInput
-   
-   val ren_mask  = Vec(pl_width, Bool().asOutput) // mask of valid instructions
-   val ren_uops  = Vec(pl_width, new MicroOp().asOutput)
+
+   // physical specifiers now available (but not the busy/ready status of the operands).
+   val ren1_mask = Vec(pl_width, Bool().asOutput) // mask of valid instructions
+   val ren1_uops = Vec(pl_width, new MicroOp().asOutput)
+
+   // physical specifiers available AND busy/ready status available.
+   val ren2_mask  = Vec(pl_width, Bool().asOutput) // mask of valid instructions
+   val ren2_uops  = Vec(pl_width, new MicroOp().asOutput)
 
    val ren_pred_info = new BranchPredictionResp().asInput
 
@@ -133,7 +144,7 @@ class RenameStage(
       ren1_uops(w)      := GetNewUopAndBrMask(io.dec_uops(w), io.brinfo)
       ren1_br_vals(w)   := io.dec_will_fire(w) && io.dec_uops(w).allocate_brtag
    }
-    
+
    //-------------------------------------------------------------
    // Branch Predictor Snapshots
 
@@ -153,10 +164,10 @@ class RenameStage(
 
    val temp = Wire(new BranchPredictionResp)
    println("\t\tPrediction Snapshots: " + temp.toBits.getWidth + "-bits, " + MAX_BR_COUNT + " entries")
- 
+
    //-------------------------------------------------------------
    // Free List
- 
+
    for (list <- Seq(ifreelist, ffreelist))
    {
       list.io.brinfo := io.brinfo
@@ -177,7 +188,7 @@ class RenameStage(
       val f_preg = ffreelist.io.req_pregs(w)
       uop.pdst := Mux(uop.dst_rtype === RT_FLT, f_preg, i_preg)
    }
- 
+
    //-------------------------------------------------------------
    // Rename Table
 
@@ -210,12 +221,36 @@ class RenameStage(
 
    //-------------------------------------------------------------
    // pipeline registers
-   // TODO add def function for RegOrWire
 
    for (w <- 0 until pl_width)
    {
-      ren2_valids(w) := ren1_will_fire(w)
-      ren2_uops(w)   := GetNewUopAndBrMask(ren1_uops(w), io.brinfo)
+      if (renameLatency == 1)
+      {
+         ren2_valids(w) := ren1_will_fire(w)
+         ren2_uops(w)   := GetNewUopAndBrMask(ren1_uops(w), io.brinfo)
+      }
+      else
+      {
+         require (renameLatency == 2)
+         val r_valids = Reg(Vec.fill(pl_width) {Bool(false)})
+         val r_uops   = Reg(Vec(pl_width, new MicroOp()))
+
+//         ren2_valids(w) := RegEnable(ren1_will_fire(w), io.dis_inst_can_proceed(w))
+
+         when (io.dis_inst_can_proceed(w))
+         {
+            r_valids(w) := ren1_will_fire(w)
+            r_uops(w) := GetNewUopAndBrMask(ren1_uops(w), io.brinfo)
+         }
+         .otherwise
+         {
+//            r_valids(w) := ren1_will_fire(w)
+            r_uops(w) := GetNewUopAndBrMask(r_uops(w), io.brinfo)
+         }
+
+         ren2_valids(w) := r_valids(w)
+         ren2_uops  (w) := r_uops(w)
+      }
    }
 
    val ren2_will_fire = ren2_valids zip io.inst_can_proceed map {case (v,c) => v && c&& !io.kill}
@@ -225,8 +260,7 @@ class RenameStage(
 
    ibusytable.io.ren_mask := ren2_will_fire
    ibusytable.io.ren_uops := ren2_uops  // expects pdst to be set up.
-   ibusytable.io.freelist_can_allocate := ifreelist.io.can_allocate
-   ibusytable.io.map_table := imaptable.io.values
+   ibusytable.io.map_table := RegNext(imaptable.io.values)
    ibusytable.io.wb_valids := io.int_wakeups.map(_.valid)
    ibusytable.io.wb_pdsts := io.int_wakeups.map(_.bits.uop.pdst)
 
@@ -235,11 +269,10 @@ class RenameStage(
 
    fbusytable.io.ren_mask := ren2_will_fire
    fbusytable.io.ren_uops := ren2_uops  // expects pdst to be set up.
-   fbusytable.io.freelist_can_allocate := ffreelist.io.can_allocate
-   fbusytable.io.map_table := fmaptable.io.values
+   fbusytable.io.map_table := RegNext(fmaptable.io.values)
    fbusytable.io.wb_valids := io.fp_wakeups.map(_.valid)
    fbusytable.io.wb_pdsts := io.fp_wakeups.map(_.bits.uop.pdst)
-   
+
    assert (!(io.fp_wakeups.map(x => x.valid && x.bits.uop.dst_rtype =/= RT_FLT).reduce(_|_)),
       "[rename] fp wakeup is not waking up a FP register.")
 
@@ -250,10 +283,19 @@ class RenameStage(
       uop.prs1_busy := Mux(uop.lrs1_rtype === RT_FLT, fbusy.prs1_busy, ibusy.prs1_busy)
       uop.prs2_busy := Mux(uop.lrs2_rtype === RT_FLT, fbusy.prs2_busy, ibusy.prs2_busy)
       uop.prs3_busy := fbusy.prs3_busy
+
+      assert (!(ibusy.prs1_busy && uop.lrs1_rtype === RT_FIX && uop.lrs1 === UInt(0)), "[rename] x0 is busy??")
+      assert (!(ibusy.prs2_busy && uop.lrs2_rtype === RT_FIX && uop.lrs2 === UInt(0)), "[rename] x0 is busy??")
    }
 
    //-------------------------------------------------------------
    // Outputs
+
+   io.ren1_mask := ren1_will_fire
+   io.ren1_uops := ren1_uops
+
+   io.ren2_mask := ren2_will_fire
+   io.ren2_uops := ren2_uops map {u => GetNewUopAndBrMask(u, io.brinfo)}
 
    for (w <- 0 until pl_width)
    {
@@ -263,11 +305,8 @@ class RenameStage(
          ((ren1_uops(w).dst_rtype =/= RT_FIX && ren1_uops(w).dst_rtype =/= RT_FLT) ||
          (ifreelist.io.can_allocate(w) && ren1_uops(w).dst_rtype === RT_FIX) ||
          (ffreelist.io.can_allocate(w) && ren1_uops(w).dst_rtype === RT_FLT))
-
-      io.ren_mask(w) := ren2_will_fire(w)
-      io.ren_uops(w) := GetNewUopAndBrMask(ren2_uops(w), io.brinfo)
    }
-       
+
 
    //-------------------------------------------------------------
    // Debug signals

--- a/src/main/scala/rename.scala
+++ b/src/main/scala/rename.scala
@@ -12,415 +12,22 @@
 
 
 package boom
-{
 
 import Chisel._
 import config.Parameters
 
-//-------------------------------------------------------------
-//-------------------------------------------------------------
 
-class RenameMapTableElementIo(pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class RenameStageIO(
+   pl_width: Int,
+   num_int_pregs: Int,
+   num_fp_pregs: Int,
+   num_int_wb_ports: Int,
+   num_fp_wb_ports: Int)
+   (implicit p: Parameters) extends BoomBundle()(p)
 {
-   val element            = UInt(OUTPUT, PREG_SZ)
+   private val int_preg_sz = log2Up(num_int_pregs)
+   private val fp_preg_sz = log2Up(num_fp_pregs)
 
-   val wens               = Vec(pl_width, Bool()).asInput
-   val ren_pdsts          = Vec(pl_width, UInt(width=PREG_SZ)).asInput
-
-   val ren_br_vals        = Vec(pl_width, Bool()).asInput
-   val ren_br_tags        = Vec(pl_width, UInt(width=BR_TAG_SZ)).asInput
-
-   val br_mispredict      = Bool(INPUT)
-   val br_mispredict_tag  = UInt(INPUT, BR_TAG_SZ)
-
-   // rollback (on exceptions)
-   // TODO REMOVE THIS ROLLBACK PORT, since wens is mutually exclusive with rollback_wens
-   val rollback_wen        = Bool(INPUT)
-   val rollback_stale_pdst = UInt(INPUT, PREG_SZ)
-
-   // TODO scr option
-   val flush_pipeline      = Bool(INPUT)
-   val commit_wen          = Bool(INPUT)
-   val commit_pdst         = UInt(INPUT, PREG_SZ)
-   val committed_element   = UInt(OUTPUT, PREG_SZ)
-
-   override def cloneType: this.type = new RenameMapTableElementIo(pl_width).asInstanceOf[this.type]
-}
-
-class RenameMapTableElement(pipeline_width: Int)(implicit p: Parameters) extends BoomModule()(p)
-{
-   val io = new RenameMapTableElementIo(pipeline_width)
-
-   // Note: I don't use a "valid" signal, since it's annoying to deal with and
-   // only necessary until the map tables are filled. So instead I reset the
-   // map table to all point to P0. I'm not sure which is less expensive.  The
-   // corner-case to deal with is the "stale" register needs to be correct and
-   // valid, so that freeing it won't free an actual register that was handed
-   // out in the meantime. A software solution is also possible, but I'm
-   // unwilling to trust that.
-
-   val element = Reg(init = UInt(0, PREG_SZ))
-
-   // handle branch speculation
-   val element_br_copies = Mem(MAX_BR_COUNT, UInt(width = PREG_SZ))
-
-
-   // this is possibly the hardest piece of code I have ever had to reason about in my LIFE.
-   // Or maybe that's the 5am talking.
-   // on every branch, make a copy of the rename map table state
-   // if jal/jalr, we want to capture our own setting of this register
-   // We need to know the AGE of the branch!
-   // 1st, is "wen" (incoming)
-   // 2nd, is older instructions in same bundle
-   // 3rd, current element
-
-   for (w <- 0 until pipeline_width)
-   {
-      var elm_cases = Array((Bool(false),  UInt(0,PREG_SZ)))
-
-      for (xx <- w to 0 by -1)
-      {
-         elm_cases ++= Array((io.wens(xx),  io.ren_pdsts(xx)))
-      }
-
-      when (io.ren_br_vals(w))
-      {
-         element_br_copies(io.ren_br_tags(w)) := MuxCase(element, elm_cases)
-      }
-   }
-
-
-   // reset table on mispredict
-   when(io.br_mispredict)
-   {
-      element := element_br_copies(io.br_mispredict_tag)
-   }
-   // rollback to the previous mapping
-   .elsewhen (io.rollback_wen)
-   {
-      element := io.rollback_stale_pdst
-   }
-   // free list is giving us a new pdst
-   .elsewhen (io.wens.reduce(_|_))
-   {
-      // give write priority to the last instruction in the bundle
-      element := PriorityMux(io.wens.reverse, io.ren_pdsts.reverse)
-   }
-
-   if (ENABLE_COMMIT_MAP_TABLE)
-   {
-      val committed_element = Reg(init=UInt(0,PREG_SZ))
-      when (io.commit_wen)
-      {
-         committed_element := io.commit_pdst
-      }
-      when (io.flush_pipeline)
-      {
-         element := committed_element
-      }
-      io.committed_element := committed_element
-   }
-
-   // outputs
-   io.element  := element
-}
-
-//-------------------------------------------------------------
-//-------------------------------------------------------------
-
-class FreeListIo(num_phys_registers: Int, pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
-{
-   val req_preg_vals = Vec(pl_width, Bool()).asInput
-   val req_pregs     = Vec(pl_width, UInt(width=log2Up(num_phys_registers))).asOutput
-
-   // committed and newly freed register
-   val enq_vals      = Vec(pl_width, Bool()).asInput
-   val enq_pregs     = Vec(pl_width, UInt(width=log2Up(num_phys_registers))).asInput
-
-   // do we have space to service incoming requests? (per inst granularity)
-   val can_allocate  = Vec(pl_width, Bool()).asOutput
-
-   // handle branches (save copy of freelist on branch, merge on mispredict)
-   val ren_br_vals   = Vec(pl_width, Bool()).asInput
-   val ren_br_tags   = Vec(pl_width, UInt(width=BR_TAG_SZ)).asInput
-
-   // handle mispredicts
-   val br_mispredict_val = Bool(INPUT)
-   val br_mispredict_tag = UInt(INPUT, BR_TAG_SZ)
-
-   // rollback (on exceptions)
-   val rollback_wens  = Vec(pl_width, Bool()).asInput
-   val rollback_pdsts = Vec(pl_width, UInt(width=log2Up(num_phys_registers))).asInput
-
-   // or...
-   // TODO there are TWO free-list IOs now, based on constants. What is the best way to handle these two designs?
-   // perhaps freelist.scala, and instantiate which-ever one I want?
-   // TODO naming is inconsistent
-   // TODO combine with rollback, whatever?
-   val flush_pipeline = Bool(INPUT)
-   val com_wens       = Vec(pl_width, Bool()).asInput
-   val com_uops       = Vec(pl_width, new MicroOp()).asInput
-
-   val debug = new DebugFreeListIO(num_phys_registers).asOutput
-}
-
-class DebugFreeListIO(num_phys_registers: Int) extends Bundle
-{
-   val freelist = Bits(width=num_phys_registers)
-   val isprlist = Bits(width=num_phys_registers)
-   override def cloneType: this.type = new DebugFreeListIO(num_phys_registers).asInstanceOf[this.type]
-}
-
-// provide a fixed set of renamed destination registers
-// i.e., it doesn't matter if a previous UOP needs a pdst or not
-// this prevents a dependency chain from existing between UOPs when trying to
-// compute a pdst to give away (as well as computing if an available free
-// register exists
-class RenameFreeList(num_phys_registers: Int // number of physical registers
-                    , pl_width: Int          // pipeline width ("dispatch group size")
-                     )(implicit p: Parameters) extends BoomModule()(p)
-{
-   val io = new FreeListIo(num_phys_registers, pl_width)
-
-   // ** FREE LIST TABLE ** //
-   val free_list = Reg(init=(~Bits(1,num_phys_registers)))
-
-   // track all allocations that have occurred since branch passed by
-   // can quickly reset pipeline on branch mispredict
-   val allocation_lists = Reg(Vec(MAX_BR_COUNT, Bits(width = num_phys_registers)))
-
-   // TODO why is this a Vec? can I do this all on one bit-vector?
-   val enq_mask = Wire(Vec(pl_width, Bits(width = num_phys_registers)))
-
-   // ------------------------------------------
-   // find new,free physical registers
-
-   val requested_pregs_oh_array = Array.fill(pl_width,num_phys_registers){Bool(false)}
-   val requested_pregs_oh       = Wire(Vec(pl_width, Bits(width=num_phys_registers)))
-   val requested_pregs          = Wire(Vec(pl_width, UInt(width=log2Up(num_phys_registers))))
-   var allocated                = Wire(Vec(pl_width, Bool())) // did each inst get allocated a register?
-
-   // init
-   for (w <- 0 until pl_width)
-   {
-      allocated(w) := Bool(false)
-   }
-
-
-   for (i <- 1 until num_phys_registers) // note: p0 stays zero
-   {
-      val next_allocated = Wire(Vec(pl_width, Bool()))
-      var can_allocate = free_list(i)
-
-      for (w <- 0 until pl_width)
-      {
-         requested_pregs_oh_array(w)(i) = can_allocate && !allocated(w)
-
-         next_allocated(w) := can_allocate | allocated(w)
-         can_allocate = can_allocate && allocated(w)
-      }
-
-      allocated = next_allocated
-   }
-
-   for (w <- 0 until pl_width)
-   {
-      requested_pregs_oh(w) := Vec(requested_pregs_oh_array(w)).toBits
-      requested_pregs(w) := PriorityEncoder(requested_pregs_oh(w))
-   }
-
-
-   // ------------------------------------------
-   // Calculate next Free List
-   val req_free_list = Wire(Bits(width = num_phys_registers))
-   val enq_free_list = Wire(Bits(width = num_phys_registers))
-   req_free_list := free_list
-   enq_free_list := free_list
-
-   // ** Set requested PREG to "Not Free" ** //
-
-   // bit vector of newly allocated physical registers
-   var just_allocated_mask = Bits(0, num_phys_registers)
-
-   // track which allocation_lists just got cleared out by a branch,
-   // to enforce a write priority to allocation_lists()
-   val br_cleared = Wire(Vec(MAX_BR_COUNT, Bool()))
-   for (i <- 0 until MAX_BR_COUNT) { br_cleared(i) := Bool(false) }
-
-   for (w <- pl_width-1 to 0 by -1)
-   {
-      // When branching, start a fresh copy of the allocation_list
-      // but don't forget to bypass in the allocations within our bundle
-      when (io.ren_br_vals(w))
-      {
-         allocation_lists(io.ren_br_tags(w)) := just_allocated_mask
-         br_cleared(io.ren_br_tags(w)) := Bool(true)
-      }
-
-      // check that we both request a register and was able to allocate a register
-      just_allocated_mask = Mux(io.req_preg_vals(w) && allocated(w), requested_pregs_oh(w) | just_allocated_mask,
-                                                                     just_allocated_mask)
-   }
-
-   for (i <- 0 until MAX_BR_COUNT)
-   {
-      when (!br_cleared(i))
-      {
-         allocation_lists(i) := allocation_lists(i) | just_allocated_mask
-      }
-   }
-
-
-   // ** Set enqueued PREG to "Free" ** //
-   for (w <- 0 until pl_width)
-   {
-      enq_mask(w) := Bits(0,num_phys_registers)
-      when (io.enq_vals(w))
-      {
-         enq_mask(w) := UInt(1) << io.enq_pregs(w)
-      }
-      .elsewhen (io.rollback_wens(w))
-      {
-         enq_mask(w) := UInt(1) << io.rollback_pdsts(w)
-      }
-   }
-
-
-   // Update the Free List
-   when (!io.br_mispredict_val)
-   {
-      free_list := (free_list & ~(just_allocated_mask)) | (enq_mask.reduce(_|_))
-   }
-
-   // Handle Misprediction
-   //merge misspeculated allocation_list with free_list
-   val allocation_list = Wire(Bits(width = num_phys_registers))
-   allocation_list := allocation_lists(io.br_mispredict_tag)
-
-   when (io.br_mispredict_val)
-   {
-      // include newly freed register as well!
-      free_list := allocation_list | free_list | (enq_mask.reduce(_|_))
-
-      // set other branch allocation_lists to zero where allocation_list(j) == 1...
-      for (i <- 0 until MAX_BR_COUNT)
-      {
-         allocation_lists(i) := allocation_lists(i) & ~allocation_list
-      }
-   }
-
-
-   // OPTIONALLY: handle single-cycle resets
-   // Committed Free List tracks what the free list is at the commit point,
-   // allowing for a single-cycle reset of the rename state on a pipeline flush.
-   if (ENABLE_COMMIT_MAP_TABLE)
-   {
-      val committed_free_list = Reg(init=(~Bits(1,num_phys_registers)))
-
-      val com_mask = Wire(Vec(pl_width, Bits(width=num_phys_registers)))
-      val stale_mask = Wire(Vec(pl_width, Bits(width=num_phys_registers)))
-      for (w <- 0 until pl_width)
-      {
-         com_mask(w) := Bits(0,width=num_phys_registers)
-         stale_mask(w) := Bits(0,width=num_phys_registers)
-         when (io.com_wens(w))
-         {
-            com_mask(w) := UInt(1) << io.com_uops(w).pdst
-            stale_mask(w) := UInt(1) << io.com_uops(w).stale_pdst
-         }
-      }
-
-      committed_free_list := (committed_free_list & ~(com_mask.reduce(_|_))) | stale_mask.reduce(_|_)
-
-      when (io.flush_pipeline)
-      {
-         free_list := committed_free_list
-      }
-      io.debug.isprlist := committed_free_list
-   }
-
-
-
-   // ** SET OUTPUTS ** //
-   io.req_pregs := requested_pregs
-
-   io.can_allocate := allocated
-
-   io.debug.freelist := free_list
-}
-
-
-//-------------------------------------------------------------
-//-------------------------------------------------------------
-
-// internally bypasses newly busy registers (.write) to the read ports (.read)
-// num_operands is the maximum number of operands per instruction (.e.g., 2 normally, but 3 if FMAs are supported)
-class BusyTableIo(pipeline_width:Int, num_regs: Int, num_read_ports:Int, num_wb_ports:Int)(implicit p: Parameters) extends BoomBundle()(p)
-{
-   // reading out the busy bits
-   val p_rs           = Vec(num_read_ports, UInt(width=PREG_SZ)).asInput
-   val p_rs_busy      = Vec(num_read_ports, Bool()).asOutput
-
-   def prs(i:Int, w:Int):UInt      = p_rs     (w+i*pipeline_width)
-   def prs_busy(i:Int, w:Int):Bool = p_rs_busy(w+i*pipeline_width)
-
-   // marking new registers as busy
-   val allocated_pdst = Vec(pipeline_width, new ValidIO(UInt(width=PREG_SZ))).flip
-
-   // marking registers being written back as unbusy
-   val unbusy_pdst    = Vec(num_wb_ports, new ValidIO(UInt(width = PREG_SZ))).flip
-
-   val debug = new Bundle { val bsy_table= Bits(width=num_regs).asOutput }
-}
-
-// Register P0 is always NOT_BUSY, and cannot be set to BUSY
-// Note: I do NOT bypass from newly busied registers to the read ports.
-// That bypass check should be done elsewhere (this is to get it off the
-// critical path).
-class BusyTable(pipeline_width:Int, num_regs: Int, num_read_ports:Int, num_wb_ports:Int)(implicit p: Parameters) extends BoomModule()(p)
-{
-   val io = new BusyTableIo(pipeline_width, num_regs, num_read_ports, num_wb_ports)
-
-   def BUSY     = Bool(true)
-   def NOT_BUSY = Bool(false)
-
-   //TODO BUG chisel3
-   val table_bsy = Reg(init=Vec.fill(num_regs){Bool(false)})
-
-   for (wb_idx <- 0 until num_wb_ports)
-   {
-      when (io.unbusy_pdst(wb_idx).valid)
-      {
-         table_bsy(io.unbusy_pdst(wb_idx).bits) := NOT_BUSY
-      }
-   }
-
-   for (w <- 0 until pipeline_width)
-   {
-      when (io.allocated_pdst(w).valid && io.allocated_pdst(w).bits =/= UInt(0))
-      {
-         table_bsy(io.allocated_pdst(w).bits) := BUSY
-      }
-   }
-
-   // handle bypassing a clearing of the busy-bit
-   for (ridx <- 0 until num_read_ports)
-   {
-      val just_cleared = io.unbusy_pdst.map(p => p.valid && (p.bits === io.p_rs(ridx))).reduce(_|_)
-      // note: no bypassing of the newly busied (that is done outside this module)
-      io.p_rs_busy(ridx) := (table_bsy(io.p_rs(ridx)) && !just_cleared)
-   }
-
-   io.debug.bsy_table := table_bsy.toBits
-}
-
-//-------------------------------------------------------------
-//-------------------------------------------------------------
-//-------------------------------------------------------------
-//-------------------------------------------------------------
-
-class RenameStageIO(pl_width: Int, num_wb_ports: Int)(implicit p: Parameters) extends BoomBundle()(p)
-{
    val ren_mask  = Vec(pl_width, Bool().asOutput) // mask of valid instructions
    val inst_can_proceed = Vec(pl_width, Bool()).asOutput
 
@@ -440,8 +47,10 @@ class RenameStageIO(pl_width: Int, num_wb_ports: Int)(implicit p: Parameters) ex
    val dis_inst_can_proceed = Vec(DISPATCH_WIDTH, Bool()).asInput
 
    // issue stage (fast wakeup)
-   val wb_valids = Vec(num_wb_ports, Bool()).asInput
-   val wb_pdsts  = Vec(num_wb_ports, UInt(width=PREG_SZ)).asInput
+   val int_wb_valids = Vec(num_int_wb_ports, Bool()).asInput
+   val int_wb_pdsts  = Vec(num_int_wb_ports, UInt(width=int_preg_sz)).asInput
+   val fp_wb_valids = Vec(num_fp_wb_ports, Bool()).asInput
+   val fp_wb_pdsts  = Vec(num_fp_wb_ports, UInt(width=num_fp_pregs)).asInput
 
    // commit stage
    val com_valids = Vec(pl_width, Bool()).asInput
@@ -450,278 +59,135 @@ class RenameStageIO(pl_width: Int, num_wb_ports: Int)(implicit p: Parameters) ex
 
    val flush_pipeline = Bool(INPUT) // TODO only used for SCR (single-cycle reset)
 
-   val debug = new DebugRenameStageIO(numIntPhysRegs).asOutput
+   val debug_rob_empty = Bool(INPUT)
+   val debug = new DebugRenameStageIO(num_int_pregs).asOutput
 }
+
 
 class DebugRenameStageIO(num_pregs: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val freelist = Bits(width=num_pregs)
-   val isprlist = Bits(width=num_pregs)
-   val bsy_table = UInt(width=num_pregs)
+   val ifreelist = Bits(width=num_pregs)
+   val iisprlist = Bits(width=num_pregs)
+   val ibusytable = UInt(width=num_pregs)
    override def cloneType: this.type = new DebugRenameStageIO(num_pregs).asInstanceOf[this.type]
 }
 
-class RenameStage(pl_width: Int, num_wb_ports: Int)(implicit p: Parameters) extends BoomModule()(p)
+
+class RenameStage(
+   pl_width: Int,
+   num_int_wb_ports: Int,
+   num_fp_wb_ports: Int)
+(implicit p: Parameters) extends BoomModule()(p)
 {
-   val io = new RenameStageIO(pl_width, num_wb_ports)
+   val io = new RenameStageIO(pl_width, numIntPhysRegs, numFpPhysRegs, num_int_wb_ports, num_fp_wb_ports)
 
-   val ren_br_vals = Wire(Vec(pl_width, Bool()))
-   val freelist_can_allocate = Wire(Vec(pl_width, Bool()))
+   // integer registers
+   val imaptable = Module(new RenameMapTable(
+      pl_width,
+      RT_FIX.litValue,
+      32,
+      numIntPhysRegs))
+   val ifreelist = Module(new RenameFreeList(
+      pl_width,
+      RT_FIX.litValue,
+      numIntPhysRegs))
+   val ibusytable = Module(new BusyTable(
+      pl_width,
+      RT_FIX.litValue,
+      num_pregs = numIntPhysRegs,
+      num_read_ports = pl_width*2,
+      num_wb_ports = num_int_wb_ports))
 
-   val max_operands = if(usingFPU) 3 else 2
+   // floating point registers
+   val fmaptable = Module(new RenameMapTable(
+      pl_width,
+      RT_FLT.litValue,
+      32,
+      numFpPhysRegs))
+   val ffreelist = Module(new RenameFreeList(
+      pl_width,
+      RT_FLT.litValue,
+      numFpPhysRegs))
+   val fbusytable = Module(new BusyTable(
+      pl_width,
+      RT_FLT.litValue,
+      num_pregs = numFpPhysRegs,
+      num_read_ports = pl_width*3,
+      num_wb_ports = num_fp_wb_ports))
 
    //-------------------------------------------------------------
-   // Set outputs up... we'll write in the pop*/pdst info below
+
+   val ren_br_vals = Wire(Vec(pl_width, Bool()))
    for (w <- 0 until pl_width)
    {
       io.ren_mask(w)         := io.dec_mask(w) && io.inst_can_proceed(w) && !io.kill
       io.ren_uops(w)         := io.dec_uops(w)
       io.ren_uops(w).br_mask := GetNewBrMask(io.brinfo, io.dec_uops(w))
-      ren_br_vals(w)         := Mux(io.dec_mask(w), io.dec_uops(w).allocate_brtag, Bool(false))
+      ren_br_vals(w)         := io.dec_mask(w) && io.dec_uops(w).allocate_brtag
    }
-
 
    //-------------------------------------------------------------
    // Rename Table
 
-   val map_table_io = Vec.fill(LOGICAL_REG_COUNT) { Module(new RenameMapTableElement(DECODE_WIDTH)).io }
-
-   for (i <- 0 until LOGICAL_REG_COUNT)
-   {
-      map_table_io(i).rollback_wen := Bool(false)
-      map_table_io(i).rollback_stale_pdst := io.com_uops(0).stale_pdst
-
-      map_table_io(i).commit_wen := Bool(false)
-      map_table_io(i).commit_pdst := io.com_uops(0).pdst
-
-      for (w <- 0 until pl_width)
-      {
-         map_table_io(i).wens(w)        := io.ren_uops(w).ldst === UInt(i) &&
-                                           io.ren_mask(w) &&
-                                           io.ren_uops(w).ldst_val &&
-                                           (io.ren_uops(w).dst_rtype === RT_FIX ||
-                                             io.ren_uops(w).dst_rtype === RT_FLT) &&
-                                           !io.kill &&
-                                           io.inst_can_proceed(w) &&
-                                           freelist_can_allocate(w)
-         map_table_io(i).ren_pdsts(w)   := io.ren_uops(w).pdst
-
-         map_table_io(i).ren_br_vals(w) := ren_br_vals(w)
-         map_table_io(i).ren_br_tags(w) := io.ren_uops(w).br_tag
-      }
-
-      map_table_io(i).br_mispredict     := io.brinfo.mispredict
-      map_table_io(i).br_mispredict_tag := io.brinfo.tag
-
-      map_table_io(i).flush_pipeline    := io.flush_pipeline
-   }
-
-   // backwards, because rollback must give highest priority to 0 (the oldest instruction)
-   for (w <- pl_width-1 to 0 by -1)
-   {
-      val ldst = io.com_uops(w).ldst
-
-      when (io.com_rbk_valids(w))
-      {
-         map_table_io(ldst).rollback_wen        := Bool(true)
-         map_table_io(ldst).rollback_stale_pdst := io.com_uops(w).stale_pdst
-      }
-   }
-
-   if (ENABLE_COMMIT_MAP_TABLE)
-   {
-      for (w <- 0 until pl_width)
-      {
-         val ldst = io.com_uops(w).ldst
-         when (io.com_valids(w) && (io.com_uops(w).dst_rtype === RT_FIX || io.com_uops(w).dst_rtype === RT_FLT))
-         {
-            map_table_io(ldst).commit_wen := Bool(true)
-            map_table_io(ldst).commit_pdst := io.com_uops(w).pdst
-         }
-      }
-   }
-
-   // Read out the map-table entries ASAP, then deal with bypassing busy-bits later.
-   // Also speculatively read out both integer and fp specifiers to get decode off critical path.
-   private val map_table_output = Seq.fill(pl_width*5)(Wire(UInt(width=PREG_SZ)))
-   def map_table_prs1_int(w:Int) = map_table_output(w+0*pl_width)
-   def map_table_prs2_int(w:Int) = map_table_output(w+1*pl_width)
-   def map_table_prs1_flt(w:Int) = map_table_output(w+2*pl_width)
-   def map_table_prs2_flt(w:Int) = map_table_output(w+3*pl_width)
-
-   def map_table_prs1(w:Int) = Mux(io.ren_uops(w).lrs1_rtype === RT_FLT, map_table_prs1_flt(w), map_table_prs1_int(w))
-   def map_table_prs2(w:Int) = Mux(io.ren_uops(w).lrs2_rtype === RT_FLT, map_table_prs2_flt(w), map_table_prs2_int(w))
-   def map_table_prs3(w:Int) = map_table_output(w+4*pl_width)
-
+   imaptable.io.brinfo := io.brinfo
+   imaptable.io.kill := io.kill
+   imaptable.io.ren_mask := io.ren_mask
+   imaptable.io.ren_uops := io.ren_uops
+   imaptable.io.ren_br_vals := ren_br_vals
+   imaptable.io.com_valids := io.com_valids
+   imaptable.io.com_uops := io.com_uops
+   imaptable.io.com_rbk_valids := io.com_rbk_valids
+   imaptable.io.flush_pipeline := io.flush_pipeline
+   imaptable.io.inst_can_proceed := io.inst_can_proceed
+   imaptable.io.freelist_can_allocate := ifreelist.io.can_allocate
 
    for (w <- 0 until pl_width)
    {
-      map_table_prs1_int(w) := map_table_io(Cat(Bool(false), io.ren_uops(w).inst(RS1_MSB, RS1_LSB))).element
-      map_table_prs2_int(w) := map_table_io(Cat(Bool(false), io.ren_uops(w).inst(RS2_MSB, RS2_LSB))).element
-      map_table_prs1_flt(w) := map_table_io(Cat(Bool(true),  io.ren_uops(w).inst(RS1_MSB, RS1_LSB))).element
-      map_table_prs2_flt(w) := map_table_io(Cat(Bool(true),  io.ren_uops(w).inst(RS2_MSB, RS2_LSB))).element
-      if (max_operands > 2)
-         map_table_prs3(w) := map_table_io(io.ren_uops(w).lrs3).element
-      else
-         map_table_prs3(w) := UInt(0)
+      // TODO XXX choose between FP, INT
+      io.ren_uops(w).pop1 := imaptable.io.values(w).prs1
+      io.ren_uops(w).pop2 := imaptable.io.values(w).prs2
+      io.ren_uops(w).pop3 := imaptable.io.values(w).prs3
+      io.ren_uops(w).stale_pdst := imaptable.io.values(w).stale_pdst
    }
-
-   // Bypass the physical register mappings
-   val prs1_was_bypassed = Wire(Vec(pl_width, Bool()))
-   val prs2_was_bypassed = Wire(Vec(pl_width, Bool()))
-   val prs3_was_bypassed = Wire(Vec(pl_width, Bool()))
-
-   for (w <- 0 until pl_width)
-   {
-      var rs1_cases =  Array((Bool(false),  UInt(0,PREG_SZ)))
-      var rs2_cases =  Array((Bool(false),  UInt(0,PREG_SZ)))
-      var rs3_cases =  Array((Bool(false),  UInt(0,PREG_SZ)))
-      var stale_cases= Array((Bool(false),  UInt(0,PREG_SZ)))
-
-      prs1_was_bypassed(w) := Bool(false)
-      prs2_was_bypassed(w) := Bool(false)
-      prs3_was_bypassed(w) := Bool(false)
-
-      // Handle bypassing new physical destinations to operands (and stale destination)
-      // scalastyle:off
-      for (xx <- w-1 to 0 by -1)
-      {
-         rs1_cases  ++= Array(((io.ren_uops(w).lrs1_rtype === RT_FIX || io.ren_uops(w).lrs1_rtype === RT_FLT)
-                                                                 && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).lrs1 === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
-         rs2_cases  ++= Array(((io.ren_uops(w).lrs2_rtype === RT_FIX || io.ren_uops(w).lrs2_rtype === RT_FLT)
-                                                                 && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).lrs2 === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
-         rs3_cases  ++= Array((io.ren_uops(w).frs3_en            && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).lrs3 === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
-         stale_cases++= Array(( io.ren_uops(w).ldst_val          && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).ldst === io.ren_uops(xx).ldst), (io.ren_uops(xx).pdst)))
-
-         when ((io.ren_uops(w).lrs1_rtype === RT_FIX || io.ren_uops(w).lrs1_rtype === RT_FLT) && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).lrs1 === io.ren_uops(xx).ldst))
-            { prs1_was_bypassed(w) := Bool(true) }
-         when ((io.ren_uops(w).lrs2_rtype === RT_FIX || io.ren_uops(w).lrs2_rtype === RT_FLT) && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).lrs2 === io.ren_uops(xx).ldst))
-            { prs2_was_bypassed(w) := Bool(true) }
-         when (io.ren_uops(w).frs3_en                                                         && io.ren_mask(xx) && io.ren_uops(xx).ldst_val && (io.ren_uops(w).lrs3 === io.ren_uops(xx).ldst))
-            { prs3_was_bypassed(w) := Bool(true) }
-      }
-
-      // add default case where we can just read the map table for our information
-      rs1_cases ++= Array(((io.ren_uops(w).lrs1_rtype === RT_FIX || io.ren_uops(w).lrs1_rtype === RT_FLT) &&
-                           (io.ren_uops(w).lrs1 =/= UInt(0)), map_table_prs1(w)))
-      rs2_cases ++= Array(((io.ren_uops(w).lrs2_rtype === RT_FIX || io.ren_uops(w).lrs2_rtype === RT_FLT) &&
-                           (io.ren_uops(w).lrs2 =/= UInt(0)), map_table_prs2(w)))
-      rs3_cases ++= Array((io.ren_uops(w).frs3_en  &&
-                           (io.ren_uops(w).lrs3 =/= UInt(0)), map_table_prs3(w)))
-
-      io.ren_uops(w).pop1                       := MuxCase(io.ren_uops(w).lrs1, rs1_cases)
-      io.ren_uops(w).pop2                       := MuxCase(io.ren_uops(w).lrs2, rs2_cases)
-      if (max_operands > 2){io.ren_uops(w).pop3 := MuxCase(io.ren_uops(w).lrs3, rs3_cases)}
-      io.ren_uops(w).stale_pdst                 := MuxCase(map_table_io(io.ren_uops(w).ldst).element, stale_cases)
-
-   }
-
-
-   //-------------------------------------------------------------
-   // Busy Table
-
-   val freelist_req_pregs = Wire(Vec(pl_width, UInt(width=PREG_SZ)))
-
-   // 3 WB ports for now
-   // 1st is back-to-back bypassable ALU ops
-   // 2nd is memory/muldiv
-   // TODO 3rd is ALU ops that aren't bypassable... can maybe remove this? or set TTL countdown on 1st port?
-   // TODO optimize - too many write ports, but how to deal with that? (slow + fast...)
-   val bsy_table = Module(new BusyTable(
-      pipeline_width=pl_width,
-      num_regs = numIntPhysRegs,
-      num_read_ports = pl_width*max_operands,
-      num_wb_ports=num_wb_ports))
-
-      for (w <- 0 until pl_width)
-      {
-         // Reading the Busy Bits
-         // for critical path reasons, we speculatively read out the busy-bits assuming no dependencies between uops
-         // then verify if the uop actually uses a register and if it depends on a newly unfreed register
-         bsy_table.io.prs(0,w) := map_table_prs1(w)
-         bsy_table.io.prs(1,w) := map_table_prs2(w)
-
-         io.ren_uops(w).prs1_busy := (io.ren_uops(w).lrs1_rtype === RT_FIX || io.ren_uops(w).lrs1_rtype === RT_FLT) && (bsy_table.io.prs_busy(0,w) || prs1_was_bypassed(w))
-         io.ren_uops(w).prs2_busy := (io.ren_uops(w).lrs2_rtype === RT_FIX || io.ren_uops(w).lrs2_rtype === RT_FLT) && (bsy_table.io.prs_busy(1,w) || prs2_was_bypassed(w))
-
-         if (max_operands > 2)
-         {
-            bsy_table.io.prs(2,w) := map_table_prs3(w)
-            io.ren_uops(w).prs3_busy := (io.ren_uops(w).frs3_en) && (bsy_table.io.prs_busy(2,w) || prs3_was_bypassed(w))
-         }
-         else
-         {
-            io.ren_uops(w).prs3_busy := Bool(false)
-         }
-
-
-          // Updating the Table (new busy register)
-         bsy_table.io.allocated_pdst(w).valid := freelist_can_allocate(w) &&
-                                                  io.ren_mask(w) &&
-                                                  io.ren_uops(w).ldst_val &&
-                                                  (io.ren_uops(w).dst_rtype === RT_FIX || io.ren_uops(w).dst_rtype === RT_FLT)
-         bsy_table.io.allocated_pdst(w).bits  := freelist_req_pregs(w)
-      }
-
-      // Clear Busy-bit
-      for (i <- 0 until num_wb_ports)
-      {
-         bsy_table.io.unbusy_pdst(i).valid := io.wb_valids(i)
-         bsy_table.io.unbusy_pdst(i).bits  := io.wb_pdsts(i)
-      }
-
-   // scalastyle:on
 
    //-------------------------------------------------------------
    // Free List
 
-   val freelist = Module(new RenameFreeList(numIntPhysRegs, pl_width))
+   ifreelist.io.brinfo := io.brinfo
+   ifreelist.io.kill := io.kill
+   ifreelist.io.ren_mask := io.ren_mask
+   ifreelist.io.ren_uops := io.ren_uops
+   ifreelist.io.ren_br_vals := ren_br_vals
+   ifreelist.io.inst_can_proceed := io.inst_can_proceed
+   ifreelist.io.com_valids := io.com_valids
+   ifreelist.io.com_uops := io.com_uops
+   ifreelist.io.com_rbk_valids := io.com_rbk_valids
+   ifreelist.io.flush_pipeline := io.flush_pipeline
+   ifreelist.io.debug_rob_empty := io.debug_rob_empty
 
-      for (w <- 0 until pl_width)
-      {
-         freelist.io.req_preg_vals(w) := (io.inst_can_proceed(w) &&
-                                         !io.kill &&
-                                         io.ren_mask(w) &&
-                                         io.ren_uops(w).ldst_val &&
-                                         (io.ren_uops(w).dst_rtype === RT_FIX || io.ren_uops(w).dst_rtype === RT_FLT))
-      }
-      freelist_req_pregs := freelist.io.req_pregs
-
-      for (w <- 0 until pl_width)
-      {
-         freelist.io.enq_vals(w)    := io.com_valids(w) &&
-                                       (io.com_uops(w).dst_rtype === RT_FIX || io.com_uops(w).dst_rtype === RT_FLT) &&
-                                       (io.com_uops(w).stale_pdst =/= UInt(0))
-         freelist.io.enq_pregs(w)   := io.com_uops(w).stale_pdst
-
-         freelist.io.ren_br_vals(w) := ren_br_vals(w)
-         freelist.io.ren_br_tags(w) := io.ren_uops(w).br_tag
-
-         freelist_can_allocate(w)   := freelist.io.can_allocate(w)
-
-         freelist.io.rollback_wens(w)  := io.com_rbk_valids(w) &&
-                                        (io.com_uops(w).pdst =/= UInt(0)) &&
-                                        (io.com_uops(w).dst_rtype === RT_FIX || io.com_uops(w).dst_rtype === RT_FLT)
-         freelist.io.rollback_pdsts(w) := io.com_uops(w).pdst
-
-         freelist.io.com_wens(w)    := io.com_valids(w) &&
-                                       (io.com_uops(w).pdst =/= UInt(0)) &&
-                                       (io.com_uops(w).dst_rtype === RT_FIX || io.com_uops(w).dst_rtype === RT_FLT)
-         freelist.io.com_uops(w)    := io.com_uops(w)
-      }
-
-      freelist.io.br_mispredict_val := io.brinfo.mispredict
-      freelist.io.br_mispredict_tag := io.brinfo.tag
-
-      freelist.io.flush_pipeline := io.flush_pipeline
-
-
-   // x0 is a special-case and should not be renamed
    for (w <- 0 until pl_width)
    {
-      io.ren_uops(w).pdst := Mux(io.ren_uops(w).ldst === UInt(0), UInt(0), freelist_req_pregs(w))
+      io.ren_uops(w).pdst := ifreelist.io.req_pregs(w) // TODO BUG XXX choose between FP, Int
    }
 
+   //-------------------------------------------------------------
+   // Busy Table
+
+   ibusytable.io.ren_mask := io.ren_mask
+   ibusytable.io.ren_uops := io.ren_uops  // expects pdst to be set up.
+   ibusytable.io.freelist_can_allocate := ifreelist.io.can_allocate
+   ibusytable.io.map_table := imaptable.io.values
+   ibusytable.io.wb_valids := io.int_wb_valids
+   ibusytable.io.wb_pdsts := io.int_wb_pdsts
+
+
+   for (w <- 0 until pl_width)
+   {
+      // TODO XXX choose between FP, INT
+      io.ren_uops(w).prs1_busy := ibusytable.io.values(w).prs1_busy
+      io.ren_uops(w).prs2_busy := ibusytable.io.values(w).prs2_busy
+      io.ren_uops(w).prs3_busy := ibusytable.io.values(w).prs3_busy
+   }
 
    //-------------------------------------------------------------
    // Branch Predictor Snapshots
@@ -733,8 +199,7 @@ class RenameStage(pl_width: Int, num_wb_ports: Int)(implicit p: Parameters) exte
 
    for (w <- 0 until pl_width)
    {
-      when(ren_br_vals(w))
-      {
+      when(ren_br_vals(w)) {
          prediction_copies(io.ren_uops(w).br_tag) := io.ren_pred_info
       }
    }
@@ -749,21 +214,17 @@ class RenameStage(pl_width: Int, num_wb_ports: Int)(implicit p: Parameters) exte
    for (w <- 0 until pl_width)
    {
       // TODO REFACTOR, make == rt_x?
-      io.inst_can_proceed(w) := (freelist.io.can_allocate(w) ||
-                                 (io.ren_uops(w).dst_rtype =/= RT_FIX && io.ren_uops(w).dst_rtype =/= RT_FLT)) &&
-                                io.dis_inst_can_proceed(w)
+      // TODO BUG XXX canallocate int vs fp
+      io.inst_can_proceed(w) :=
+         (ifreelist.io.can_allocate(w) || (io.ren_uops(w).dst_rtype =/= RT_FIX && io.ren_uops(w).dst_rtype =/= RT_FLT)) &&
+         io.dis_inst_can_proceed(w)
    }
-
 
    //-------------------------------------------------------------
    // Debug signals
 
-   io.debug.freelist  := freelist.io.debug.freelist
-   io.debug.isprlist  := freelist.io.debug.isprlist
-   io.debug.bsy_table := bsy_table.io.debug.bsy_table
-}
-
-
-
+   io.debug.ifreelist  := ifreelist.io.debug.freelist
+   io.debug.iisprlist  := ifreelist.io.debug.isprlist
+   io.debug.ibusytable := ibusytable.io.debug.busytable
 }
 

--- a/src/main/scala/rob.scala
+++ b/src/main/scala/rob.scala
@@ -552,10 +552,10 @@ class Rob(width: Int,
 
          assert (!(io.wb_resps(i).valid && MatchBank(GetBankIdx(rob_idx)) &&
                      !rob_val(GetRowIdx(rob_idx))),
-                  "[ROB] writeback occurred to an invalid ROB entry.")
+                  "[ROB] writeback (" + i + ") occurred to an invalid ROB entry.")
          assert (!(io.wb_resps(i).valid && MatchBank(GetBankIdx(rob_idx)) &&
                   temp_uop.ldst_val && temp_uop.pdst =/= io.wb_resps(i).bits.uop.pdst),
-                  "[ROB] writeback occurred to the wrong pdst.")
+                  "[ROB] writeback (" + i + ") occurred to the wrong pdst.")
       }
       io.commit.uops(w).debug_wdata := rob_uop(rob_head).debug_wdata
 

--- a/src/main/scala/rob.scala
+++ b/src/main/scala/rob.scala
@@ -33,7 +33,6 @@ import config.Parameters
 import util.Str
 
 class RobIo(machine_width: Int
-            , issue_width: Int
             , num_wakeup_ports: Int
             , num_fpu_ports: Int
             )(implicit p: Parameters)  extends BoomBundle()(p)
@@ -177,12 +176,11 @@ class DebugRobSignals(implicit p: Parameters) extends BoomBundle()(p)
 // num_fpu_ports = number of FPU units that will write back fflags
 class Rob(width: Int
          , num_rob_entries: Int
-         , issue_width: Int
          , num_wakeup_ports: Int
          , num_fpu_ports: Int
          )(implicit p: Parameters) extends BoomModule()(p)
 {
-   val io = new RobIo(width, issue_width, num_wakeup_ports, num_fpu_ports)
+   val io = new RobIo(width, num_wakeup_ports, num_fpu_ports)
 
    val num_rob_rows = num_rob_entries / width
    require (num_rob_rows % 2 == 0) // this is due to how rob PCs are stored in two banks

--- a/src/main/scala/util.scala
+++ b/src/main/scala/util.scala
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 package boom
-{
 
 import Chisel._
 
@@ -257,4 +256,87 @@ object AgePriorityEncoder
    }
 }
 
+
+class QueueForMicroOpWithData(entries: Int, data_width: Int)(implicit p: config.Parameters) extends BoomModule()(p)
+{
+   val io = new Bundle
+   {
+      val enq     = Decoupled(new ExeUnitResp(data_width)).flip
+      val deq     = Decoupled(new ExeUnitResp(data_width))
+
+      val brinfo  = new BrResolutionInfo().asInput
+      val flush   = Bool(INPUT)
+
+      val empty   = Bool(OUTPUT)
+      val count   = UInt(OUTPUT, log2Up(entries))
+   }
+
+   private val ram     = Mem(entries, new ExeUnitResp(data_width))
+   private val valids  = Reg(init = Vec.fill(entries) {Bool(false)})
+   private val brmasks = Reg(Vec(entries, UInt(width = MAX_BR_COUNT)))
+
+   private val enq_ptr = Counter(entries)
+   private val deq_ptr = Counter(entries)
+   private val maybe_full = Reg(init=false.B)
+
+   private val ptr_match = enq_ptr.value === deq_ptr.value
+   io.empty := ptr_match && !maybe_full
+   private val full = ptr_match && maybe_full
+   private val do_enq = Wire(init=io.enq.fire())
+
+   private val deq_ram_valid = Wire(init= !(io.empty))
+   private val do_deq = Wire(init=io.deq.ready && deq_ram_valid)
+
+   for (i <- 0 until entries)
+   {
+      val mask = brmasks(i)
+      valids(i)  := valids(i) && !IsKilledByBranch(io.brinfo, mask) && !io.flush
+      when (valids(i)) {
+         brmasks(i) := GetNewBrMask(io.brinfo, mask)
+      }
+   }
+
+
+   when (do_enq) {
+      ram(enq_ptr.value) := io.enq.bits
+      valids(enq_ptr.value) := true.B
+      brmasks(enq_ptr.value) := GetNewBrMask(io.brinfo, io.enq.bits.uop)
+      enq_ptr.inc()
+   }
+   when (do_deq) {
+      deq_ptr.inc()
+   }
+   when (do_enq != do_deq) {
+      maybe_full := do_enq
+   }
+
+   io.enq.ready := !full
+
+   private val out = ram(deq_ptr.value)
+   io.deq.valid := deq_ram_valid && valids(deq_ptr.value) && !IsKilledByBranch(io.brinfo, out.uop) //!empty
+   io.deq.bits := out
+   io.deq.bits.uop.br_mask := GetNewBrMask(io.brinfo, brmasks(deq_ptr.value))
+
+
+   // For flow queue behavior.
+   when (io.enq.valid) { io.deq.valid := true.B }
+   when (io.empty) {
+      io.deq.bits := io.enq.bits
+      io.deq.bits.uop.br_mask := GetNewBrMask(io.brinfo, io.enq.bits.uop)
+
+      do_deq := false.B
+      when (io.deq.ready) { do_enq := false.B }
+   }
+
+   private val ptr_diff = enq_ptr.value - deq_ptr.value
+   if (isPow2(entries)) {
+      io.count := Cat(maybe_full && ptr_match, ptr_diff)
+   } else {
+      io.count := Mux(ptr_match,
+                     Mux(maybe_full,
+                        entries.asUInt, 0.U),
+                     Mux(deq_ptr.value > enq_ptr.value,
+                        entries.asUInt + ptr_diff, ptr_diff))
+   }
 }
+

--- a/src/main/scala/util.scala
+++ b/src/main/scala/util.scala
@@ -31,6 +31,19 @@ object IsKilledByBranch
    }
 }
 
+object GetNewUopAndBrMask
+{
+   def apply(uop: MicroOp, brinfo: BrResolutionInfo)(implicit p: config.Parameters): MicroOp =
+   {
+      val newuop = Wire(init = uop)
+      newuop.br_mask := 
+         Mux(brinfo.valid,
+            (uop.br_mask & ~brinfo.mask),
+            uop.br_mask)
+      newuop
+   }
+}
+
 object GetNewBrMask
 {
    def apply(brinfo: BrResolutionInfo, uop: MicroOp): UInt =

--- a/src/main/scala/util.scala
+++ b/src/main/scala/util.scala
@@ -14,6 +14,14 @@ import Chisel._
 import rocket.Instructions._
 import rocket._
 
+object assertNever
+{
+   def apply(cond: Bool, message: String): Unit =
+   {
+      assert(!cond, message)
+   }
+}
+
 object IsKilledByBranch
 {
    def apply(brinfo: BrResolutionInfo, uop: MicroOp): Bool =


### PR DESCRIPTION
  * refactor rename stage; pipeline it so it takes two cycles now.
  * split floating point and integer into separate register files (to reduce port counts and RF size).
  * split issue windows into FP, IntALU and Memory. Provides larger total issue window slots while reducing issue port counts (so hopefully a win for both IPC and timing paths).