### PR TITLE
3-cycle Fetch; new BTB; new BPD timings.

### DIFF
--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -121,12 +121,13 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
 
    btb.io.req := io.ext_btb_req
    btb.io.icmiss := io.icmiss
-   bpd.io.req_pc := io.ext_btb_req.bits.addr
+//   bpd.io.req_pc := io.ext_btb_req.bits.addr
 
 
    //************************************************
    // Branch Prediction (BP1 Stage)
 
+   bpd.io.req_pc := btb.io.resp.bits.fetch_pc
    io.f0_btb <> btb.io.resp
 
 

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -113,11 +113,13 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    val f2_btb = Reg(Valid(new BTBsaResp))
    val f2_pc  = Reg(UInt())
 
-   when (!io.fetch_stalled)
+   // request in BTB can advance
+   when (io.ext_btb_req.valid)
    {
       f2_btb := btb.io.resp
       f2_pc := f1_pc
    }
+
    io.f2_bpu_info := f2_btb
 
 

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -66,18 +66,20 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    val io = new BoomBundle()(p)
    {
       // Fetch0
-      val ext_btb_req = Valid(new PCReq).flip
+      val ext_btb_req   = Valid(new PCReq).flip
       val fetch_stalled = Bool(INPUT)
-      val f0_btb     = Valid(new BTBsaResp)
-      val f2_bpu_info = Valid(new BTBsaResp)
+      val f0_btb        = Valid(new BTBsaResp)
+      val f2_bpu_info   = Valid(new BTBsaResp)
+      val f2_btb_update = Valid(new BTBsaUpdate).flip
+      val f2_ras_update = Valid(new RasUpdate).flip
 
       // Other
-      val br_unit    = new BranchUnitResp().asInput
+      val br_unit       = new BranchUnitResp().asInput
 //      val brob       = new BrobBackendIo(fetch_width)
-      val flush      = Bool(INPUT) // pipeline flush
-      val redirect   = Bool(INPUT)
+      val flush         = Bool(INPUT) // pipeline flush
+      val redirect      = Bool(INPUT)
 //      val status_prv = UInt(INPUT, width = rocket.PRV.SZ)
-      val status_debug = Bool(INPUT)
+      val status_debug  = Bool(INPUT)
    }
 
    //************************************************
@@ -118,23 +120,37 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    }
    io.f2_bpu_info := f2_btb
 
-   // update RAS based on BTB's prediction information.
+
+   //************************************************
+   // Update the RAS
+
+   // update RAS based on BTB's prediction information (or the branch-check correction).
    val f2_aligned_pc = ~(~f2_pc | (UInt(fetch_width*coreInstBytes-1)))
    val jmp_idx = f2_btb.bits.cfi_idx
-   btb.io.ras_update.valid := f2_btb.valid && !io.fetch_stalled
-   btb.io.ras_update.bits.is_call := f2_btb.bits.bpd_type === BpredType.call
-   btb.io.ras_update.bits.is_ret  := f2_btb.bits.bpd_type === BpredType.ret
-   btb.io.ras_update.bits.return_addr := f2_aligned_pc + (jmp_idx << 2.U) + 4.U
+
+   btb.io.ras_update := io.f2_ras_update
+   btb.io.ras_update.valid := (f2_btb.valid || io.f2_ras_update.valid) && !io.fetch_stalled
+   when (f2_btb.valid)
+   {
+      btb.io.ras_update.bits.is_call      := f2_btb.bits.bpd_type === BpredType.call
+      btb.io.ras_update.bits.is_ret       := f2_btb.bits.bpd_type === BpredType.ret
+      btb.io.ras_update.bits.return_addr  := f2_aligned_pc + (jmp_idx << 2.U) + 4.U
+   }
 
 
    //************************************************
    // Update the BTB/BIM
 
-   btb.io.btb_update := io.br_unit.btb_update
+   // TODO XXX: allow branch-checker to kill bad entries.
+   // TODO XXX update the BTB during the F3/branch-checker stage if BPD says we should take it.
+   btb.io.btb_update :=
+      Mux(io.br_unit.btb_update.valid,
+         io.br_unit.btb_update,
+         io.f2_btb_update)
+
+   // TODO XXX allow F2/BPD redirects to correct the BIM.
    btb.io.bim_update := io.br_unit.bim_update
 
-   // TODO do we also update the BTB during the F3/branch-checker stage if BPD says we should take it?
-   // TODO when do we update the bim?
 
 
    //************************************************

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -62,19 +62,16 @@ class BpuRequest(implicit p: Parameters) extends BoomBundle()(p)
 // TODO rename to make clear this is "BPD->RenameSnapshot->BRU". Should NOT go into Issue Windows.
 class BranchPredInfo(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val bpd_predicted     = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
-   val bpd_taken         = Bool() // did the bpd predict taken for this instruction?
+   val btb_blame         = Bool() // Does the BTB get credit for the prediction? (during BRU check).
    val btb_hit           = Bool() // this instruction was the br/jmp predicted by the BTB
    val btb_taken         = Bool() // this instruction was the br/jmp predicted by the BTB and was taken
-   val btb_predicted     = Bool() // Does the BTB get credit for the prediction? (FU checks)
-//
-//   val is_br_or_jalr    = Bool() // is this instruction a branch or jalr?
-                                   // (need to allocate brob entry).
+
+   val bpd_blame         = Bool() // Does the BPD get credit for this prediction? (during BRU check).
+   val bpd_hit           = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
+   val bpd_taken         = Bool() // did the bpd predict taken for this instruction?
+
    val bim_resp         = new BimResp
-
    val bpd_resp         = new BpdResp // TODO XXX this can be very expensive -- don't give to every instruction? And break into separate toBRU/Exe and toCom versions.
-
-   def wasBTB = btb_predicted
 }
 
 class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -181,8 +181,8 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    btb.io.ras_update.valid := (f2_btb.valid || io.f2_ras_update.valid) && !io.fetch_stalled
    when (f2_btb.valid)
    {
-      btb.io.ras_update.bits.is_call      := f2_btb.bits.bpd_type === BpredType.call
-      btb.io.ras_update.bits.is_ret       := f2_btb.bits.bpd_type === BpredType.ret
+      btb.io.ras_update.bits.is_call      := BpredType.isCall(f2_btb.bits.bpd_type)
+      btb.io.ras_update.bits.is_ret       := BpredType.isReturn(f2_btb.bits.bpd_type)
       btb.io.ras_update.bits.return_addr  := f2_aligned_pc + (jmp_idx << 2.U) + 4.U
    }
 

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -161,7 +161,7 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    val bpd_disagrees_with_btb =
       f2_btb.valid && bpd_valid && (bpd_predict_taken ^ f2_btb.bits.taken) && f2_btb.bits.cfi_type === CfiType.branch
 
-   io.f2_bpu_request.valid := bpd_disagrees_with_btb
+   io.f2_bpu_request.valid := bpd_disagrees_with_btb && enableBpdF2Redirect.B
    io.f2_bpu_request.bits.target :=
       Mux(bpd_predict_taken,
          f2_btb.bits.target.sextTo(vaddrBitsExtended),

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -10,15 +10,12 @@
 // Christopher Celio
 // 2014 Apr 23
 //
-// Access branch predictor and redirect the pipeline as necessary. Also in
-// charge of JALs (direction and target are known).
+// Access BTB and BPD to feed predictions to the Fetch Unit.
 //
-// These stages are effectively in parallel with instruction fetch and decode.
-// BHT look-up (bp1) is in parallel with I$ access, and Branch Decode (bp2)
-// occurs before fetch buffer insertion.
-//
-// Currently, I ignore JALRs (either the BTB took care of it or it'll get
-// mispredicted and kill everything behind it anyways).
+// These stages are in parallel with instruction fetch.
+//    * F0 - Select next PC.
+//    * F1 - Access I$ and BTB RAMs. Perform BPD hashing.
+//    * F2 - Access BPD RAMs. Begin decoding instruction bits and computing targets from I$.
 
 package boom
 
@@ -26,19 +23,6 @@ import Chisel._
 import config.Parameters
 
 import util.Str
-
-//class RedirectRequest(fetch_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
-//{
-//   val target  = UInt(width = vaddrBits+1)
-//   val br_pc   = UInt(width = vaddrBits+1) // PC of the instruction changing control flow (to update the BTB with jumps)
-//   val idx     = UInt(width = log2Up(fetch_width)) // idx of br in fetch bundle (to mask out the appropriate fetch
-//                                                   // instructions)
-//   val is_jump = Bool() // (only valid if redirect request is valid)
-//   val is_cfi  = Bool() // Is redirect due to a control-flow instruction?
-//   val is_taken= Bool() // (true if redirect is to "take" a branch,
-//                        //  false if it's to request PC+4 for a mispred
-//  override def cloneType = new RedirectRequest(fetch_width)(p).asInstanceOf[this.type]
-//}
 
 // this information is shared across the entire fetch packet, and stored in the
 // branch snapshots. Since it's not unique to an instruction, it could be
@@ -59,6 +43,7 @@ import util.Str
 //class BranchPrediction(implicit p: Parameters) extends BoomBundle()(p)
 // Give this to each instruction/uop and pass this down the pipeline to the branch-unit
 // This covers the per-instruction info on all cfi-related predictions.
+// TODO rename to make clear this is "BPD->RenameSnapshot->BRU". Should NOT go into Issue Windows.
 class BranchPredInfo(implicit p: Parameters) extends BoomBundle()(p)
 {
 //   val bpd_predict_val  = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
@@ -68,8 +53,10 @@ class BranchPredInfo(implicit p: Parameters) extends BoomBundle()(p)
 //   val btb_predicted    = Bool() // Does the BTB get credit for the prediction? (FU checks)
 //
 //   val is_br_or_jalr    = Bool() // is this instruction a branch or jalr?
-//                                 // (need to allocate brob entry).
-//
+                                   // (need to allocate brob entry).
+
+   val bim_resp         = new BimResp
+
 //   def wasBTB = btb_predicted
 }
 
@@ -134,36 +121,13 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    io.f2_bpu_info := f2_btb
 
    //************************************************
-   // Update the BTB
+   // Update the BTB/BIM
 
    btb.io.btb_update := io.br_unit.btb_update
+   btb.io.bim_update := io.br_unit.bim_update
 
-   if (enableBTB)
-   {
-      btb.io.btb_update.valid :=
-         (io.br_unit.btb_update.valid || false.B) && !io.flush
-//       (io.bp2_take_pc && io.bp2_is_taken && !if_stalled && !br_unit.take_pc)) &&
-   }
-   else
-   {
-      btb.io.btb_update.valid := false.B
-   }
-
-   // update the BTB
-   // If a branch is mispredicted and taken, update the BTB.
-   // (if branch unit mispredicts, instructions in decode are no longer valid)
-   //io.imem.btb_update.bits.pc         := Mux(br_unit.btb_update_valid, br_unit.btb_update.pc, io.imem.resp.bits.pc)
-   //io.imem.btb_update.bits.br_pc      := Mux(br_unit.btb_update_valid, br_unit.btb_update.br_pc, io.bp2_pc_of_br_inst)
-   //io.imem.btb_update.bits.target     := Mux(br_unit.btb_update_valid, br_unit.btb_update.target,
-   //                                                                    (io.bp2_pred_target.toSInt &
-   //                                                                     SInt(-coreInstBytes)).toUInt)
-   //io.imem.btb_update.bits.prediction := Mux(br_unit.btb_update_valid, br_unit.btb_update.prediction,
-   //                                                                    io.imem.resp.bits.btb)
-   //io.imem.btb_update.bits.taken      := Mux(br_unit.btb_update_valid, br_unit.btb_update.taken,
-   //                                                                    io.bp2_take_pc && io.bp2_is_taken && !if_stalled)
-   //io.imem.btb_update.bits.isJump     := Mux(br_unit.btb_update_valid, br_unit.btb_update.isJump, io.bp2_is_jump)
-   //io.imem.btb_update.bits.isReturn   := Mux(br_unit.btb_update_valid, br_unit.btb_update.isReturn, Bool(false))
-   //io.imem.btb_update.bits.isValid    := Mux(br_unit.btb_update_valid, Bool(true), io.bp2_is_cfi)
+   // TODO do we also update the BTB during the F3/branch-checker stage if BPD says we should take it?
+   // TODO when do we update the bim?
 
 
    //************************************************
@@ -193,11 +157,6 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
          , Mux(btb.io.resp.valid, Str("V"), Str("-"))
          , btb.io.resp.bits.target
          )
-//      printf("bp2_aligned_pc: 0x%x BHT:(%c 0x%x, %d) p:%x (%d) b:%x j:%x (%d) %c %c\n"
-//         , aligned_pc, Mux(imemreq_valid, Str("T"), Str("-")), imemreq.target, imemreq.idx
-//         , bpd_predictions.toBits, bpd_br_idx, is_br.toBits, is_jal.toBits, bpd_jal_idx
-//         , Mux(bpd_br_beats_jal, Str("B"), Str("J")), Mux(bpd_nextline_fire, Str("N"), Str("-"))
-//         )
    }
 
    //************************************************

--- a/src/main/scala/bpd_pipeline.scala
+++ b/src/main/scala/bpd_pipeline.scala
@@ -27,47 +27,50 @@ import config.Parameters
 
 import util.Str
 
-class RedirectRequest(fetch_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
-{
-   val target  = UInt(width = vaddrBits+1)
-   val br_pc   = UInt(width = vaddrBits+1) // PC of the instruction changing control flow (to update the BTB with jumps)
-   val idx     = UInt(width = log2Up(fetch_width)) // idx of br in fetch bundle (to mask out the appropriate fetch
-                                                   // instructions)
-   val is_jump = Bool() // (only valid if redirect request is valid)
-   val is_cfi  = Bool() // Is redirect due to a control-flow instruction?
-   val is_taken= Bool() // (true if redirect is to "take" a branch,
-                        //  false if it's to request PC+4 for a mispred
-  override def cloneType = new RedirectRequest(fetch_width)(p).asInstanceOf[this.type]
-}
+//class RedirectRequest(fetch_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+//{
+//   val target  = UInt(width = vaddrBits+1)
+//   val br_pc   = UInt(width = vaddrBits+1) // PC of the instruction changing control flow (to update the BTB with jumps)
+//   val idx     = UInt(width = log2Up(fetch_width)) // idx of br in fetch bundle (to mask out the appropriate fetch
+//                                                   // instructions)
+//   val is_jump = Bool() // (only valid if redirect request is valid)
+//   val is_cfi  = Bool() // Is redirect due to a control-flow instruction?
+//   val is_taken= Bool() // (true if redirect is to "take" a branch,
+//                        //  false if it's to request PC+4 for a mispred
+//  override def cloneType = new RedirectRequest(fetch_width)(p).asInstanceOf[this.type]
+//}
 
 // this information is shared across the entire fetch packet, and stored in the
 // branch snapshots. Since it's not unique to an instruction, it could be
 // compressed further. It can be de-allocated once the branch is resolved in
 // Execute.
-class BranchPredictionResp(implicit p: Parameters) extends BoomBundle()(p)
+//class BranchPredictionResp(implicit p: Parameters) extends BoomBundle()(p)
+//{
+//   val btb_resp_valid = Bool()
+//   val btb_resp       = new rocket.BTBResp
+//
+//   val bpd_resp       = new BpdResp
+//
+//   // used to tell front-end how to mask off instructions
+//   val mask           = Bits(width = fetchWidth)
+//   val br_seen        = Bool() // was a branch seen in this fetch packet?
+//}
+
+//class BranchPrediction(implicit p: Parameters) extends BoomBundle()(p)
+// Give this to each instruction/uop and pass this down the pipeline to the branch-unit
+// This covers the per-instruction info on all cfi-related predictions.
+class BranchPredInfo(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val btb_resp_valid = Bool()
-   val btb_resp       = new rocket.BTBResp
-
-   val bpd_resp       = new BpdResp
-
-   // used to tell front-end how to mask off instructions
-   val mask           = Bits(width = fetchWidth)
-   val br_seen        = Bool() // was a branch seen in this fetch packet?
-}
-
-// give this to each instruction/uop and pass this down the pipeline to the branch-unit
-class BranchPrediction(implicit p: Parameters) extends BoomBundle()(p)
-{
-   val bpd_predict_val  = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
-   val bpd_predict_taken= Bool() // did the bpd predict taken for this instruction?
+//   val bpd_predict_val  = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
+//   val bpd_predict_taken= Bool() // did the bpd predict taken for this instruction?
    val btb_hit          = Bool() // this instruction was the br/jmp predicted by the BTB
-   val btb_predicted    = Bool() // Does the BTB get credit for the prediction? (FU checks)
-
-   val is_br_or_jalr    = Bool() // is this instruction a branch or jalr?
-                                 // (need to allocate brob entry).
-
-   def wasBTB = btb_predicted
+   val btb_taken        = Bool() // this instruction was the br/jmp predicted by the BTB and was taken
+//   val btb_predicted    = Bool() // Does the BTB get credit for the prediction? (FU checks)
+//
+//   val is_br_or_jalr    = Bool() // is this instruction a branch or jalr?
+//                                 // (need to allocate brob entry).
+//
+//   def wasBTB = btb_predicted
 }
 
 class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)
@@ -76,437 +79,133 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    val io = new BoomBundle()(p)
    {
       // Fetch0
+      // TODO restructure as req/valid bundle?
       val npc        = UInt(INPUT, width = vaddrBitsExtended)
-
-      // Fetch2
-      val imem_resp  = Decoupled(new rocket.FrontendResp).flip
-      val btb_resp   = Valid(new rocket.BTBResp).flip
-
-      // Fetch3
-      val req        = Decoupled(new RedirectRequest(fetch_width))
-      val ras_update = Valid(new rocket.RASUpdate)
-      val pred_resp  = new BranchPredictionResp().asOutput
-      val predictions= Vec(fetch_width, new BranchPrediction().asOutput)
+//      val imem              = new rocket.FrontendIO
+      val ext_btb_req = Valid(new PCReq).flip
+      val fetch_stalled = Bool(INPUT)
+      val f0_btb     = Valid(new BTBsaResp)
+      val f2_bpu_info = Valid(new BTBsaResp)
+//      val f2_bpu_info = Valid(new BranchPredInfo)
 
       // Other
       val br_unit    = new BranchUnitResp().asInput
-      val brob       = new BrobBackendIo(fetch_width)
-      val flush      = Bool(INPUT)
-      val status_prv = UInt(INPUT, width = rocket.PRV.SZ)
+//      val brob       = new BrobBackendIo(fetch_width)
+      val flush      = Bool(INPUT) // pipeline flush
+      val redirect   = Bool(INPUT)
+//      val status_prv = UInt(INPUT, width = rocket.PRV.SZ)
+      val status_debug = Bool(INPUT)
    }
 
-   //-------------------------------------------------------------
+   //************************************************
+   // construct all of the modules
+
+   val btb = Module(new BTBsa())
+   btb.io.status_debug := io.status_debug
+
+
+   //************************************************
+   // Branch Prediction (BP0 Stage)
+
+//   btb.io.req.valid := Bool(true) && !io.fetch_stalled // XXX && !stall
+//   btb.io.req.valid := io.ext_btb_req.valid //(this is (!icmiss and !stall)
+//   btb.io.req.bits.addr := io.npc
+   btb.io.req := io.ext_btb_req
+
+//   when (io.ext_btb_req.valid) // this breaks when un-stalling and getting redirected on same cycle
+//   {
+//      assert (RegNext(io.npc) === io.ext_btb_req.bits.addr, "[btb stuff]")
+//   }
+
+   //************************************************
    // Branch Prediction (BP1 Stage)
 
-   val bp2_br_seen = Wire(Bool())  // did we see a branch to make a prediction?
-                                   // (and not overridden by an earlier jal or jr)
-   val bp2_jr_seen = Wire(Bool())  // did we see a JALR (not overriden by earlier jal but a taken br could)?
-   val bp2_br_taken = Wire(Bool()) // was there a taken branch in the bp2 stage
-                                   // we use this to update the bpd's history register speculatively
+   io.f0_btb <> btb.io.resp
 
-   var br_predictor: BrPredictor = null
-   if (ENABLE_BRANCH_PREDICTOR && tageParams.isDefined && tageParams.get.enabled)
+   //************************************************
+   // Branch Prediction (BP2 Stage)
+
+   val f2_btb = Reg(Valid(new BTBsaResp))
+
+   when (!io.fetch_stalled)
    {
-      br_predictor = Module(new TageBrPredictor(fetch_width = fetch_width,
-                                                num_tables = tageParams.get.num_tables,
-                                                table_sizes = tageParams.get.table_sizes,
-                                                history_lengths = tageParams.get.history_lengths,
-                                                tag_sizes = tageParams.get.tag_sizes,
-                                                ubit_sz = tageParams.get.ubit_sz
-                                                ))
+      f2_btb := btb.io.resp
    }
-   else if (ENABLE_BRANCH_PREDICTOR && gskewParams.isDefined && gskewParams.get.enabled)
+   io.f2_bpu_info := f2_btb
+
+   //************************************************
+   // Update the BTB
+
+   btb.io.btb_update := io.br_unit.btb_update
+
+   if (enableBTB)
    {
-      br_predictor = Module(new GSkewBrPredictor(fetch_width = fetch_width,
-                                                  history_length = gskewParams.get.history_length,
-                                                  dualported = gskewParams.get.dualported,
-                                                  enable_meta = gskewParams.get.enable_meta))
-   }
-   else if (ENABLE_BRANCH_PREDICTOR && gshareParams.isDefined && gshareParams.get.enabled)
-   {
-      br_predictor = Module(new GShareBrPredictor(fetch_width = fetch_width,
-                                                  history_length = gshareParams.get.history_length,
-                                                  dualported = gshareParams.get.dualported))
-   }
-   else if (ENABLE_BRANCH_PREDICTOR && p(SimpleGShareKey).enabled)
-   {
-      br_predictor = Module(new SimpleGShareBrPredictor(fetch_width = fetch_width,
-                                                  history_length = p(SimpleGShareKey).history_length))
-   }
-   else if (ENABLE_BRANCH_PREDICTOR && p(RandomBpdKey).enabled)
-   {
-      br_predictor = Module(new RandomBrPredictor(fetch_width = fetch_width))
+      btb.io.btb_update.valid :=
+         (io.br_unit.btb_update.valid || false.B) && !io.flush
+//       (io.bp2_take_pc && io.bp2_is_taken && !if_stalled && !br_unit.take_pc)) &&
    }
    else
    {
-      br_predictor = Module(new NullBrPredictor(fetch_width = fetch_width,
-                                                history_length = GLOBAL_HISTORY_LENGTH))
+      btb.io.btb_update.valid := false.B
    }
 
-   br_predictor.io.req_pc := io.npc
-   br_predictor.io.br_resolution <> io.br_unit.bpd_update
-   br_predictor.io.hist_update_spec.valid := (bp2_br_seen || bp2_jr_seen) && io.req.ready
-   br_predictor.io.hist_update_spec.bits.taken := bp2_br_taken || bp2_jr_seen
-   br_predictor.io.resp.ready := io.req.ready
+   // update the BTB
+   // If a branch is mispredicted and taken, update the BTB.
+   // (if branch unit mispredicts, instructions in decode are no longer valid)
+   //io.imem.btb_update.bits.pc         := Mux(br_unit.btb_update_valid, br_unit.btb_update.pc, io.imem.resp.bits.pc)
+   //io.imem.btb_update.bits.br_pc      := Mux(br_unit.btb_update_valid, br_unit.btb_update.br_pc, io.bp2_pc_of_br_inst)
+   //io.imem.btb_update.bits.target     := Mux(br_unit.btb_update_valid, br_unit.btb_update.target,
+   //                                                                    (io.bp2_pred_target.toSInt &
+   //                                                                     SInt(-coreInstBytes)).toUInt)
+   //io.imem.btb_update.bits.prediction := Mux(br_unit.btb_update_valid, br_unit.btb_update.prediction,
+   //                                                                    io.imem.resp.bits.btb)
+   //io.imem.btb_update.bits.taken      := Mux(br_unit.btb_update_valid, br_unit.btb_update.taken,
+   //                                                                    io.bp2_take_pc && io.bp2_is_taken && !if_stalled)
+   //io.imem.btb_update.bits.isJump     := Mux(br_unit.btb_update_valid, br_unit.btb_update.isJump, io.bp2_is_jump)
+   //io.imem.btb_update.bits.isReturn   := Mux(br_unit.btb_update_valid, br_unit.btb_update.isReturn, Bool(false))
+   //io.imem.btb_update.bits.isValid    := Mux(br_unit.btb_update_valid, Bool(true), io.bp2_is_cfi)
 
-   io.brob <> br_predictor.io.brob
-   br_predictor.io.flush := io.flush
-   br_predictor.io.status_prv := io.status_prv
 
-//   val bpd_valid = br_predictor.io.resp.valid && (io.status_prv === UInt(rocket.PRV.U) || !Bool(ENABLE_BPD_UMODE_ONLY))
-   val bpd_valid = br_predictor.io.resp.valid
-   val bpd_bits = br_predictor.io.resp.bits
+   //************************************************
+   // Handle redirects/flushes
 
-
-   //-------------------------------------------------------------
-   // Branch Decode (BP2 Stage/Fetch2 Stage)
-   //
-   // 1) Which branch to take?
-   // 2) Is there a jal earlier to take?
-   // 3) Does the BTB override our prediction?
-   //    - 3b) if no, verify BTB is correct?
-   // 4) Update RAS
-
-   // round off to nearest fetch boundary
-   val aligned_pc = ~(~io.imem_resp.bits.pc | (UInt(fetch_width*coreInstBytes-1)))
-
-   val is_br     = Wire(Vec(fetch_width, Bool()))
-   val is_jal    = Wire(Vec(fetch_width, Bool()))
-   val is_jr     = Wire(Vec(fetch_width, Bool()))
-   val br_targs  = Wire(Vec(fetch_width, UInt(width=vaddrBits+1)))
-   val jal_targs = Wire(Vec(fetch_width, UInt(width=vaddrBits+1)))
-
-   for (i <- 0 until fetch_width)
+   when (io.flush || reset.toBool)
    {
-      val inst = io.imem_resp.bits.data(i*coreInstBits+coreInstBits-1,i*coreInstBits)
-      val bpd_decoder = Module(new BranchDecode)
-      bpd_decoder.io.inst := inst
-
-      is_br(i)  := bpd_decoder.io.is_br   && io.imem_resp.bits.mask(i)
-      is_jal(i) := bpd_decoder.io.is_jal  && io.imem_resp.bits.mask(i)
-      is_jr(i)  := bpd_decoder.io.is_jalr && io.imem_resp.bits.mask(i)
-
-      val pc = aligned_pc + UInt(i << 2)
-      br_targs(i)  := ComputeBranchTarget(pc, inst, xLen, coreInstBytes)
-      jal_targs(i) := ComputeJALTarget(pc, inst, xLen, coreInstBytes)
+      f2_btb.valid := false.B
+      btb.io.btb_update.valid := false.B
    }
 
-
-   //-------------------------------------------------------------
-   // Output (make an actual prediction/redirect request)
-
-   // There are many predictions vying for priority.
-   // The following are equal priority - whosever has
-   // the instruction earliest in program-order wins:
-   //    - JALs
-   //    - BTB (JALs/JRs)
-   //    - BPD (branches)
-   //
-   // At a lower priority is the BTB predicting branches:
-   //    - BTB (branches)
-   //
-   // If the BPD defers (bpd_valid == false), then the BTB's
-   // branch prediction stand.
-
-   val bpd_predictions  = is_br.toBits & bpd_bits.takens
-   val bpd_br_taken     = bpd_predictions.orR && bpd_valid
-   val bpd_br_idx       = PriorityEncoder(bpd_predictions)
-   val bpd_jal_val      = is_jal.reduce(_|_)
-   val bpd_jr_val       = is_jr.reduce(_|_)
-   val bpd_jal_idx      = PriorityEncoder(is_jal.toBits)
-   val bpd_br_beats_jal = bpd_br_taken && (!bpd_jal_val || (bpd_br_idx < bpd_jal_idx))
-   val bpd_req_idx      = Mux(bpd_br_beats_jal, bpd_br_idx, bpd_jal_idx)
-   val bpd_req_target   = Mux(bpd_br_beats_jal, br_targs(bpd_br_idx), jal_targs(bpd_jal_idx))
-
-
-
-   // For the particular instruction the BTB predicted, does the BPD agree with the direction?
-   // (this is only valid if the BTB is predicting a branch.)
-   val bpd_agrees_with_btb = !(IsIdxAMatch(io.btb_resp.bits.bridx, bpd_predictions) ^
-                             io.btb_resp.bits.taken)
-
-   // bpd will make a redirection request (either for a br or jal)
-   // for "taking" a branch or JAL.
-   val bpd_br_fire = Wire(init = Bool(false))
-   val bpd_jal_fire = Wire(init = Bool(false))
-   // If the BTB predicted taken, and the BPD disagrees and believes no branch
-   // is taken, we must instead redirect the FrontEnd to fetch the "next packet"
-   // in program order (PC+4-ish, if you will).
-   val bpd_nextline_fire = Wire(init = Bool(false))
-   val nextline_pc = aligned_pc + UInt(fetch_width*coreInstBytes)
-   // BTB provides a suggested "valid instruction" mask, based on its prediction.
-   // Should we override its mask?
-   val override_btb = Wire(init = Bool(false))
-
-   // Is the predicted instruction a control-flow instruction?
-   // Used to invalidate BTB entries due to it predicting on
-   // a non-branch/non-jump instruction.
-   val is_cfi = Wire(init = Bool(true))
-
-   // does the index match on a true bit in the mask?
-   def IsIdxAMatch(idx: UInt, mask: UInt) : Bool =
+   when (io.redirect)
    {
-      mask(idx)
-   }
-   val btb_predicted_br          = IsIdxAMatch(io.btb_resp.bits.bridx, is_br.toBits)
-   val btb_predicted_br_taken    = btb_predicted_br && io.btb_resp.bits.taken
-   val btb_predicted_br_nottaken = btb_predicted_br && !io.btb_resp.bits.taken
-   val btb_predicted_jump        = IsIdxAMatch(io.btb_resp.bits.bridx, is_jal.toBits | is_jr.toBits)
-   val btb_predicted_jal         = IsIdxAMatch(io.btb_resp.bits.bridx, is_jal.toBits)
-
-   val btb_predicted_wrong_jal_target = btb_predicted_jal && io.btb_resp.bits.target =/= jal_targs(bpd_jal_idx)
-
-   when (io.btb_resp.valid)
-   {
-      // BTB made a prediction -
-      // make a redirect request if:
-      //    - if the BPD (br) or JAL comes earlier than the BTB's redirection
-      //    - if both the BTB and the BPD predicted a branch, the BPD wins
-      //       * involves refetching the latter half of the packet if we "undo"
-      //          the BTB's taken branch.
-
-      when (btb_predicted_jump) // both JAL and JRs
-      {
-         val btb_nt = !io.btb_resp.bits.taken
-         bpd_br_fire  := bpd_br_beats_jal && bpd_br_taken && (bpd_br_idx < io.btb_resp.bits.bridx)
-         bpd_jal_fire := !bpd_br_beats_jal && bpd_jal_val &&
-                           ((bpd_jal_idx < io.btb_resp.bits.bridx) || btb_nt || btb_predicted_wrong_jal_target)
-
-         when (io.imem_resp.valid)
-         {
-            when (!io.btb_resp.bits.taken)
-            {
-               val btb_predicted_jr = IsIdxAMatch(io.btb_resp.bits.bridx, is_jr.toBits)
-               // if JR but predicted not TAKEN, do nothing and let BrUnit fix mispredicton.
-               assert (bpd_br_fire ||
-                  (bpd_jal_fire && (bpd_jal_idx <= io.btb_resp.bits.bridx)) ||
-                  btb_predicted_jr,
-                  "[bpd_pipeline] BTB predicted a jump but didn't take it, and we are failing to correct it.")
-            }
-         }
-      }
-      .elsewhen (btb_predicted_br_taken)
-      {
-         // overrule the BTB if
-         //    1. either a jump or branch occurs earlier
-         //          (bpd_jal_fire, bpd_br_fire)
-         //    2. OR the BPD predicts the BTB's branch as not taken...
-         //       a. and no other branch taken (bpd_nextline_fire)
-         //       b. a later branch as taken (bpd_br_fire)
-         //       c. a later jump is present (bpd_jal_fire)
-
-         // does the bpd predict the branch is taken too? (assuming bpd_valid)
-         val bpd_agrees_with_btb = bpd_predictions(io.btb_resp.bits.bridx)
-
-         bpd_jal_fire := !bpd_br_beats_jal && bpd_jal_val &&
-                           ((bpd_jal_idx < io.btb_resp.bits.bridx) ||
-                           (bpd_valid && !bpd_agrees_with_btb))
-         bpd_br_fire  := bpd_br_beats_jal && bpd_br_taken &&
-                           (bpd_br_idx < io.btb_resp.bits.bridx ||  // earlier than BTB's branch
-                           (bpd_valid && !bpd_agrees_with_btb))     // taken later
-
-         bpd_nextline_fire := bpd_valid && !bpd_predictions.orR && !bpd_jal_val
-         override_btb := bpd_valid && !bpd_agrees_with_btb
-
-         when (bpd_nextline_fire)
-         {
-            assert (override_btb, "[bpd_pipeline] redirecting the PC without overriding the BTB.")
-         }
-         when (override_btb)
-         {
-            assert (bpd_nextline_fire || bpd_jal_fire || bpd_br_fire,
-               "[bpd_pipeline] overriding the BTB without redirecting the PC.")
-         }
-      }
-      .elsewhen (btb_predicted_br_nottaken)
-      {
-         // completely overrule the BTB if it predicted not-taken, but the BPD is predicted taken
-         bpd_br_fire  := bpd_br_beats_jal && bpd_br_taken
-         bpd_jal_fire := !bpd_br_beats_jal && bpd_jal_val
-      }
-      .otherwise
-      {
-         when (io.imem_resp.valid)
-         {
-            // Thanks to uncacheable regions (also, the BTB is never invalidated),
-            // The BTB may actually predict things that aren't branches!
-            // But we must undo these "mispredictions"!
-            //printf ("[bpd_pipeline] BTB resp is valid, but didn't detect what it predicted.")
-            override_btb := Bool(true)
-            is_cfi := Bool(false)
-
-            // but is there a branch or jump we need to handle? Or just fetch the nextline?
-            bpd_br_fire  := bpd_br_beats_jal && bpd_br_taken
-            bpd_jal_fire := !bpd_br_beats_jal && bpd_jal_val
-            bpd_nextline_fire := !bpd_br_fire && !bpd_jal_fire
-         }
-      }
-   }
-   .otherwise
-   {
-      // BTB made no prediction - let the BPD do what it wants
-      bpd_br_fire  := bpd_br_beats_jal
-      bpd_jal_fire := bpd_jal_val && !bpd_br_fire
-   }
-
-   assert (PopCount(Vec(bpd_br_fire, bpd_jal_fire, bpd_nextline_fire)) <= UInt(1),
-      "[bpd_pipeline] mutually-exclusive signals firing")
-
-   //-------------------------------------------------------------
-   // Fetch3 Stage
-   // Redirect the front-end based decoded instructions.
-
-   val imemreq = Wire(new RedirectRequest(fetch_width))
-   val imemreq_valid =
-         io.imem_resp.valid &&
-         (bpd_br_fire || bpd_jal_fire || bpd_nextline_fire) &&
-         !io.imem_resp.bits.xcpt_if
-
-
-   imemreq.target  := Mux(bpd_nextline_fire, nextline_pc, bpd_req_target)
-   imemreq.idx     := Mux(bpd_nextline_fire, UInt(fetch_width-1), bpd_req_idx)
-   imemreq.br_pc   := aligned_pc + (imemreq.idx << UInt(2))
-   imemreq.is_jump := !bpd_br_beats_jal
-   imemreq.is_cfi  := is_cfi
-   imemreq.is_taken:= bpd_br_fire || bpd_jal_fire
-
-   val pred_resp = Wire(new BranchPredictionResp)
-   pred_resp.btb_resp_valid   := io.btb_resp.valid
-   pred_resp.btb_resp         := io.btb_resp.bits
-   pred_resp.bpd_resp         := bpd_bits
-   pred_resp.br_seen          := bp2_br_seen
-
-   private def KillMask(m_enable: Bool, m_idx: UInt, m_width: Int): UInt =
-   {
-      val mask = Wire(Bits(width = m_width))
-      mask := Fill(m_width, m_enable) & (Fill(m_width, UInt(1)) << UInt(1) << m_idx)
-      mask
-   }
-   // mask out instructions after predicted branch
-   val bpd_kill_mask = KillMask(imemreq_valid,
-                               imemreq.idx,
-                               fetchWidth)
-   // mask out instructions after first jr (doesn't matter if predicted correctly or not!)
-   val jr_kill_mask = KillMask(is_jr.reduce(_|_),
-                               PriorityEncoder(is_jr.toBits),
-                               fetchWidth)
-   // if we accept the BTB's prediction, mask out instructions after its prediction
-   val btb_kill_mask = KillMask(io.btb_resp.valid && io.btb_resp.bits.taken &&
-                              !(bpd_br_fire || bpd_jal_fire || bpd_nextline_fire),
-                               PriorityEncoder(io.btb_resp.bits.bridx),
-                               fetchWidth)
-
-   val btb_mask = Mux(override_btb || !io.btb_resp.valid,
-                     Fill(fetchWidth, UInt(1,1)),
-                     io.btb_resp.bits.mask)
-   pred_resp.mask := ~bpd_kill_mask & ~jr_kill_mask & btb_mask
-
-
-   val predictions = Wire(Vec(fetch_width, new BranchPrediction()))
-   for (w <- 0 until FETCH_WIDTH)
-   {
-      predictions(w).is_br_or_jalr := is_br(w) || is_jr(w)
-      predictions(w).bpd_predict_taken := bpd_predictions(w) && bpd_valid && !bpd_nextline_fire
-      predictions(w).btb_predicted := io.btb_resp.valid &&
-                                       !(bpd_nextline_fire || bpd_br_fire || bpd_jal_fire)
-      predictions(w).btb_hit := Mux(io.btb_resp.bits.bridx === UInt(w),
-                                       io.btb_resp.valid, Bool(false))
-      predictions(w).bpd_predict_val   := bpd_valid
-   }
-
-   bp2_br_seen := io.imem_resp.valid &&
-                  !io.imem_resp.bits.xcpt_if &&
-                  is_br.reduce(_|_) &&
-                  (!bpd_jal_val || (PriorityEncoder(is_br.toBits) < PriorityEncoder(is_jal.toBits))) &&
-                  (!bpd_jr_val || (PriorityEncoder(is_br.toBits) < PriorityEncoder(is_jr.toBits)))
-   bp2_jr_seen := io.imem_resp.valid &&
-                  !io.imem_resp.bits.xcpt_if &&
-                  is_jr.reduce(_|_) &&
-                  (!bpd_jal_val || (PriorityEncoder(is_jr.toBits) < PriorityEncoder(is_jal.toBits)))
-   bp2_br_taken := bpd_br_fire || (io.btb_resp.valid && btb_predicted_br_taken && !bpd_nextline_fire && !override_btb)
-
-   //-------------------------------------------------------------
-   // Look for CALL and RETURN for RAS shenanigans.
-   // TODO flush_take_pc should probably be given to the branch unit, instead of resetting it here?
-   // NOTE: what about branch taken earlier?
-
-   val ras_update = Wire(Valid(new rocket.RASUpdate))
-
-   val jumps    = is_jal.toBits | is_jr.toBits
-   val jmp_idx  = PriorityEncoder(jumps)
-   val jmp_inst = (io.imem_resp.bits.data >> (jmp_idx*UInt(coreInstBits)))(coreInstBits-1,0)
-   val is_call  = IsCall(jmp_inst)
-   val is_ret   = IsReturn(jmp_inst)
-   ras_update.valid           := io.imem_resp.valid &&
-                                      !io.imem_resp.bits.xcpt_if &&
-                                      jumps.orR &&
-                                      !bpd_br_beats_jal &&
-                                      !io.flush
-                                      io.req.ready
-   ras_update.bits.isCall     := is_call
-   ras_update.bits.isReturn   := is_ret
-   ras_update.bits.returnAddr := aligned_pc + (jmp_idx << UInt(2)) + UInt(4)
-   ras_update.bits.prediction := io.btb_resp
-
-   //-------------------------------------------------------------
-   // Fetch3 Stage (Optional Pipelining)
-
-   if (fetchLatency == 2)
-   {
-      io.req.valid   := imemreq_valid
-      io.req.bits    := imemreq
-      io.ras_update  := ras_update
-      io.predictions := predictions
-      io.pred_resp   := pred_resp
-   }
-   else
-   {
-      io.req.valid   := RegNext(imemreq_valid)// && !io.flush && !(io.br_unit.brinfo.mispredict))
-      io.req.bits    := RegNext(imemreq)
-      io.ras_update  := RegNext(ras_update)
-      io.predictions := RegNext(predictions)
-      io.pred_resp   := RegNext(pred_resp)
-
-      io.ras_update.valid := RegNext(ras_update.valid) && !io.flush && io.req.ready
-
-      require (fetchLatency == 3)
+      f2_btb.valid := false.B
    }
 
 
-   //-------------------------------------------------------------
+   //************************************************
    // printfs
 
    if (DEBUG_PRINTF)
    {
-      printf("bp2_aligned_pc: 0x%x BHT:(%c 0x%x, %d) p:%x (%d) b:%x j:%x (%d) %c %c\n"
-         , aligned_pc, Mux(imemreq_valid, Str("T"), Str("-")), imemreq.target, imemreq.idx
-         , bpd_predictions.toBits, bpd_br_idx, is_br.toBits, is_jal.toBits, bpd_jal_idx
-         , Mux(bpd_br_beats_jal, Str("B"), Str("J")), Mux(bpd_nextline_fire, Str("N"), Str("-"))
+      printf("btb, f0_npc=%c 0x%x, req_pc 0x%x, f1=%c targ=0x%x\n"
+         , Mux(btb.io.req.valid, Str("V"), Str("-"))
+         , io.npc
+         , io.ext_btb_req.bits.addr
+         , Mux(btb.io.resp.valid, Str("V"), Str("-"))
+         , btb.io.resp.bits.target
          )
+//      printf("bp2_aligned_pc: 0x%x BHT:(%c 0x%x, %d) p:%x (%d) b:%x j:%x (%d) %c %c\n"
+//         , aligned_pc, Mux(imemreq_valid, Str("T"), Str("-")), imemreq.target, imemreq.idx
+//         , bpd_predictions.toBits, bpd_br_idx, is_br.toBits, is_jal.toBits, bpd_jal_idx
+//         , Mux(bpd_br_beats_jal, Str("B"), Str("J")), Mux(bpd_nextline_fire, Str("N"), Str("-"))
+//         )
    }
 
-   //-------------------------------------------------------------
+   //************************************************
    // asserts
-
-   when (io.imem_resp.valid && io.btb_resp.valid && io.btb_resp.bits.taken && !io.imem_resp.bits.xcpt_if)
-   {
-      val idx = io.btb_resp.bits.bridx
-      val targ = Mux(is_br(idx), br_targs(idx), jal_targs(idx))
-      when (!is_jr(idx) && !(bpd_nextline_fire))
-      {
-//         assert (io.btb_resp.bits.target === targ(vaddrBits-1,0),
-//            "[bpd_pipeline] BTB is jumping to an invalid target.")
-         when (io.btb_resp.bits.target =/= targ(vaddrBits-1,0))
-         {
-            // TODO remove this... BTBs can now just predict total garbage
-            //printf("[bpd_pipeline] BTB is jumping to an invalid target.\n")
-         }
-      }
-   }
 
    if (!enableBTB)
    {
-      assert (!(io.btb_resp.valid), "[bpd_pipeline] BTB predicted, but it's been disabled.")
+      assert (!(io.f0_btb.valid), "[bpd_pipeline] BTB predicted, but it's been disabled.")
    }
 
 }

--- a/src/main/scala/brpredictor.scala
+++ b/src/main/scala/brpredictor.scala
@@ -181,10 +181,16 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
       // For an un-tagged predictor, valid==true should probably only be if a branch is predicted taken.
       // This has an effect on whether to override the BTB's prediction.
       val resp = Decoupled(new BpdResp)
+      // bpd resp comes in F2, but speculative history update isn't until F3, so to avoid missing older branches in our
+      // snapshots, we need to wait and pull the history from F3 for snapshotting.
+      val f3_resp_history = if (!ENABLE_VLHR) Some(UInt(width = GLOBAL_HISTORY_LENGTH)) else None
+      val f3_resp_history_ptr = UInt(width = log2Up(VLHR_LENGTH))
+
+
       // speculatively update the global history (once we know we're predicting a branch)
       val hist_update_spec = Valid(new GHistUpdate).flip
       // branch resolution comes from the branch-unit, during the Execute stage.
-      val br_resolution = Valid(new BpdUpdate).flip // TODO XXX rename to exe_bpd_update?
+      val exe_bpd_update = Valid(new BpdUpdate).flip // Update/correct the BPD during Branch Resolution (Exe).
       val brob = new BrobBackendIo(fetch_width)
       // Pipeline flush - reset history as appropriate.
       // Arrives same cycle as redirecting the front-end -- otherwise, the ghistory would be wrong if it came later!
@@ -221,8 +227,8 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
       r_ghistory.value(
          io.hist_update_spec.valid,
          io.hist_update_spec.bits,
-         io.br_resolution.valid,
-         io.br_resolution.bits,
+         io.exe_bpd_update.valid,
+         io.exe_bpd_update.bits,
          r_flush,
          umode_only = false)
 
@@ -230,15 +236,15 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
       r_ghistory_u.value(
          io.hist_update_spec.valid,
          io.hist_update_spec.bits,
-         io.br_resolution.valid,
-         io.br_resolution.bits,
+         io.exe_bpd_update.valid,
+         io.exe_bpd_update.bits,
          r_flush,
          umode_only = true)
 
    val vlh_head =
       r_vlh.getSnapshot(
-         io.br_resolution.valid,
-         io.br_resolution.bits,
+         io.exe_bpd_update.valid,
+         io.exe_bpd_update.bits,
          r_flush)
 
    val r_vlh_commit_copy = r_vlh.commit_copy
@@ -267,12 +273,14 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
       ghistory := ghistory_all
    }
 
+   val r_ghistory_raw = r_ghistory.raw_value
+
 
    r_ghistory.update(
       io.hist_update_spec.valid,
       io.hist_update_spec.bits,
-      io.br_resolution.valid,
-      io.br_resolution.bits,
+      io.exe_bpd_update.valid,
+      io.exe_bpd_update.bits,
       r_flush,
       disable = Bool(false),
       umode_only = false)
@@ -280,8 +288,8 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
    r_ghistory_u.update(
       io.hist_update_spec.valid,
       io.hist_update_spec.bits,
-      io.br_resolution.valid,
-      io.br_resolution.bits,
+      io.exe_bpd_update.valid,
+      io.exe_bpd_update.bits,
       r_flush,
       disable = !in_usermode,
       umode_only = true)
@@ -289,24 +297,38 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
    r_vlh.update(
       io.hist_update_spec.valid,
       io.hist_update_spec.bits,
-      io.br_resolution.valid,
-      io.br_resolution.bits,
+      io.exe_bpd_update.valid,
+      io.exe_bpd_update.bits,
       r_flush,
       disable = Bool(false))
 
 
-   io.resp.bits.history match
+//   io.resp.bits.history match
+//   {
+//      case Some(resp_history: UInt) => resp_history := ghistory
+//      case _ => require (ENABLE_VLHR)
+//   }
+//   io.resp.bits.history_u match
+//   {
+//      case Some(resp_history_u: UInt) => resp_history_u := ghistory_uonly
+//      case _ => require (ENABLE_VLHR)
+//   }
+//
+//   io.resp.bits.history_ptr := vlh_head
+
+
+   io.f3_resp_history match
    {
       case Some(resp_history: UInt) => resp_history := ghistory
       case _ => require (ENABLE_VLHR)
    }
-   io.resp.bits.history_u match
-   {
-      case Some(resp_history_u: UInt) => resp_history_u := ghistory_uonly
-      case _ => require (ENABLE_VLHR)
-   }
+//   io.f3_resp_history_u match
+//   {
+//      case Some(resp_history_u: UInt) => resp_history_u := ghistory_uonly
+//      case _ => require (ENABLE_VLHR)
+//   }
 
-   io.resp.bits.history_ptr := vlh_head
+   io.f3_resp_history_ptr := vlh_head
 
 
    // -----------------------------------------------
@@ -366,6 +388,8 @@ class HistoryRegister(length: Int)
          case _ => UInt(0) // enable vlhr
       }
    }
+
+   def raw_value(): UInt = r_history
 
    def value(
       hist_update_spec_valid: Bool,

--- a/src/main/scala/btb-sa.scala
+++ b/src/main/scala/btb-sa.scala
@@ -30,7 +30,8 @@ case class BTBsaParameters(
   tagSz: Int = 20,
   nRAS : Int = 8,
   // Extra knobs.
-  bypassCalls: Boolean = false
+  bypassCalls: Boolean = false,
+  rasCheckForEmpty: Boolean = false
 )
 
 trait HasBTBsaParameters extends HasBoomCoreParameters
@@ -42,6 +43,7 @@ trait HasBTBsaParameters extends HasBoomCoreParameters
    val idx_sz = log2Ceil(nSets)
    val nRAS = btbParams.nRAS
    val bypassCalls = btbParams.bypassCalls
+   val rasCheckForEmpty = btbParams.rasCheckForEmpty
 }
 
 // Which predictor should we listen to?
@@ -150,16 +152,16 @@ class BIM(bim_entries: Int, way_idx: Int)(implicit val p: Parameters) extends Ha
 }
 
 
-class RAS(nras: Int)
+class RAS(nras: Int, coreInstBytes: Int)
 {
    def push(addr: UInt): Unit =
    {
       when (count < nras.U) { count := count + 1.U }
       val nextPos = Mux(Bool(isPow2(nras)) || pos < UInt(nras-1), pos+1.U, 0.U)
-      stack(nextPos) := addr
+      stack(nextPos) := addr >> log2Up(coreInstBytes)
       pos := nextPos
    }
-   def peek: UInt = stack(pos)
+   def peek: UInt = Cat(stack(pos), UInt(0, log2Up(coreInstBytes)))
    def pop(): Unit = when (!isEmpty)
    {
       count := count - 1.U
@@ -359,9 +361,10 @@ class BTBsa(implicit p: Parameters) extends BoomModule()(p) with HasBTBsaParamet
 
    if (nRAS > 0)
    {
-      val ras = new RAS(nRAS)
+      val ras = new RAS(nRAS, coreInstBytes)
       val doPeek = (hits_oh zip data_out map {case(hit, d) => hit && BpredType.isReturn(d.bpd_type)}).reduce(_||_)
-      when (!ras.isEmpty && doPeek)
+      val isEmpty = if (rasCheckForEmpty) ras.isEmpty else false.B
+      when (!isEmpty && doPeek)
       {
          io.resp.bits.target := ras.peek
       }

--- a/src/main/scala/btb-sa.scala
+++ b/src/main/scala/btb-sa.scala
@@ -1,0 +1,170 @@
+//******************************************************************************
+// Copyright (c) 2017, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Set-associative Branch Target Buffer (BTB-sa)
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+package boom
+
+import Chisel._
+import config.Parameters
+
+case class BTBsaParameters(
+  nSets: Int = 16,
+  nWays: Int = 2
+)
+
+trait HasBTBsaParameters extends HasBoomCoreParameters
+{
+   val btbParams = boomParams.btb
+   val nSets = btbParams.nSets
+   val nWays = btbParams.nWays
+   val setidx_sz = log2Ceil(nSets)
+   val tag_sz = 16
+   val idx_sz = log2Up(nSets)
+}
+
+//trait HasBTBParameters extends HasCoreParameters {
+//  val btbParams = tileParams.btb.getOrElse(BTBParams(nEntries = 0))
+//  val matchBits = pgIdxBits max log2Ceil(p(coreplex.CacheBlockBytes) * tileParams.icache.get.nSets)
+//  val entries = btbParams.nEntries
+//  val nRAS = btbParams.nRAS
+//}
+
+abstract class BTBsaBundle(implicit val p: Parameters) extends util.ParameterizedBundle()(p)
+  with HasBTBsaParameters
+
+// BTB update occurs during branch resolution (and only on a mispredict that's taken).
+//  - "pc" is what future fetch PCs will tag match against.
+//  - "cfi_pc" is the PC of the branch instruction.
+class BTBsaUpdate(implicit p: Parameters) extends BTBsaBundle()(p) {
+//  val prediction = Valid(new BTBResp)
+   val pc = UInt(width = vaddrBits)
+   val target = UInt(width = vaddrBits)
+   val taken = Bool()
+//  val isValid = Bool()
+//  val isReturn = Bool()
+//   val is_jump = Bool() // jal or jr; don't listen to bimodal
+//   val is_ret  = Bool() // is return; 
+   val cfi_pc = UInt(width = vaddrBits)
+	val cfi_type = CFIType()
+}
+
+//  - "bridx" is the low-order PC bits of the predicted branch (after
+//     shifting off the lowest log(inst_bytes) bits off).
+//  - "mask" provides a mask of valid instructions (instructions are
+//     masked off by the predicted taken branch from the BTB).
+class BTBsaResp(implicit p: Parameters) extends BTBsaBundle()(p) 
+{
+   val taken       = Bool()   // is BTB predicting a taken cfi?
+   val target      = UInt(width = vaddrBits) // what target are we predicting?
+   val mask        = Bits(width = fetchWidth) // mask of valid instructions.
+   val cfi_idx     = Bits(width = log2Up(fetchWidth)) // where is cfi we are predicting?
+   val cfi_type    = CFIType()
+//   val entry_idx   = UInt(width = setidx_sz) // what entry in the set is the prediction coming from?
+}
+
+class BTBsaReq(implicit p: Parameters) extends BTBsaBundle()(p) 
+{
+   val addr = UInt(width = vaddrBits)
+}
+
+// set-associative branch target buffer
+class BTBsa(implicit p: Parameters) extends BoomModule()(p) with HasBTBsaParameters
+{
+   val io = new Bundle 
+   {
+      val req = Valid(new BTBsaReq).flip
+      val resp = Valid(new BTBsaResp)
+      val btb_update = Valid(new BTBsaUpdate).flip
+   }
+
+//   val isValid = Reg(init = UInt(0, entries))
+//   val isReturn = Reg(UInt(width = entries))
+//   val isJump = Reg(UInt(width = entries))
+//   val brIdx = Reg(Vec(entries, UInt(width=log2Up(fetchWidth))))
+
+//   private def tagMatch(addr: UInt, pgMatch: UInt) = {
+//      val idxMatch = idxs.map(_ === addr(matchBits-1, log2Up(coreInstBytes))).asUInt
+//      val idxPageMatch = idxPagesOH.map(_ & pgMatch).map(_.orR).asUInt
+//      idxMatch & idxPageMatch & isValid
+//   }
+
+   private def getTag (addr: UInt): UInt = (addr >> UInt(idx_sz + log2Up(fetchWidth*coreInstBytes)))(tag_sz-1,0)
+   private def getIdx (addr: UInt): UInt = (addr >> UInt(log2Up(fetchWidth*coreInstBytes)))(idx_sz-1,0)
+ 
+   class BTBSetMetaData extends Bundle
+   {
+      val target = UInt(width = vaddrBits - log2Up(coreInstBytes))
+      val cfi_idx = UInt(width = log2Up(fetchWidth))
+      val cfi_type = CFIType()
+   }
+ 
+   val hits         = Wire(Vec(nWays, Bool()))
+   val metadata_out = Wire(Vec(nWays, new BTBSetMetaData()))
+
+   val ren = RegNext(io.req.valid)
+   val s0_idx = getIdx(io.req.bits.addr)
+   val s1_req_tag = RegEnable(getTag(io.req.bits.addr), io.req.valid)
+
+   val r_btb_update = Pipe(io.btb_update)
+   val update_valid = r_btb_update.valid 
+   val widx = getIdx(r_btb_update.bits.pc)
+
+   // a not-very-clever way to replace a way
+   val next_replace = Counter(r_btb_update.valid, nWays)._1
+   val way_wen = UIntToOH(next_replace)
+
+   for (w <- 0 until nWays)
+   {
+      val wen = update_valid && way_wen(w)
+
+      val valids     = Reg(init = UInt(0, nSets))
+      val tags       = SeqMem(nSets, UInt(width = tag_sz))
+      val metadata   = SeqMem(nSets, new BTBSetMetaData())
+
+      val is_valid    = RegNext((valids >> s0_idx)(0)) && !wen
+      val rout        = metadata.read(s0_idx, ren && !wen)
+      val rtag        = tags.read(s0_idx, ren && !wen)
+      hits(w)         := is_valid && (rtag === s1_req_tag)
+		metadata_out(w) := rout
+
+      when (wen)
+      {
+         val wtag = getTag(r_btb_update.bits.pc) 
+         val widx = getIdx(r_btb_update.bits.pc) 
+         valids := valids.bitSet(widx, Bool(true))
+
+         val newmeta = Wire(new BTBSetMetaData())
+         newmeta.target  := r_btb_update.bits.target(vaddrBits-1, log2Up(coreInstBytes))
+         newmeta.cfi_idx := r_btb_update.bits.cfi_pc >> log2Up(coreInstBytes)
+         newmeta.cfi_type := r_btb_update.bits.cfi_type
+         
+         tags(widx)     := wtag
+         metadata(widx) := newmeta
+//         printf("BTB write: %d 0x%x (PC= 0x%x, TARG= 0x%x) way=%d\n", widx, wtag, r_btb_update.bits.pc, r_btb_update.bits.target, UInt(w))
+      }
+   }
+
+   //TODO zap entries if multiple hits
+//   assert (PopCount(hits_out) <= UInt(1) && ren, "[btbsa] more than 1 valid hit.")
+   
+   // mux out the winning hit
+   val s1_valid = PopCount(hits) === UInt(1)
+	val s1_metadata = Mux1H(hits, metadata_out)
+   val s1_target = s1_metadata.target
+   val s1_cfi_idx = s1_metadata.cfi_idx
+   val s1_cfi_type = s1_metadata.cfi_type
+
+//   val update_target = io.req.bits.addr
+
+   io.resp.valid := s1_valid
+   io.resp.bits.taken := Bool(true) // TODO XXX add bimodal predictor
+  io.resp.bits.target := s1_target
+//  io.resp.bits.entry := 
+   io.resp.bits.cfi_idx := (if (fetchWidth > 1) s1_cfi_idx else UInt(0))
+   io.resp.bits.mask := Cat((UInt(1) << ~Mux(io.resp.bits.taken, ~io.resp.bits.cfi_idx, UInt(0)))-UInt(1), UInt(1))
+}

--- a/src/main/scala/btb-sa.scala
+++ b/src/main/scala/btb-sa.scala
@@ -121,6 +121,7 @@ class BIM(bim_entries: Int, way_idx: Int)(implicit val p: Parameters) extends Ha
       // read-data valid on the next cycle
       res.value := table.read(index(idx_sz-1, 0))
       res.way_idx := UInt(way_idx)
+      res.entry_idx := 0.U // unused -- set externally to save on a register
       res
    }
 
@@ -291,15 +292,15 @@ class BTBsa(implicit p: Parameters) extends BoomModule()(p) with HasBTBsaParamet
          printf("BTB write (%c): %d 0x%x (PC= 0x%x, TARG= 0x%x) way=%d C=%d\n", Mux(wen, Str("w"), Str("-")), widx,
          wtag, r_btb_update.bits.pc, r_btb_update.bits.target, UInt(w), clear_valid)
 
-         for (i <- 0 until nSets)
-         {
-            printf("    [%d] %d tag=0x%x targ=0x%x [0x%x 0x%x]\n", UInt(i), (valids >> UInt(i))(0),
-            tags.read(UInt(i)),
-            data.read(UInt(i)).target,
-            tags.read(UInt(i)) << UInt(idx_sz + log2Up(fetchWidth*coreInstBytes)),
-            data.read(UInt(i)).target << log2Up(coreInstBytes)
-            )
-         }
+         //for (i <- 0 until nSets)
+         //{
+         //   printf("    [%d] %d tag=0x%x targ=0x%x [0x%x 0x%x]\n", UInt(i), (valids >> UInt(i))(0),
+         //   tags.read(UInt(i)),
+         //   data.read(UInt(i)).target,
+         //   tags.read(UInt(i)) << UInt(idx_sz + log2Up(fetchWidth*coreInstBytes)),
+         //   data.read(UInt(i)).target << log2Up(coreInstBytes)
+         //   )
+         //}
       }
    }
 
@@ -360,8 +361,9 @@ class BTBsa(implicit p: Parameters) extends BoomModule()(p) with HasBTBsaParamet
 
    if (DEBUG_PRINTF)
    {
-      printf("BTB predi (%c): hits:%x %d (PC= 0x%x, TARG= 0x%x %d)\n",
-         Mux(s1_valid, Str("V"), Str("-")), hits_oh.asUInt, true.B, RegNext(io.req.bits.addr), s1_target, s1_cfi_type)
+      printf("BTB predi (%c): hits:%x %d (PC= 0x%x, TARG= 0x%x %d) BIM [%d, %d]\n",
+         Mux(s1_valid, Str("V"), Str("-")), hits_oh.asUInt, true.B, RegNext(io.req.bits.addr), s1_target, s1_cfi_type,
+         io.resp.bits.bim_resp.way_idx, io.resp.bits.bim_resp.entry_idx)
    }
 }
 

--- a/src/main/scala/btb-sa.scala
+++ b/src/main/scala/btb-sa.scala
@@ -30,7 +30,7 @@ case class BTBsaParameters(
   tagSz: Int = 20,
   nRAS : Int = 8,
   // Extra knobs.
-  bypassCalls: Boolean = true
+  bypassCalls: Boolean = false
 )
 
 trait HasBTBsaParameters extends HasBoomCoreParameters
@@ -251,6 +251,9 @@ class BTBsa(implicit p: Parameters) extends BoomModule()(p) with HasBTBsaParamet
       val tags     = SeqMem(nSets, UInt(width = tag_sz))
       val data     = SeqMem(nSets, new BTBSetData())
       val bim      = new BIM(nSets, way_idx = w)
+
+      tags.suggestName("btb_tag_array")
+      data.suggestName("btb_data_array")
 
       val is_valid = RegNext((valids >> s0_idx)(0) && !wen)
       val rout     = data.read(s0_idx, !wen)

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -91,10 +91,10 @@ class WithMediumBooms extends Config((site, here, up) => {
          IssueParams(issueWidth=1, numEntries=16, iqType=IQT_MEM.litValue),
          IssueParams(issueWidth=2, numEntries=16, iqType=IQT_INT.litValue),
          IssueParams(issueWidth=1, numEntries=16, iqType=IQT_FP.litValue)),
-      numIntPhysRegisters = 80,
-      numFpPhysRegisters = 56,
+      numIntPhysRegisters = 70,
+      numFpPhysRegisters = 64,
       numLsuEntries = 16,
-      gshare = Some(GShareParameters(enabled = true, history_length=14))
+      gshare = Some(GShareParameters(enabled=true, history_length=14))
       )
 })
 

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -27,7 +27,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          nPerfEvents = 37,
          perfIncWidth = 3, // driven by issue ports, as set in BoomCoreParams.issueParams
          fpu = Some(tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
-      btb = Some(BTBParams(nEntries = 40, nRAS = 4, updatesOutOfOrder = true))
+         btb = Some(BTBParams(nEntries = 0, updatesOutOfOrder = true))
    )}
 
    // BOOM-specific uarch Parameters
@@ -44,6 +44,9 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       enableBranchPredictor = true,
       gshare = Some(GShareParameters(enabled = true, history_length=15))
    )
+   // Widen L1toL2 bandwidth.
+   case L1toL2Config => up(L1toL2Config, site).copy(
+      beatBytes = site(XLen)/4)
   }
 )
 
@@ -115,6 +118,6 @@ class WithMegaBooms extends Config((site, here, up) => {
       )
    // Widen L1toL2 bandwidth so we can increase icache rowBytes size for 4-wide fetch.
    case L1toL2Config => up(L1toL2Config, site).copy(
-      beatBytes = site(XLen)/4)
+      beatBytes = site(XLen)/2)
 
 })

--- a/src/main/scala/configs.scala
+++ b/src/main/scala/configs.scala
@@ -94,12 +94,12 @@ class WithMediumBooms extends Config((site, here, up) => {
       numIntPhysRegisters = 70,
       numFpPhysRegisters = 64,
       numLsuEntries = 16,
-      gshare = Some(GShareParameters(enabled=true, history_length=14))
+      gshare = Some(GShareParameters(enabled=true, history_length=13))
       )
 })
 
 
-//// try to match the Cortex-A15
+// try to match the Cortex-A15
 class WithMegaBooms extends Config((site, here, up) => {
    case RocketTilesKey => up(RocketTilesKey, site) map { r => r.copy(core = r.core.copy(
       fWidth = 4,

--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -358,7 +358,7 @@ trait RISCVConstants
    def GetRs1(inst: UInt): UInt = inst(RS1_MSB,RS1_LSB)
    def IsCall(inst: UInt): Bool = (inst === rocket.Instructions.JAL ||
                                   inst === rocket.Instructions.JALR) && GetRd(inst) === RA
-   def IsReturn(inst: UInt): Bool = GetUop(inst) === jalr_opc && GetRd(inst) === X0 && GetRs1(inst) === RA
+   def IsReturn(inst: UInt): Bool = GetUop(inst) === jalr_opc && GetRs1(inst) === BitPat("b00?01")
 
    def ComputeBranchTarget(pc: UInt, inst: UInt, xlen: Int, coreInstBytes: Int): UInt =
    {

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -171,7 +171,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    println("   BTB Size              : " + 
       (if (enableBTB) ("" + boomParams.btb.nSets * boomParams.btb.nWays + " entries (" + 
          boomParams.btb.nSets + " x " + boomParams.btb.nWays + " ways)") else 0))
-   println("   RAS Size              : n/a") // + (if (enableBTB) boomParams.btb.get.nRAS     else 0))
+   println("   RAS Size              : " + (if (enableBTB) boomParams.btb.nRAS else 0))
    println("   Rename  Stage Latency : " + renameLatency)
    println("   RegRead Stage Latency : " + regreadLatency)
 
@@ -246,7 +246,6 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 //   }
 //   io.imem.resp.ready <> fetch_unit.io.imem.resp.ready
 //
-   bpd_stage.io.npc := io.imem.npc
    bpd_stage.io.ext_btb_req := io.imem.ext_btb.req
 
 

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -76,13 +76,13 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_read_ports).sum,
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_write_ports).sum,
                                  xLen,
-                                 ENABLE_REGFILE_BYPASSING))
+                                 exe_units.bypassable_write_port_mask))
                           else
                               Module(new RegisterFileSeq(numIntPhysRegs,
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_read_ports).sum,
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_write_ports).sum,
                                  xLen,
-                                 ENABLE_REGFILE_BYPASSING))
+                                 exe_units.bypassable_write_port_mask))
    val ll_wbarb         = Module(new Arbiter(new ExeUnitResp(xLen), 2))
    val iregister_read   = Module(new RegisterRead(
                                  issue_units.map(_.issue_width).sum,

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -204,19 +204,12 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    fetch_unit.io.br_unit <> br_unit
    fetch_unit.io.tsc_reg           := debug_tsc_reg
 
-   fetch_unit.io.f0_btb            := bpd_stage.io.f0_btb
+   fetch_unit.io.f1_btb            := bpd_stage.io.f1_btb
+   fetch_unit.io.f2_bpu_request    := bpd_stage.io.f2_bpu_request
    fetch_unit.io.f2_btb_resp       := bpd_stage.io.f2_btb_resp
    fetch_unit.io.f2_bpd_resp       := bpd_stage.io.f2_bpd_resp
-   fetch_unit.io.f2_bpu_request    := bpd_stage.io.f2_bpu_request
 
    fetch_unit.io.f3_bpd_resp       := bpd_stage.io.f3_bpd_resp
-//   fetch_unit.io.bp2_take_pc       := bpd_stage.io.req.valid
-//   fetch_unit.io.bp2_pc_of_br_inst := bpd_stage.io.req.bits.br_pc
-//   fetch_unit.io.bp2_is_jump       := bpd_stage.io.req.bits.is_jump
-//   fetch_unit.io.bp2_is_cfi        := bpd_stage.io.req.bits.is_cfi
-//   fetch_unit.io.bp2_is_taken      := bpd_stage.io.req.bits.is_taken
-//   fetch_unit.io.bp2_br_seen       := bpd_stage.io.pred_resp.br_seen
-//   fetch_unit.io.bp2_pred_target   := bpd_stage.io.req.bits.target
 
    fetch_unit.io.clear_fetchbuffer := br_unit.brinfo.mispredict ||
                                        rob.io.flush.valid

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -258,6 +258,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    bpd_stage.io.fetch_stalled := fetch_unit.io.stalled
    bpd_stage.io.status_debug := csr.io.status.debug
 
+   bpd_stage.io.f2_btb_update := fetch_unit.io.f2_btb_update
+   bpd_stage.io.f2_ras_update := fetch_unit.io.f2_ras_update
 //   fetch_unit.io.bp2_pred_resp <> bpd_stage.io.pred_resp
 //   fetch_unit.io.bp2_predictions <> bpd_stage.io.predictions
 
@@ -1091,7 +1093,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 
       val numBrobWhitespace = if (DEBUG_PRINTF_BROB) NUM_BROB_ENTRIES else 0
 //      val screenheight = 103 - 12 //- 10
-      val screenheight = 85 - 10 - 10
+      val screenheight = 85 - 4 - 10
 //      val screenheight = 62-8
        var whitespace = (screenheight - 11 + 3 - NUM_LSU_ENTRIES -
          issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -77,12 +77,20 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_write_ports).sum,
                                  xLen,
                                  exe_units.bypassable_write_port_mask))
-                          else
+                          else if (regreadLatency == 1 && enableCustomRf)
+                              Module(new RegisterFileSeqCustomArray(numIntPhysRegs,
+                                 exe_units.withFilter(_.usesIRF).map(e => e.num_rf_read_ports).sum,
+                                 exe_units.withFilter(_.usesIRF).map(e => e.num_rf_write_ports).sum,
+                                 xLen,
+                                 exe_units.bypassable_write_port_mask))
+                          else {
+                              require (regreadLatency == 1)
                               Module(new RegisterFileSeq(numIntPhysRegs,
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_read_ports).sum,
                                  exe_units.withFilter(_.usesIRF).map(e => e.num_rf_write_ports).sum,
                                  xLen,
                                  exe_units.bypassable_write_port_mask))
+                          }
    val ll_wbarb         = Module(new Arbiter(new ExeUnitResp(xLen), 2))
    val iregister_read   = Module(new RegisterRead(
                                  issue_units.map(_.issue_width).sum,

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -49,6 +49,7 @@ class BoomBundle(implicit val p: Parameters) extends util.ParameterizedBundle()(
 class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends BoomModule()(p)
    with tile.HasCoreIO
 {
+  println("PaddrBits: " + p(rocket.PAddrBits))
    //**********************************
    // construct all of the modules
 
@@ -63,8 +64,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    val num_irf_write_ports = exe_units.map(_.num_rf_write_ports).sum
    val num_fast_wakeup_ports = exe_units.count(_.isBypassable)
    val num_wakeup_ports = num_irf_write_ports + num_fast_wakeup_ports
-   val fetch_unit       = Module(new FetchUnit(FETCH_WIDTH))
-   val bpd_stage        = Module(new BranchPredictionStage(FETCH_WIDTH))
+   val fetch_unit       = Module(new FetchUnit(fetchWidth))
+   val bpd_stage        = Module(new BranchPredictionStage(fetchWidth))
    val dec_serializer   = Module(new FetchSerializerNtoM)
    val decode_units     = for (w <- 0 until DECODE_WIDTH) yield { val d = Module(new DecodeUnit); d }
    val dec_brmask_logic = Module(new BranchMaskGenerationLogic(DECODE_WIDTH))
@@ -159,7 +160,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 
    val iss_str = if (enableAgePriorityIssue) " (Age-based Priority)"
                  else " (Unordered Priority)"
-   println("\n   Fetch Width           : " + FETCH_WIDTH)
+   println("\n   Fetch Width           : " + fetchWidth)
    println("   Issue Width           : " + issueParams.map(_.issueWidth).sum)
    println("   ROB Size              : " + NUM_ROB_ENTRIES)
    println("   Issue Window Size     : " + issueParams.map(_.numEntries) + iss_str)
@@ -167,8 +168,10 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    println("   Num Int Phys Registers: " + numIntPhysRegs)
    println("   Num FP  Phys Registers: " + numFpPhysRegs)
    println("   Max Branch Count      : " + MAX_BR_COUNT)
-   println("   BTB Size              : " + btbParams.nEntries)
-   println("   RAS Size              : " + btbParams.nRAS)
+   println("   BTB Size              : " + 
+      (if (enableBTB) ("" + boomParams.btb.nSets * boomParams.btb.nWays + " entries (" + 
+         boomParams.btb.nSets + " x " + boomParams.btb.nWays + " ways)") else 0))
+   println("   RAS Size              : n/a") // + (if (enableBTB) boomParams.btb.get.nRAS     else 0))
    println("   Rename  Stage Latency : " + renameLatency)
    println("   RegRead Stage Latency : " + regreadLatency)
 
@@ -179,6 +182,11 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 
    print(fp_pipeline)
 
+   println("\n   DCache Ways           : " + dcacheParams.nWays)
+   println("   DCache Sets           : " + dcacheParams.nSets)
+   println("   ICache Ways           : " + icacheParams.nWays)
+   println("   ICache Sets           : " + icacheParams.nSets)
+
    //-------------------------------------------------------------
    //-------------------------------------------------------------
    // **** Fetch Stage/Frontend ****
@@ -188,7 +196,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    io.imem <> fetch_unit.io.imem
    // TODO: work-around rocket-chip issue #183, broken imem.mask for fetchWidth=1
    // TODO: work-around rocket-chip issue #184, broken imem.mask for fetchWidth=1
-   if (FETCH_WIDTH == 1)
+   if (fetchWidth == 1)
    {
       fetch_unit.io.imem.resp.bits.mask := UInt(1)
       fetch_unit.io.imem.resp.bits.btb.bits.bridx := UInt(0)
@@ -196,13 +204,15 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    fetch_unit.io.br_unit <> br_unit
    fetch_unit.io.tsc_reg           := debug_tsc_reg
 
-   fetch_unit.io.bp2_take_pc       := bpd_stage.io.req.valid
-   fetch_unit.io.bp2_pc_of_br_inst := bpd_stage.io.req.bits.br_pc
-   fetch_unit.io.bp2_is_jump       := bpd_stage.io.req.bits.is_jump
-   fetch_unit.io.bp2_is_cfi        := bpd_stage.io.req.bits.is_cfi
-   fetch_unit.io.bp2_is_taken      := bpd_stage.io.req.bits.is_taken
-   fetch_unit.io.bp2_br_seen       := bpd_stage.io.pred_resp.br_seen
-   fetch_unit.io.bp2_pred_target   := bpd_stage.io.req.bits.target
+   fetch_unit.io.f0_btb            := bpd_stage.io.f0_btb
+   fetch_unit.io.f2_bpu_info       := bpd_stage.io.f2_bpu_info
+//   fetch_unit.io.bp2_take_pc       := bpd_stage.io.req.valid
+//   fetch_unit.io.bp2_pc_of_br_inst := bpd_stage.io.req.bits.br_pc
+//   fetch_unit.io.bp2_is_jump       := bpd_stage.io.req.bits.is_jump
+//   fetch_unit.io.bp2_is_cfi        := bpd_stage.io.req.bits.is_cfi
+//   fetch_unit.io.bp2_is_taken      := bpd_stage.io.req.bits.is_taken
+//   fetch_unit.io.bp2_br_seen       := bpd_stage.io.pred_resp.br_seen
+//   fetch_unit.io.bp2_pred_target   := bpd_stage.io.req.bits.target
 
    fetch_unit.io.clear_fetchbuffer := br_unit.brinfo.mispredict ||
                                        rob.io.flush.valid
@@ -225,29 +235,32 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    // decode.  BHT look-up is in parallel with I$ access, and Branch Decode
    // occurs before fetch buffer insertion.
 
-   //io.imem <> bpd_stage.io.imem
-   bpd_stage.io.imem_resp <> io.imem.resp
-   bpd_stage.io.btb_resp <> io.imem.resp.bits.btb
-   // TODO: work-around rocket-chip issue #183, broken imem.mask for fetchWidth=1
-   // TODO: work-around rocket-chip issue #184, broken imem.mask for fetchWidth=1
-   if (FETCH_WIDTH == 1)
-   {
-      bpd_stage.io.imem_resp.bits.mask := UInt(1)
-      bpd_stage.io.btb_resp.bits.bridx := UInt(0)
-   }
-   io.imem.resp.ready <> fetch_unit.io.imem.resp.ready
+//   bpd_stage.io.imem_resp <> io.imem.resp
+//   bpd_stage.io.btb_resp <> io.imem.resp.bits.btb
+//   // TODO: work-around rocket-chip issue #183, broken imem.mask for fetchWidth=1
+//   // TODO: work-around rocket-chip issue #184, broken imem.mask for fetchWidth=1
+//   if (fetchWidth == 1)
+//   {
+//      bpd_stage.io.imem_resp.bits.mask := UInt(1)
+//      bpd_stage.io.btb_resp.bits.bridx := UInt(0)
+//   }
+//   io.imem.resp.ready <> fetch_unit.io.imem.resp.ready
+//
+   bpd_stage.io.npc := io.imem.npc
+   bpd_stage.io.ext_btb_req := io.imem.ext_btb.req
 
-   bpd_stage.io.npc <> io.imem.npc
 
-
-   io.imem.ras_update <> bpd_stage.io.ras_update
+//   io.imem.ras_update <> bpd_stage.io.ras_update
    bpd_stage.io.br_unit := br_unit
    bpd_stage.io.flush := rob.io.flush.valid //|| rob.io.clear_brob
-   bpd_stage.io.status_prv := csr.io.status.prv
-   bpd_stage.io.req.ready := !fetch_unit.io.stalled
+   bpd_stage.io.redirect := io.imem.req.valid
 
-   fetch_unit.io.bp2_pred_resp <> bpd_stage.io.pred_resp
-   fetch_unit.io.bp2_predictions <> bpd_stage.io.predictions
+//   bpd_stage.io.status_prv := csr.io.status.prv
+   bpd_stage.io.fetch_stalled := fetch_unit.io.stalled
+   bpd_stage.io.status_debug := csr.io.status.debug
+
+//   fetch_unit.io.bp2_pred_resp <> bpd_stage.io.pred_resp
+//   fetch_unit.io.bp2_predictions <> bpd_stage.io.predictions
 
    //-------------------------------------------------------------
    //-------------------------------------------------------------
@@ -262,7 +275,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    val dec_finished_mask = Reg(init = Bits(0, DECODE_WIDTH))
 
    // TODO need to generalize this logic to other width disparities
-   require (DECODE_WIDTH == FETCH_WIDTH)
+   require (DECODE_WIDTH == fetchWidth)
 
    //-------------------------------------------------------------
    // Pull out instructions and send to the Decoders
@@ -308,10 +321,10 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
                         || br_unit.brinfo.mispredict
                         || rob.io.flush.valid
                         || dec_stall_next_inst
-                        || !bpd_stage.io.brob.allocate.ready
                         || (dec_valids(w) && dec_uops(w).is_fencei && !lsu.io.lsu_fencei_rdy)
                         )) ||
                      dec_last_inst_was_stalled
+//                        || !bpd_stage.io.brob.allocate.ready
 
       // stall the next instruction following me in the decode bundle?
       dec_last_inst_was_stalled = stall_me
@@ -382,22 +395,24 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
       else
          dec_uops(w).rob_idx := Cat(rob.io.curr_rob_tail, UInt(w, log2Up(DECODE_WIDTH)))
 
-      dec_uops(w).brob_idx := bpd_stage.io.brob.allocate_brob_tail
+//      dec_uops(w).brob_idx := bpd_stage.io.brob.allocate_brob_tail
    }
 
+   // TODO XXX
    val dec_has_br_or_jalr_in_packet =
-      (dec_valids zip dec_uops map {case(v,u) => v && u.br_prediction.is_br_or_jalr}).reduce(_|_)
+      (dec_valids zip dec_uops map {case(v,u) => v && u.is_br_or_jmp && !u.is_jal}).reduce(_|_)
+//      (dec_valids zip dec_uops map {case(v,u) => v && u.br_prediction.is_br_or_jalr}).reduce(_|_)
 
-   bpd_stage.io.brob.allocate.valid := dec_will_fire.reduce(_|_) &&
-                                       dec_finished_mask === Bits(0) &&
-                                       dec_has_br_or_jalr_in_packet
-   bpd_stage.io.brob.allocate.bits.ctrl.executed.map{_ := Bool(false)}
-   bpd_stage.io.brob.allocate.bits.ctrl.taken.map{_ := Bool(false)}
-   bpd_stage.io.brob.allocate.bits.ctrl.mispredicted.map{_ := Bool(false)}
-   bpd_stage.io.brob.allocate.bits.ctrl.debug_executed := Bool(false)
-   bpd_stage.io.brob.allocate.bits.ctrl.debug_rob_idx := dec_uops(0).rob_idx
-   bpd_stage.io.brob.allocate.bits.ctrl.brob_idx := dec_uops(0).brob_idx
-   bpd_stage.io.brob.allocate.bits.info := dec_fbundle.pred_resp.bpd_resp
+//   bpd_stage.io.brob.allocate.valid := dec_will_fire.reduce(_|_) &&
+//                                       dec_finished_mask === Bits(0) &&
+//                                       dec_has_br_or_jalr_in_packet
+//   bpd_stage.io.brob.allocate.bits.ctrl.executed.map{_ := Bool(false)}
+//   bpd_stage.io.brob.allocate.bits.ctrl.taken.map{_ := Bool(false)}
+//   bpd_stage.io.brob.allocate.bits.ctrl.mispredicted.map{_ := Bool(false)}
+//   bpd_stage.io.brob.allocate.bits.ctrl.debug_executed := Bool(false)
+//   bpd_stage.io.brob.allocate.bits.ctrl.debug_rob_idx := dec_uops(0).rob_idx
+//   bpd_stage.io.brob.allocate.bits.ctrl.brob_idx := dec_uops(0).brob_idx
+//   bpd_stage.io.brob.allocate.bits.info := dec_fbundle.pred_resp.bpd_resp
 
 
 
@@ -410,7 +425,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    // TODO for now, assume worst-case all instructions will dispatch towards one issue unit.
    val dis_readys = issue_units.map(_.io.dis_readys.toBits).reduce(_&_) & fp_pipeline.io.dis_readys.toBits
    rename_stage.io.dis_inst_can_proceed := dis_readys.toBools
-   rename_stage.io.ren_pred_info := dec_fbundle.pred_resp
+   rename_stage.io.ren_pred_info := Vec(dec_fbundle.uops.map(_.br_prediction))
 
    rename_stage.io.kill     := fetch_unit.io.clear_fetchbuffer // mispredict or flush
    rename_stage.io.brinfo   := br_unit.brinfo
@@ -893,6 +908,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    {
       rob.io.wb_resps(cnt) <> wakeup
       rob.io.fflags(f_cnt) <> wakeup.bits.fflags
+      rob.io.debug_wb_valids(cnt) := Bool(false) // TODO XXX add back commit logging for FP instructions.
       cnt += 1
       f_cnt += 1
    }
@@ -923,9 +939,9 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 
    rob.io.bxcpt <> br_unit.xcpt
 
-   bpd_stage.io.brob.deallocate <> rob.io.brob_deallocate
-   bpd_stage.io.brob.bpd_update <> br_unit.bpd_update
-   bpd_stage.io.brob.flush := rob.io.flush.valid || rob.io.clear_brob
+//   bpd_stage.io.brob.deallocate <> rob.io.brob_deallocate
+//   bpd_stage.io.brob.bpd_update <> br_unit.bpd_update
+//   bpd_stage.io.brob.flush := rob.io.flush.valid || rob.io.clear_brob
 
    //-------------------------------------------------------------
    // **** Flush Pipeline ****
@@ -1075,8 +1091,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
       println("\n Chisel Printout Enabled\n")
 
       val numBrobWhitespace = if (DEBUG_PRINTF_BROB) NUM_BROB_ENTRIES else 0
-//      val screenheight = 103-8
-      val screenheight = 85 -8
+//      val screenheight = 103 - 12 //- 10
+      val screenheight = 85 - 10 - 10
 //      val screenheight = 62-8
        var whitespace = (screenheight - 11 + 3 - NUM_LSU_ENTRIES -
          issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numBrobWhitespace
@@ -1194,17 +1210,18 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
          )
 
       // branch unit
-      printf("                          Branch Unit: %c,%c,%d PC=0x%x, %d Targ=0x%x NPC=%d,0x%x %d%d\n"
+//      printf("                          Branch Unit: %c,%c,%d PC=0x%x, %d Targ=0x%x NPC=%d,0x%x %d%d\n"
+      printf("                          Branch Unit: %c,%c,%d  NPC=%d,0x%x\n"
          , Mux(br_unit.brinfo.valid,Str("V"), Str(" "))
          , Mux(br_unit.brinfo.mispredict, Str("M"), Str(" "))
          , br_unit.brinfo.taken
-         , br_unit.btb_update.br_pc(19,0)
-         , br_unit.btb_update_valid
-         , br_unit.btb_update.target(19,0)
+//         , br_unit.btb_update.bits.br_pc(19,0)
+//         , br_unit.btb_update.valid
+//         , br_unit.btb_update.bits.target(19,0)
          , exe_units(brunit_idx).io.get_rob_pc.next_val
          , exe_units(brunit_idx).io.get_rob_pc.next_pc(19,0)
-         , br_unit.btb_update.isJump
-         , br_unit.btb_update.isReturn
+//         , br_unit.btb_update.isJump
+//         , br_unit.btb_update.isReturn
       )
 
       // Rename Map Tables / ISA Register File

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -168,8 +168,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    println("   Num Int Phys Registers: " + numIntPhysRegs)
    println("   Num FP  Phys Registers: " + numFpPhysRegs)
    println("   Max Branch Count      : " + MAX_BR_COUNT)
-   println("   BTB Size              : " + 
-      (if (enableBTB) ("" + boomParams.btb.nSets * boomParams.btb.nWays + " entries (" + 
+   println("   BTB Size              : " +
+      (if (enableBTB) ("" + boomParams.btb.nSets * boomParams.btb.nWays + " entries (" +
          boomParams.btb.nSets + " x " + boomParams.btb.nWays + " ways)") else 0))
    println("   RAS Size              : " + (if (enableBTB) boomParams.btb.nRAS else 0))
    println("   Rename  Stage Latency : " + renameLatency)
@@ -208,6 +208,8 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
    fetch_unit.io.f2_btb_resp       := bpd_stage.io.f2_btb_resp
    fetch_unit.io.f2_bpd_resp       := bpd_stage.io.f2_bpd_resp
    fetch_unit.io.f2_bpu_request    := bpd_stage.io.f2_bpu_request
+
+   fetch_unit.io.f3_bpd_resp       := bpd_stage.io.f3_bpd_resp
 //   fetch_unit.io.bp2_take_pc       := bpd_stage.io.req.valid
 //   fetch_unit.io.bp2_pc_of_br_inst := bpd_stage.io.req.bits.br_pc
 //   fetch_unit.io.bp2_is_jump       := bpd_stage.io.req.bits.is_jump
@@ -249,6 +251,7 @@ class BoomCore(implicit p: Parameters, edge: uncore.tilelink2.TLEdgeOut) extends
 
    bpd_stage.io.f2_btb_update := fetch_unit.io.f2_btb_update
    bpd_stage.io.f2_ras_update := fetch_unit.io.f2_ras_update
+   bpd_stage.io.f3_hist_update:= fetch_unit.io.f3_hist_update
    bpd_stage.io.status_prv   := csr.io.status.prv
    bpd_stage.io.status_debug := csr.io.status.debug
 

--- a/src/main/scala/decode.scala
+++ b/src/main/scala/decode.scala
@@ -480,8 +480,8 @@ class BranchDecode extends Module
 
 class FetchSerializerResp(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val uops     = Vec(DECODE_WIDTH, new MicroOp())
-//   val pred_resp = new BranchPredictionResp() XXX // per packet info?
+   val uops = Vec(DECODE_WIDTH, new MicroOp())
+   val bpd_resp = new BpdResp()
 }
 class FetchSerializerIO(implicit p: Parameters) extends BoomBundle()(p)
 {
@@ -544,7 +544,6 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
    io.deq.bits.uops(0).pc             := io.enq.bits.pc
    io.deq.bits.uops(0).fetch_pc_lob   := io.enq.bits.pc
    io.deq.bits.uops(0).inst           := io.enq.bits.insts(inst_idx)
-//   io.deq.bits.uops(0).br_prediction  := io.enq.bits.predictions(inst_idx) XXX
    io.deq.bits.uops(0).br_prediction  := io.enq.bits.bpu_info(inst_idx)
    io.deq.bits.uops(0).valid          := io.enq.bits.mask(inst_idx)
    io.deq.bits.uops(0).xcpt_if        := io.enq.bits.xcpt_if
@@ -565,7 +564,6 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
          io.deq.bits.uops(i).inst           := io.enq.bits.insts(i)
          io.deq.bits.uops(i).xcpt_if        := io.enq.bits.xcpt_if
          io.deq.bits.uops(i).replay_if        := io.enq.bits.replay_if
-//         io.deq.bits.uops(i).br_prediction  := io.enq.bits.predictions(i) XXX
          io.deq.bits.uops(i).br_prediction  := io.enq.bits.bpu_info(i)
          io.deq.bits.uops(i).debug_events   := io.enq.bits.debug_events(i)
       }
@@ -575,7 +573,9 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
    // Pipe valid straight through, since conceptually,
    // we are just an extension of the Fetch Buffer
    io.deq.valid := io.enq.valid
-//   io.deq.bits.pred_resp := io.enq.bits.pred_resp // XXX
+   // TODO XXX HACK bpd_resp is associated with a "fetch packet", so only copy the first one.
+   // Ideally, separate out which parts of bpu_info are "per packet"/"per instruction" and "commit info" and "exe info".
+   io.deq.bits.bpd_resp := io.enq.bits.bpu_info(0).bpd_resp
 
 }
 

--- a/src/main/scala/decode.scala
+++ b/src/main/scala/decode.scala
@@ -480,8 +480,8 @@ class BranchDecode extends Module
 
 class FetchSerializerResp(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val uops = Vec(DECODE_WIDTH, new MicroOp())
-   val pred_resp = new BranchPredictionResp()
+   val uops     = Vec(DECODE_WIDTH, new MicroOp())
+//   val pred_resp = new BranchPredictionResp() XXX // per packet info?
 }
 class FetchSerializerIO(implicit p: Parameters) extends BoomBundle()(p)
 {
@@ -544,7 +544,8 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
    io.deq.bits.uops(0).pc             := io.enq.bits.pc
    io.deq.bits.uops(0).fetch_pc_lob   := io.enq.bits.pc
    io.deq.bits.uops(0).inst           := io.enq.bits.insts(inst_idx)
-   io.deq.bits.uops(0).br_prediction  := io.enq.bits.predictions(inst_idx)
+//   io.deq.bits.uops(0).br_prediction  := io.enq.bits.predictions(inst_idx) XXX
+   io.deq.bits.uops(0).br_prediction  := io.enq.bits.bpu_info(inst_idx)
    io.deq.bits.uops(0).valid          := io.enq.bits.mask(inst_idx)
    io.deq.bits.uops(0).xcpt_if        := io.enq.bits.xcpt_if
    io.deq.bits.uops(0).replay_if        := io.enq.bits.replay_if
@@ -564,7 +565,8 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
          io.deq.bits.uops(i).inst           := io.enq.bits.insts(i)
          io.deq.bits.uops(i).xcpt_if        := io.enq.bits.xcpt_if
          io.deq.bits.uops(i).replay_if        := io.enq.bits.replay_if
-         io.deq.bits.uops(i).br_prediction  := io.enq.bits.predictions(i)
+//         io.deq.bits.uops(i).br_prediction  := io.enq.bits.predictions(i) XXX
+         io.deq.bits.uops(i).br_prediction  := io.enq.bits.bpu_info(i)
          io.deq.bits.uops(i).debug_events   := io.enq.bits.debug_events(i)
       }
       io.enq.ready := io.deq.ready
@@ -573,7 +575,7 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
    // Pipe valid straight through, since conceptually,
    // we are just an extension of the Fetch Buffer
    io.deq.valid := io.enq.valid
-   io.deq.bits.pred_resp := io.enq.bits.pred_resp
+//   io.deq.bits.pred_resp := io.enq.bits.pred_resp // XXX
 
 }
 

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -172,6 +172,11 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          f2_fetch_bundle.bpu_info(w).btb_hit := true.B
       }
 
+      when (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_bpd_resp.valid && !f2_req.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).bpd_taken := io.f2_bpd_resp.bits.takens(w.U)
+      }
+
       assert (!(f2_fetch_bundle.bpu_info(w).btb_predicted && f2_fetch_bundle.bpu_info(w).bpd_predicted))
    }
 

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -587,7 +587,9 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    io.btb_update.bits.bpd_type := Mux(io.is_call(jal_idx), BpredType.call, BpredType.jump)
    io.btb_update.bits.cfi_type := CfiType.jal
 
-   io.ras_update.valid := jal_wins && io.is_call(jal_idx)
+   // for critical path reasons, remove dependence on bpu_request to ras_update.
+   val jal_may_win = io.is_jal.reduce(_|_) && (!btb_hit || btb_was_wrong || jal_idx < btb_idx)
+   io.ras_update.valid := jal_may_win && io.is_call(jal_idx)
    io.ras_update.bits.is_call := true.B
    io.ras_update.bits.is_ret := false.B
    io.ras_update.bits.return_addr := io.aligned_pc + (jal_idx << 2.U) + 4.U

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -6,6 +6,11 @@
 // Fetch Unit
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
+//
+// f0 = next PC select
+// f1 = icache SRAM access
+// f2 = icache response/pre-decode
+// f3 = redirect 
 
 package boom
 
@@ -22,8 +27,9 @@ class FetchBundle(implicit p: Parameters) extends BoomBundle()(p)
    val xcpt_if     = Bool()
    val replay_if   = Bool()
 
-   val pred_resp   = new BranchPredictionResp
-   val predictions = Vec(FETCH_WIDTH, new BranchPrediction)
+//   val pred_resp   = new BranchPredictionResp
+//   val predictions = Vec(FETCH_WIDTH, new BranchPrediction)
+   val bpu_info    = Vec(FETCH_WIDTH, new BranchPredInfo)
 
    val debug_events = Vec(FETCH_WIDTH, new DebugStageEvents)
 
@@ -37,43 +43,205 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    val io = new BoomBundle()(p)
    {
       val imem              = new rocket.FrontendIO
+      val f0_btb            = Valid(new BTBsaResp).flip
+      val f2_bpu_info       = Valid(new BTBsaResp).flip
+
       val br_unit           = new BranchUnitResp().asInput
 
       val tsc_reg           = UInt(INPUT, xLen)
-
-      val bp2_take_pc       = Bool(INPUT)
-      val bp2_is_taken      = Bool(INPUT)
-      val bp2_br_seen       = Bool(INPUT)
-      val bp2_is_jump       = Bool(INPUT)
-      val bp2_is_cfi        = Bool(INPUT)
-      val bp2_pred_resp     = new BranchPredictionResp().asInput
-      val bp2_predictions   = Vec(fetch_width, new BranchPrediction()).asInput
-      val bp2_pc_of_br_inst = UInt(INPUT, vaddrBits+1)
-      val bp2_pred_target   = UInt(INPUT, vaddrBits+1)
 
       val clear_fetchbuffer = Bool(INPUT)
 
       val flush_take_pc     = Bool(INPUT)
       val flush_pc          = UInt(INPUT, vaddrBits+1)
 
-      val stalled           = Bool(OUTPUT)
       val resp              = new DecoupledIO(new FetchBundle)
+      val stalled           = Bool(OUTPUT) // CODE REVIEW
    }
-
-   val fseq_reg = Reg(init = UInt(0, xLen))
-   val if_pc_next = Wire(UInt(width = vaddrBits+1))
-
-   val br_unit = io.br_unit
-
-
-   val fetch_bundle = Wire(new FetchBundle())
-
+ 
+   val bchecker = Module (new BranchChecker(fetchWidth))
    val FetchBuffer = Module(new Queue(gen=new FetchBundle,
                                 entries=fetchBufferSz,
                                 pipe=false,
                                 flow=enableFetchBufferFlowThrough,
                                 _reset=(io.clear_fetchbuffer || reset.toBool)))
+        
+   val br_unit = io.br_unit
+   val if_pc_next = Wire(UInt(width = vaddrBits+1))
+   val fseq_reg = Reg(init = UInt(0, xLen))
+   val fetch_bundle = Wire(new FetchBundle())
 
+//   val kill_f2 = Wire(init = Bool(false)) // TODO XXX redirects from F3 need to kill f2
+   val f2_req = Wire(Valid(new RequestPCRedirect()))
+   val f3_req = Wire(Valid(new RequestPCRedirect()))
+ 
+   //-------------------------------------------------------------
+   // **** Helper Functions ****
+   //-------------------------------------------------------------
+                     
+   private def KillMask(m_enable: Bool, m_idx: UInt, m_width: Int): UInt =
+   {
+      val mask = Wire(Bits(width = m_width))
+      mask := Fill(m_width, m_enable) & (Fill(m_width, UInt(1)) << UInt(1) << m_idx)
+      mask
+   }
+
+   //-------------------------------------------------------------
+   // **** NextPC Select (F0) ****
+   //-------------------------------------------------------------
+
+   val if_stalled = !(FetchBuffer.io.enq.ready) // if FetchBuffer backs up, we have to stall the front-end
+   io.stalled := if_stalled
+
+
+   val redirect_val  = 
+      br_unit.take_pc || 
+      io.flush_take_pc || 
+      (f2_req.valid && !if_stalled) || // TODO this seems way too low-level to get backpressure signal correct
+      (f3_req.valid && !if_stalled)
+
+   io.imem.req.valid   := redirect_val // tell front-end we had an unexpected change in the stream
+   io.imem.req.bits.pc := if_pc_next
+   io.imem.req.bits.speculative := !(io.flush_take_pc)
+   io.imem.resp.ready  := !(if_stalled)
+
+   if_pc_next := Mux(io.flush_take_pc, io.flush_pc,
+                 Mux(br_unit.take_pc,  br_unit.target(vaddrBits,0),
+                 Mux(f3_req.valid,     f3_req.bits.addr,
+                                       f2_req.bits.addr)))
+
+//   io.imem.ext_btb.resp := io.f0_btb
+   io.imem.ext_btb.resp.valid := io.f0_btb.valid
+   io.imem.ext_btb.resp.bits.taken := io.f0_btb.bits.taken
+   io.imem.ext_btb.resp.bits.mask := io.f0_btb.bits.mask
+   io.imem.ext_btb.resp.bits.bridx := io.f0_btb.bits.cfi_idx
+   io.imem.ext_btb.resp.bits.target := io.f0_btb.bits.target
+                   
+   //-------------------------------------------------------------
+   // **** ICache Access (F1) ****
+   //-------------------------------------------------------------
+
+   // twiddle thumbs
+
+   //-------------------------------------------------------------
+   // **** ICache Response/Pre-decode (F2) ****
+   //-------------------------------------------------------------
+
+   val f2_valid = io.imem.resp.valid && !io.clear_fetchbuffer && !f3_req.valid
+   val f2_fetch_bundle = Wire(new FetchBundle)
+   f2_fetch_bundle.pc := io.imem.resp.bits.pc
+   f2_fetch_bundle.mask := io.imem.resp.bits.mask
+   f2_fetch_bundle.xcpt_if := io.imem.resp.bits.xcpt_if
+   f2_fetch_bundle.replay_if := io.imem.resp.bits.replay
+
+
+   for (w <- 0 until fetch_width)
+   {
+      f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(false) 
+      f2_fetch_bundle.bpu_info(w).btb_taken := Bool(false) 
+      
+      when (UInt(w) === io.f2_bpu_info.bits.cfi_idx && io.f2_bpu_info.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(true) 
+         f2_fetch_bundle.bpu_info(w).btb_taken := io.f2_bpu_info.bits.taken
+      }
+   }
+
+ 
+   // round off to nearest fetch boundary
+   val aligned_pc = ~(~io.imem.resp.bits.pc | (UInt(fetch_width*coreInstBytes-1)))
+   val is_br     = Wire(Vec(fetch_width, Bool()))
+   val is_jal    = Wire(Vec(fetch_width, Bool()))
+   val is_jr     = Wire(Vec(fetch_width, Bool()))
+   val br_targs  = Wire(Vec(fetch_width, UInt(width=vaddrBits+1)))
+   val jal_targs = Wire(Vec(fetch_width, UInt(width=vaddrBits+1)))
+        
+   for (i <- 0 until fetch_width)
+   {
+      val bpd_decoder = Module(new BranchDecode)
+
+      val inst = io.imem.resp.bits.data(i*coreInstBits+coreInstBits-1,i*coreInstBits)
+      bpd_decoder.io.inst := inst
+      f2_fetch_bundle.insts(i) := inst
+
+      val pc = aligned_pc + UInt(i << 2)
+      is_br(i) := io.imem.resp.valid && bpd_decoder.io.is_br && io.imem.resp.bits.mask(i)
+      is_jal(i) := io.imem.resp.valid && bpd_decoder.io.is_jal  && io.imem.resp.bits.mask(i)
+      is_jr(i) := io.imem.resp.valid && bpd_decoder.io.is_jalr  && io.imem.resp.bits.mask(i)
+      jal_targs(i) := ComputeJALTarget(pc, inst, xLen, coreInstBytes)
+                          
+      if (i == 0) {
+         f2_fetch_bundle.debug_events(i).fetch_seq := fseq_reg
+      } else {
+         f2_fetch_bundle.debug_events(i).fetch_seq := fseq_reg +
+            PopCount(f2_fetch_bundle.mask.toBits()(i-1,0))
+      }
+   }
+
+   val jal_idx = PriorityEncoder(is_jal.toBits)
+   f2_req.valid  := is_jal.reduce(_|_)
+  f2_req.bits.addr := jal_targs(jal_idx)
+       
+   // mask out instructions after predicted branch
+   val f2_kill_mask = KillMask(f2_req.valid,
+                               jal_idx,
+                               fetchWidth)
+
+   f2_fetch_bundle.mask := io.imem.resp.bits.mask & ~f2_kill_mask 
+
+
+   // catch any BTB mispredictions
+   bchecker.io.is_br  := is_br  zip f2_kill_mask.toBools map {case(e,k) => e & ~k}
+   bchecker.io.is_jal := is_jal zip f2_kill_mask.toBools map {case(e,k) => e & ~k}
+   bchecker.io.is_jr  := is_jr  zip f2_kill_mask.toBools map {case(e,k) => e & ~k}
+   bchecker.io.bpu_info := io.f2_bpu_info
+   // TODO, fix up f2_bpu_info
+
+      
+   //-------------------------------------------------------------
+   // **** ??? ****
+   //-------------------------------------------------------------
+
+   val f3_fetch_bundle = Pipe(f2_valid, f2_fetch_bundle, 1)
+
+   // TODO XXX make this occur on cycle f3
+   f3_req := bchecker.io.req
+//   f3_req := Pipe(f2_valid, bchecker.io.req, 1)
+
+   //-------------------------------------------------------------
+   // **** FetchBuffer Enqueue ****
+   //-------------------------------------------------------------
+                   
+   // Fetch Buffer
+//   FetchBuffer.io.enq <> f3_fetch_bundle
+   FetchBuffer.io.enq.valid := f2_valid
+   FetchBuffer.io.enq.bits  := f2_fetch_bundle
+//   FetchBuffer.io.enq.valid := f2_valid
+//   FetchBuffer.io.enq.bits  := f2_fetch_bundle
+//   FetchBuffer.io.enq.bits.pred_resp.btb_resp_valid  := Bool(false)
+//   FetchBuffer.io.enq.bits.predictions := 
+
+
+
+//   io.imem.bht_update := Bool(false)
+//   fetch_bundle.mask := io.imem.resp.bits.mask //& io.bp2_pred_resp.mask
+//   fetch_bundle.pred_resp := io.bp2_pred_resp
+//   fetch_bundle.predictions := io.bp2_predictions
+ 
+   // We do not use the imem's BTB.
+   io.imem.btb_update.valid := Bool(false)
+                                  
+   //-------------------------------------------------------------
+   // **** Frontend Response ****
+   //-------------------------------------------------------------
+    
+   io.resp <> FetchBuffer.io.deq
+ 
+     
+   //-------------------------------------------------------------
+   // **** Pipeview Support ****
+   //-------------------------------------------------------------
+                   
    if (O3PIPEVIEW_PRINTF)
    {
       when (FetchBuffer.io.enq.fire())
@@ -95,131 +263,31 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
             }
          }
       }
+       
    }
 
-
-   require (fetchLatency == 2 || fetchLatency == 3)
-   val if_stalled =
-      if (fetchLatency == 2) !(FetchBuffer.io.enq.ready) // if FetchBuffer backs up, we have to stall the front-end
-      else FetchBuffer.io.count >= UInt(fetchBufferSz-(fetchLatency-2))
-
-
-   val take_pc = br_unit.take_pc ||
-                 io.flush_take_pc ||
-                 (io.bp2_take_pc && !if_stalled) // TODO this seems way too low-level to get backpressure signal correct
-
-   io.imem.req.valid   := take_pc // tell front-end we had an unexpected change in the stream
-   io.imem.req.bits.pc := if_pc_next
-   io.imem.req.bits.speculative := !(io.flush_take_pc)
-   io.imem.resp.ready  := !(if_stalled) // TODO perf BUG || take_pc?
-
-   if_pc_next := Mux(io.flush_take_pc, io.flush_pc,
-                 Mux(br_unit.take_pc,  br_unit.target(vaddrBits,0),
-                                       io.bp2_pred_target)) // bp2_take_pc
-
-   // Fetch Buffer
-   if (fetchLatency == 2) {
-      FetchBuffer.io.enq.valid := io.imem.resp.valid && !io.clear_fetchbuffer
-      FetchBuffer.io.enq.bits  := fetch_bundle
-   } else {
-      require (fetchLatency == 3)
-      FetchBuffer.io.enq.valid := RegNext(io.imem.resp.valid && !io.clear_fetchbuffer) &&
-                                 !io.clear_fetchbuffer &&
-                                 !io.bp2_take_pc
-      FetchBuffer.io.enq.bits  := RegNext(fetch_bundle)
-   }
-
-   fetch_bundle.pc := io.imem.resp.bits.pc
-   fetch_bundle.xcpt_if := io.imem.resp.bits.xcpt_if
-   fetch_bundle.replay_if := io.imem.resp.bits.replay
-
-   for (i <- 0 until fetch_width)
-   {
-      fetch_bundle.insts(i) := io.imem.resp.bits.data(i*coreInstBits+coreInstBits-1,i*coreInstBits)
-
-      if (i == 0)
-      {
-         fetch_bundle.debug_events(i).fetch_seq := fseq_reg
-      }
-      else
-      {
-         fetch_bundle.debug_events(i).fetch_seq := fseq_reg +
-            PopCount(fetch_bundle.mask.toBits()(i-1,0))
-      }
-   }
-
-   if (enableBTB)
-   {
-      io.imem.btb_update.valid := (br_unit.btb_update_valid ||
-                                    (io.bp2_take_pc && io.bp2_is_taken && !if_stalled && !br_unit.take_pc)) &&
-                                  !io.flush_take_pc
-   }
-   else
-   {
-      io.imem.btb_update.valid := Bool(false)
-   }
-
-   // update the BTB
-   // If a branch is mispredicted and taken, update the BTB.
-   // (if branch unit mispredicts, instructions in decode are no longer valid)
-   io.imem.btb_update.bits.pc         := Mux(br_unit.btb_update_valid, br_unit.btb_update.pc, io.imem.resp.bits.pc)
-   io.imem.btb_update.bits.br_pc      := Mux(br_unit.btb_update_valid, br_unit.btb_update.br_pc, io.bp2_pc_of_br_inst)
-   io.imem.btb_update.bits.target     := Mux(br_unit.btb_update_valid, br_unit.btb_update.target,
-                                                                       (io.bp2_pred_target.toSInt &
-                                                                        SInt(-coreInstBytes)).toUInt)
-   io.imem.btb_update.bits.prediction := Mux(br_unit.btb_update_valid, br_unit.btb_update.prediction,
-                                                                       io.imem.resp.bits.btb)
-   io.imem.btb_update.bits.taken      := Mux(br_unit.btb_update_valid, br_unit.btb_update.taken,
-                                                                       io.bp2_take_pc && io.bp2_is_taken && !if_stalled)
-   io.imem.btb_update.bits.isJump     := Mux(br_unit.btb_update_valid, br_unit.btb_update.isJump, io.bp2_is_jump)
-   io.imem.btb_update.bits.isReturn   := Mux(br_unit.btb_update_valid, br_unit.btb_update.isReturn, Bool(false))
-   io.imem.btb_update.bits.isValid    := Mux(br_unit.btb_update_valid, Bool(true), io.bp2_is_cfi)
-
-   // Update the BHT in the BP2 stage.
-   // Also update the BHT in the Exe stage IF and only if the branch is a misprediction.
-   // TODO move this into the bpd_pipeline
-   val bp2_bht_update = Wire(Valid(new rocket.BHTUpdate()).asOutput)
-   bp2_bht_update.valid           := io.imem.resp.valid && io.bp2_br_seen && !if_stalled && !br_unit.take_pc
-   bp2_bht_update.bits.prediction := io.imem.resp.bits.btb
-   bp2_bht_update.bits.pc         := io.imem.resp.bits.pc
-   bp2_bht_update.bits.taken      := Mux(io.bp2_take_pc,
-                                       io.bp2_is_taken,
-                                       io.imem.resp.bits.btb.valid && io.imem.resp.bits.btb.bits.taken)
-   bp2_bht_update.bits.mispredict := io.bp2_take_pc
-
-   io.imem.bht_update := Mux(br_unit.brinfo.valid &&
-                             br_unit.brinfo.mispredict &&
-                             RegNext(br_unit.bht_update.valid),
-                           RegNext(br_unit.bht_update),
-                           bp2_bht_update)
-
-
-   // bp2 stage
-   fetch_bundle.mask := io.imem.resp.bits.mask & io.bp2_pred_resp.mask
-   fetch_bundle.pred_resp := io.bp2_pred_resp
-   fetch_bundle.predictions := io.bp2_predictions
-
-   // output
-   io.stalled := if_stalled
-   io.resp <> FetchBuffer.io.deq
-
-
+     
    //-------------------------------------------------------------
+   // **** Assertions ****
+   //-------------------------------------------------------------
+      
+   assert (!(io.imem.resp.bits.btb.valid), "[bpd_pipeline] BTB predicted, but it's been disabled.")
+    
+   //-------------------------------------------------------------
+   // **** Printfs ****
+   //-------------------------------------------------------------
+      
    if (DEBUG_PRINTF)
    {
       // Fetch Stage 1
-      printf("BrPred1:    (IF1_PC= 0x%x Predict:n/a) ------ PC: [%c%c%c-%c for br_id:(n/a), %c %c next: 0x%x ifst:%d]\n"
+      printf("BrPred1:    (IF1_PC= 0x%x Predict:n/a) ------ PC: [%c%c-%c for br_id:(n/a), %c %c next: 0x%x ifst:%d]\n"
          , io.imem.npc
          , Mux(br_unit.brinfo.valid, Str("V"), Str("-"))
          , Mux(br_unit.brinfo.taken, Str("T"), Str("-"))
-         , Mux(br_unit.debug_btb_pred, Str("B"), Str("_"))
          , Mux(br_unit.brinfo.mispredict, Str("M"), Str(" "))
-         , Mux(take_pc, Str("T"), Str(" "))
+         , Mux(redirect_val, Str("T"), Str(" "))
          , Mux(io.flush_take_pc, Str("F"),
-           Mux(br_unit.take_pc, Str("B"),
-           Mux(io.bp2_take_pc && !if_stalled, Str("P"),
-           Mux(io.bp2_take_pc, Str("J"),
-                              Str(" ")))))
+           Mux(br_unit.take_pc, Str("B"), Str(" ")))
          , if_pc_next
          , if_stalled)
 
@@ -255,9 +323,38 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       printf(" Fetch3 : (%c) 0x%x jkilmsk:0x%x ->(0x%x)\n"
          , Mux(FetchBuffer.io.enq.valid, Str("V"), Str("-"))
          , FetchBuffer.io.enq.bits.pc
-         , io.bp2_pred_resp.mask
+         , UInt(0) //io.bp2_pred_resp.mask
          , FetchBuffer.io.enq.bits.mask
          )
 
    }
 }
+
+
+// Verify BTB predicted the type and target of instructions correctly.
+// If an error is found, redirect the front-end to refetch and correct the misprediction.
+class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)
+{
+   val io = new Bundle
+   {
+      val req        = Valid(new RequestPCRedirect)
+
+      val is_br      = Vec(fetch_width, Bool()).asInput
+      val is_jal     = Vec(fetch_width, Bool()).asInput
+      val is_jr      = Vec(fetch_width, Bool()).asInput
+
+      val bpu_info   = Valid(new BTBsaResp).flip
+      // TODO only handle if taken and taken_targ != correct_targ
+
+   }
+
+   // If
+   // #A If predicted JR but not a JR, refetch PC+4.
+
+   io.req.valid := Bool(false)
+   io.req.bits.addr := UInt(0)
+}
+
+
+
+

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -10,7 +10,7 @@
 // f0 = next PC select
 // f1 = icache SRAM access
 // f2 = icache response/pre-decode
-// f3 = redirect 
+// f3 = redirect
 
 package boom
 
@@ -58,30 +58,30 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       val resp              = new DecoupledIO(new FetchBundle)
       val stalled           = Bool(OUTPUT) // CODE REVIEW
    }
- 
+
    val bchecker = Module (new BranchChecker(fetchWidth))
    val FetchBuffer = Module(new Queue(gen=new FetchBundle,
                                 entries=fetchBufferSz,
                                 pipe=false,
                                 flow=enableFetchBufferFlowThrough,
                                 _reset=(io.clear_fetchbuffer || reset.toBool)))
-        
-   val br_unit = io.br_unit
-   val if_pc_next = Wire(UInt(width = vaddrBits+1))
-   val fseq_reg = Reg(init = UInt(0, xLen))
-   val fetch_bundle = Wire(new FetchBundle())
 
-//   val kill_f2 = Wire(init = Bool(false)) // TODO XXX redirects from F3 need to kill f2
+   val br_unit = io.br_unit
+   val fseq_reg = Reg(init = UInt(0, xLen))
+   val f0_redirect_pc = Wire(UInt(width = vaddrBits+1))
+
+   val f2_valid = Wire(Bool())
    val f2_req = Wire(Valid(new PCReq()))
-   
+   val f2_fetch_bundle = Wire(new FetchBundle)
+
    val f3_valid = Reg(init=Bool(false))
-   val f3_fetch_bundle = Reg(new FetchBundle())
    val f3_req = Reg(Valid(new PCReq()))
- 
+   val f3_fetch_bundle = Reg(new FetchBundle())
+
    //-------------------------------------------------------------
    // **** Helper Functions ****
    //-------------------------------------------------------------
-                     
+
    private def KillMask(m_enable: Bool, m_idx: UInt, m_width: Int): UInt =
    {
       val mask = Wire(Bits(width = m_width))
@@ -97,28 +97,23 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    io.stalled := if_stalled
 
 
-   val redirect_val  = 
-      br_unit.take_pc || 
-      io.flush_take_pc || 
-      (f3_req.valid && !if_stalled)
-//      (f2_req.valid && !if_stalled) || // TODO this seems way too low-level to get backpressure signal correct
+   val f0_redirect_val =
+      br_unit.take_pc ||
+      io.flush_take_pc ||
+      (f3_req.valid && !if_stalled) // TODO this seems way too low-level to get backpressure signal correct
 
-   io.imem.req.valid   := redirect_val // tell front-end we had an unexpected change in the stream
-   io.imem.req.bits.pc := if_pc_next
+   io.imem.req.valid   := f0_redirect_val // tell front-end we had an unexpected change in the stream
+   io.imem.req.bits.pc := f0_redirect_pc
    io.imem.req.bits.speculative := !(io.flush_take_pc)
    io.imem.resp.ready  := !(if_stalled)
 
-   if_pc_next := Mux(io.flush_take_pc, io.flush_pc,
-                 Mux(br_unit.take_pc,  br_unit.target(vaddrBits,0),
-                                       f3_req.bits.addr))
+   f0_redirect_pc := 
+      Mux(io.flush_take_pc, io.flush_pc,
+      Mux(br_unit.take_pc,  br_unit.target(vaddrBits,0),
+         f3_req.bits.addr))
 
-//   io.imem.ext_btb.resp := io.f0_btb
-   io.imem.ext_btb.resp.valid := io.f0_btb.valid
-   io.imem.ext_btb.resp.bits.taken := io.f0_btb.bits.taken
-   io.imem.ext_btb.resp.bits.mask := io.f0_btb.bits.mask
-   io.imem.ext_btb.resp.bits.bridx := io.f0_btb.bits.cfi_idx
-   io.imem.ext_btb.resp.bits.target := io.f0_btb.bits.target
-                   
+   io.imem.ext_btb.resp := io.f0_btb
+
    //-------------------------------------------------------------
    // **** ICache Access (F1) ****
    //-------------------------------------------------------------
@@ -129,8 +124,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    // **** ICache Response/Pre-decode (F2) ****
    //-------------------------------------------------------------
 
-   val f2_valid = io.imem.resp.valid && !io.clear_fetchbuffer && !f3_req.valid
-   val f2_fetch_bundle = Wire(new FetchBundle)
+   f2_valid := io.imem.resp.valid && !io.clear_fetchbuffer && !f3_req.valid
    f2_fetch_bundle.pc := io.imem.resp.bits.pc
    f2_fetch_bundle.mask := io.imem.resp.bits.mask
    f2_fetch_bundle.xcpt_if := io.imem.resp.bits.xcpt_if
@@ -139,25 +133,25 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
    for (w <- 0 until fetch_width)
    {
-      f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(false) 
-      f2_fetch_bundle.bpu_info(w).btb_taken := Bool(false) 
-      
+      f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(false)
+      f2_fetch_bundle.bpu_info(w).btb_taken := Bool(false)
+
       when (UInt(w) === io.f2_bpu_info.bits.cfi_idx && io.f2_bpu_info.valid)
       {
-         f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(true) 
+         f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(true)
          f2_fetch_bundle.bpu_info(w).btb_taken := io.f2_bpu_info.bits.taken
       }
    }
 
- 
+
    // round off to nearest fetch boundary
    val aligned_pc = ~(~io.imem.resp.bits.pc | (UInt(fetch_width*coreInstBytes-1)))
    val is_br     = Wire(Vec(fetch_width, Bool()))
    val is_jal    = Wire(Vec(fetch_width, Bool()))
    val is_jr     = Wire(Vec(fetch_width, Bool()))
-   val br_targs  = Wire(Vec(fetch_width, UInt(width=vaddrBits+1)))
-   val jal_targs = Wire(Vec(fetch_width, UInt(width=vaddrBits+1)))
-        
+   val br_targs  = Wire(Vec(fetch_width, UInt(width=vaddrBitsExtended)))
+   val jal_targs = Wire(Vec(fetch_width, UInt(width=vaddrBitsExtended)))
+
    for (i <- 0 until fetch_width)
    {
       val bpd_decoder = Module(new BranchDecode)
@@ -170,8 +164,9 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       is_br(i) := io.imem.resp.valid && bpd_decoder.io.is_br && io.imem.resp.bits.mask(i)
       is_jal(i) := io.imem.resp.valid && bpd_decoder.io.is_jal  && io.imem.resp.bits.mask(i)
       is_jr(i) := io.imem.resp.valid && bpd_decoder.io.is_jalr  && io.imem.resp.bits.mask(i)
+      br_targs(i) := ComputeBranchTarget(pc, inst, xLen, coreInstBytes)
       jal_targs(i) := ComputeJALTarget(pc, inst, xLen, coreInstBytes)
-                          
+
       if (i == 0) {
          f2_fetch_bundle.debug_events(i).fetch_seq := fseq_reg
       } else {
@@ -180,31 +175,34 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       }
    }
 
-   val jal_idx = PriorityEncoder(is_jal.toBits)
-   f2_req.valid  := is_jal.reduce(_|_) && !redirect_val
-  f2_req.bits.addr := jal_targs(jal_idx)
-       
-   // mask out instructions after predicted branch
-   val f2_kill_mask = KillMask(f2_req.valid,
-                               jal_idx,
-                               fetchWidth)
 
-   f2_fetch_bundle.mask := io.imem.resp.bits.mask & ~f2_kill_mask 
-
-
-   // catch any BTB mispredictions
-   bchecker.io.is_br  := is_br  zip f2_kill_mask.toBools map {case(e,k) => e & ~k}
-   bchecker.io.is_jal := is_jal zip f2_kill_mask.toBools map {case(e,k) => e & ~k}
-   bchecker.io.is_jr  := is_jr  zip f2_kill_mask.toBools map {case(e,k) => e & ~k}
+   // catch any BTB mispredictions (and fix-up missed JALs)
+   bchecker.io.is_br  := is_br
+   bchecker.io.is_jal := is_jal
+   bchecker.io.is_jr  := is_jr
+   bchecker.io.br_targs := br_targs
+   bchecker.io.jal_targs := jal_targs
+   bchecker.io.nextline_pc := aligned_pc + UInt(fetch_width*coreInstBytes)
    bchecker.io.bpu_info := io.f2_bpu_info
    // TODO, fix up f2_bpu_info
 
-      
+
+   f2_req.valid := bchecker.io.req.valid && !f0_redirect_val && f2_valid
+   f2_req.bits  := bchecker.io.req.bits
+
+   // mask out instructions after predicted branch
+   val btb_kill_mask = KillMask(f2_req.valid, bchecker.io.cfi_idx, fetchWidth)
+   val f2_kill_mask = KillMask(f2_req.valid, bchecker.io.cfi_idx, fetchWidth)
+
+   val btb_mask = Mux(f2_req.valid || !io.f2_bpu_info.valid,
+                  Fill(fetchWidth, UInt(1,1)),
+                  io.f2_bpu_info.bits.mask)
+   f2_fetch_bundle.mask := io.imem.resp.bits.mask & ~f2_kill_mask & btb_mask
+
    //-------------------------------------------------------------
-   // **** ??? ****
+   // **** F3 ****
    //-------------------------------------------------------------
 
-  
    when (io.clear_fetchbuffer)
    {
       f3_valid := Bool(false)
@@ -215,89 +213,73 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       f3_valid := f2_valid
       f3_fetch_bundle := f2_fetch_bundle
       f3_req := f2_req
+//      f3_req := Mux(bchecker.io.req.valid, bchecker.io.req, f2_req)
    }
 
-//   val f3_fetch_bundle = Pipe(f2_valid, f2_fetch_bundle, 1)
-//   val f3_valid = Reg(Bool(), next=f2_valid, init=Bool(false))
-//   val f3_fetch_bundle = RegEnable(f2_fetch_bundle, !if_stalled)
-
-//   val f3_fetch_bundle = Queue(entries=1, pipe=true)
-
-//   f3_req := RegEnable(f2_req, !if_stalled)
-   // TODO XXX make this occur on cycle f3; 
-   // TODO XXX figure out how to have f2, f3 fight for redirect.
-//   f3_req := bchecker.io.req
-//   f3_req := Pipe(f2_valid, bchecker.io.req, 1)
 
    //-------------------------------------------------------------
    // **** FetchBuffer Enqueue ****
    //-------------------------------------------------------------
-                   
+
    // Fetch Buffer
-//   FetchBuffer.io.enq <> f3_fetch_bundle
-//   FetchBuffer.io.enq.valid := f2_valid
-//   FetchBuffer.io.enq.bits  := f2_fetch_bundle
    FetchBuffer.io.enq.valid := f3_valid
    FetchBuffer.io.enq.bits  := f3_fetch_bundle
-//   FetchBuffer.io.enq.bits.pred_resp.btb_resp_valid  := Bool(false)
-//   FetchBuffer.io.enq.bits.predictions := 
 
 
-
-//   io.imem.bht_update := Bool(false)
 //   fetch_bundle.mask := io.imem.resp.bits.mask //& io.bp2_pred_resp.mask
 //   fetch_bundle.pred_resp := io.bp2_pred_resp
 //   fetch_bundle.predictions := io.bp2_predictions
- 
+
    // We do not use the imem's BTB.
    io.imem.btb_update.valid := Bool(false)
-                                  
+
    //-------------------------------------------------------------
    // **** Frontend Response ****
    //-------------------------------------------------------------
-    
+
    io.resp <> FetchBuffer.io.deq
- 
-     
+
+
    //-------------------------------------------------------------
    // **** Pipeview Support ****
    //-------------------------------------------------------------
-                   
+
    if (O3PIPEVIEW_PRINTF)
    {
       when (FetchBuffer.io.enq.fire())
       {
          fseq_reg := fseq_reg + PopCount(FetchBuffer.io.enq.bits.mask)
+         val bundle = FetchBuffer.io.enq.bits
          for (i <- 0 until fetch_width)
          {
-            when (fetch_bundle.mask(i))
+            when (bundle.mask(i))
             {
                // TODO for now, manually set the fetch_tsc to point to when the fetch
                // started. This doesn't properly account for i-cache and i-tlb misses. :(
                // Also not factoring in NPC.
                printf("%d; O3PipeView:fetch:%d:0x%x:0:%d:DASM(%x)\n",
-                  fetch_bundle.debug_events(i).fetch_seq,
+                  bundle.debug_events(i).fetch_seq,
                   io.tsc_reg - UInt(1*O3_CYCLE_TIME),
-                  (fetch_bundle.pc.toSInt & SInt(-(fetch_width*coreInstBytes))).toUInt + UInt(i << 2),
-                  fetch_bundle.debug_events(i).fetch_seq,
-                  fetch_bundle.insts(i))
+                  (bundle.pc.toSInt & SInt(-(fetch_width*coreInstBytes))).toUInt + UInt(i << 2),
+                  bundle.debug_events(i).fetch_seq,
+                  bundle.insts(i))
             }
          }
       }
-       
+
    }
 
-     
+
    //-------------------------------------------------------------
    // **** Assertions ****
    //-------------------------------------------------------------
-      
+
    assert (!(io.imem.resp.bits.btb.valid), "[bpd_pipeline] BTB predicted, but it's been disabled.")
-    
+
    //-------------------------------------------------------------
    // **** Printfs ****
    //-------------------------------------------------------------
-      
+
    if (DEBUG_PRINTF)
    {
       // Fetch Stage 1
@@ -306,10 +288,10 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          , Mux(br_unit.brinfo.valid, Str("V"), Str("-"))
          , Mux(br_unit.brinfo.taken, Str("T"), Str("-"))
          , Mux(br_unit.brinfo.mispredict, Str("M"), Str(" "))
-         , Mux(redirect_val, Str("T"), Str(" "))
+         , Mux(f0_redirect_val, Str("T"), Str(" "))
          , Mux(io.flush_take_pc, Str("F"),
            Mux(br_unit.take_pc, Str("B"), Str(" ")))
-         , if_pc_next
+         , f0_redirect_pc
          , if_stalled)
 
       // Fetch Stage 2
@@ -347,13 +329,15 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          , UInt(0) //io.bp2_pred_resp.mask
          , FetchBuffer.io.enq.bits.mask
          )
-
    }
 }
 
 
 // Verify BTB predicted the type and target of instructions correctly.
+// Also catch any JALs and redirect the frontend.
+// Combinational logic.
 // If an error is found, redirect the front-end to refetch and correct the misprediction.
+// Incoming signals may be garbage (if f2_valid not true); consumer will have to handle that scenario.
 class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)
 {
    val io = new Bundle
@@ -364,18 +348,66 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
       val is_jal     = Vec(fetch_width, Bool()).asInput
       val is_jr      = Vec(fetch_width, Bool()).asInput
 
+      val br_targs  = Vec(fetch_width, UInt(width=vaddrBitsExtended)).asInput
+      val jal_targs = Vec(fetch_width, UInt(width=vaddrBitsExtended)).asInput
+      val nextline_pc = UInt(INPUT, width=vaddrBitsExtended)
+
       val bpu_info   = Valid(new BTBsaResp).flip
       // TODO only handle if taken and taken_targ != correct_targ
+
+
+      // pass in F2's thoughts on JALs... or compute it ourselves?
+      // pass in PCnextline, in case no-JALs and we want to redirect after a bad-taken
+
+//      val kill_mask = UInt(OUTPUT, width = fetch_width)
+      val cfi_idx     = UInt(OUTPUT, width = log2Up(fetchWidth)) // where is cfi we are predicting?
 
    }
 
    // If
-   // #A If predicted JR but not a JR, refetch PC+4.
+   // Step #1: did the BTB mispredict the cfi type?
+   // Step #2: did the BTB mispredict the cfi target?
+   val wrong_cfi = Wire(init = false.B)
+   val wrong_target = Wire(init = false.B)
 
-   io.req.valid := Bool(false)
-   io.req.bits.addr := UInt(0)
+   val btb_idx = io.bpu_info.bits.cfi_idx
+   val btb_target = io.bpu_info.bits.target
+   when (io.bpu_info.valid)
+   {
+      when (io.bpu_info.bits.cfi_type === CFIType.branch && io.bpu_info.bits.taken)
+      {
+         wrong_cfi := !io.is_br(btb_idx)
+         wrong_target := io.br_targs(btb_idx) =/= btb_target
+      }
+      .elsewhen (io.bpu_info.bits.cfi_type === CFIType.jal)
+      {
+         wrong_cfi := !io.is_jal(btb_idx)
+         wrong_target := io.jal_targs(btb_idx) =/= btb_target
+      }
+      .elsewhen (io.bpu_info.bits.cfi_type === CFIType.jalr)
+      {
+         wrong_cfi := !io.is_jr(btb_idx)
+      }
+   }
+
+   val btb_was_wrong = io.bpu_info.valid && (wrong_cfi || wrong_target)
+
+   // Redirect if:
+   //    - JAL comes before BT's cfi_idx
+   //       * kill everything behind JAL -- including BTB's predinfo
+   //    - BTB was wrong
+   //       * if JAL, take JAL (if valid instructions available)
+   //       * if !JAL, request nextline (set all masks to valid).
+   //    - No JAL, BTB correct
+   //       * do nothing
+
+   val jal_idx = PriorityEncoder(io.is_jal.toBits)
+   val btb_hit  = io.bpu_info.valid
+   val jal_wins = io.is_jal.reduce(_|_) && (!btb_hit || btb_was_wrong || (jal_idx < btb_idx))
+
+   io.req.valid := jal_wins || btb_was_wrong
+   io.req.bits.addr := Mux(jal_wins, io.jal_targs(jal_idx), io.nextline_pc)
+   // Help mask out instructions after predicted cfi.
+   io.cfi_idx := Mux(jal_wins, jal_idx, UInt(fetchWidth-1))
 }
-
-
-
 

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -135,6 +135,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    {
       f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(false)
       f2_fetch_bundle.bpu_info(w).btb_taken := Bool(false)
+      f2_fetch_bundle.bpu_info(w).bim_resp  := io.f2_bpu_info.bits.bim_resp
 
       when (UInt(w) === io.f2_bpu_info.bits.cfi_idx && io.f2_bpu_info.valid)
       {

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -127,7 +127,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          io.flush_pc,
       Mux(br_unit.take_pc,
          br_unit.target(vaddrBits,0),
-      Mux(f3_req.valid,
+      Mux(f3_req.valid || !enableBpdF2Redirect.B,
          f3_req.bits.addr,
          io.f2_bpu_request.bits.target)))
 
@@ -633,14 +633,16 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
 
    val btb_was_wrong = io.btb_resp.valid && (wrong_cfi || wrong_target || !io.is_valid(btb_idx))
 
+   val f2_bpu_req_valid = io.f2_bpu_request.valid && enableBpdF2Redirect.B
+
    val jal_idx = PriorityEncoder(io.is_jal.toBits)
    val btb_hit  = io.btb_resp.valid
    val jal_wins = io.is_jal.reduce(_|_) &&
       (!btb_hit ||
       btb_was_wrong ||
       (jal_idx < btb_idx) ||
-      (!io.f2_bpu_request.valid && !io.btb_resp.bits.taken) ||
-      (io.f2_bpu_request.valid && !bpd_predicted_taken))
+      (!f2_bpu_req_valid && !io.btb_resp.bits.taken) ||
+      (f2_bpu_req_valid && !bpd_predicted_taken))
 
    //-------------------------------------------------------------
    // Perform redirection & updates

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -193,14 +193,25 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    val f2_bpd_br_taken = f2_bpd_predictions.orR
    val f2_bpd_br_idx = PriorityEncoder(f2_bpd_predictions)
    val f2_bpd_target = br_targs(f2_bpd_br_idx)
+   // check for jumps -- if we decide to override a taken BTB and choose "nextline" we don't want to miss the JAL.
+   val f2_has_jal = is_jal.reduce(_|_)
+   val f2_jal_idx = PriorityEncoder(is_jal.toBits)
+   val f2_jal_target = jal_targs(f2_jal_idx)
    val f2_bpd_may_redirect_taken = Wire(init=false.B) // request towards a taken branch target
-   val f2_bpd_may_redirect_next = Wire(init=false.B) // override a taken prediction and fetch the next line
+   val f2_bpd_may_redirect_next = Wire(init=false.B) // override taken prediction and fetch the next line (or take JAL)
    val f2_bpd_may_redirect = f2_bpd_may_redirect_taken || f2_bpd_may_redirect_next
-   val f2_bpd_redirect_cfiidx = Mux(f2_bpd_may_redirect_taken, f2_bpd_br_idx, (fetch_width-1).U)
+   val f2_bpd_redirect_cfiidx =
+      Mux(f2_bpd_may_redirect_taken,
+         f2_bpd_br_idx,
+      Mux(f2_has_jal,
+         f2_jal_idx,
+         (fetch_width-1).U))
    val f2_bpd_redirect_target =
-         Mux(f2_bpd_may_redirect_taken,
-            f2_bpd_target,
-            f2_aligned_pc + (fetch_width*coreInstBytes).U)
+      Mux(f2_bpd_may_redirect_taken,
+         f2_bpd_target,
+      Mux(f2_has_jal,
+         f2_jal_target,
+         f2_aligned_pc + (fetch_width*coreInstBytes).U))
 
    if (enableBpdF2Redirect)
    {
@@ -252,7 +263,6 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          "[bpd_pipeline] mutually-exclusive signals firing")
    }
 
-
    // catch any BTB mispredictions (and fix-up missed JALs)
    bchecker.io.is_valid  := Vec(io.imem.resp.bits.mask.toBools)
    bchecker.io.imem_resp_valid := io.imem.resp.valid
@@ -270,11 +280,8 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
    // who wins? bchecker or bpd?
    val f2_bpd_overrides_bcheck = f2_bpd_may_redirect && (!bchecker.io.req.valid || (f2_bpd_redirect_cfiidx < bchecker.io.req_cfi_idx))
-
-
    f2_req.valid := (bchecker.io.req.valid || f2_bpd_may_redirect) && f2_valid && !(f0_redirect_val && !io.f2_bpu_request.valid)
    f2_req.bits.addr := Mux(f2_bpd_overrides_bcheck, f2_bpd_redirect_target, bchecker.io.req.bits.addr)
-
 
    io.f2_btb_update := bchecker.io.btb_update // XXX let f3_bpd_redirect update the BTB too? or let BRU handle it?
    io.f2_ras_update := bchecker.io.ras_update
@@ -284,6 +291,8 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       f2_req.valid,
       Mux(f2_bpd_overrides_bcheck, f2_bpd_redirect_cfiidx, bchecker.io.req_cfi_idx),
       fetchWidth)
+
+
 
    val btb_mask = Mux(io.f2_btb_resp.valid && !io.f2_bpu_request.valid && !f2_req.valid,
                   io.f2_btb_resp.bits.mask,
@@ -350,6 +359,8 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    //-------------------------------------------------------------
    // **** F3 ****
    //-------------------------------------------------------------
+
+   // Rely on register-retiming to move a lot of the work in the F2 stage to here.
 
    when (io.clear_fetchbuffer)
    {
@@ -470,6 +481,11 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          }
          .elsewhen (last_cfi_type === CfiType.jal)
          {
+            when (fetch_pc =/= last_target) {
+               printf("about to abort: [fetch] JAL is followed by the wrong instruction.")
+               printf("fetch_pc: 0x%x, last_target: 0x%x, last_nextlinepc: 0x%x\n",
+                  fetch_pc, last_target, last_nextlinepc)
+            }
             assert (fetch_pc === last_target, "[fetch] JAL is followed by the wrong instruction.")
          }
          .elsewhen (last_cfi_type === CfiType.branch)

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -143,57 +143,8 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    // **** ICache Response/Pre-decode (F2) ****
    //-------------------------------------------------------------
 
-   f2_valid := io.imem.resp.valid && !io.clear_fetchbuffer && !f3_req.valid
-   f2_fetch_bundle.pc := io.imem.resp.bits.pc
-   f2_fetch_bundle.mask := io.imem.resp.bits.mask
-   f2_fetch_bundle.xcpt_if := io.imem.resp.bits.xcpt_if
-   f2_fetch_bundle.replay_if := io.imem.resp.bits.replay
-
-   for (w <- 0 until fetch_width)
-   {
-      f2_fetch_bundle.bpu_info(w).btb_blame     := false.B
-      f2_fetch_bundle.bpu_info(w).btb_hit       := io.f2_btb_resp.valid
-      f2_fetch_bundle.bpu_info(w).btb_taken     := false.B
-
-      f2_fetch_bundle.bpu_info(w).bpd_blame     := false.B
-      f2_fetch_bundle.bpu_info(w).bpd_hit       := io.f2_bpd_resp.valid
-      f2_fetch_bundle.bpu_info(w).bpd_taken     := io.f2_bpd_resp.bits.takens(w.U)
-      f2_fetch_bundle.bpu_info(w).bim_resp      := io.f2_btb_resp.bits.bim_resp
-      f2_fetch_bundle.bpu_info(w).bpd_resp      := io.f2_bpd_resp.bits
-
-      when (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_bpu_request.valid && !f2_req.valid)
-      {
-         f2_fetch_bundle.bpu_info(w).bpd_blame := true.B
-      }
-      .elsewhen (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_btb_resp.valid && !f2_req.valid)
-      {
-         f2_fetch_bundle.bpu_info(w).btb_blame := true.B
-      }
-
-      when (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_btb_resp.valid)
-      {
-         f2_fetch_bundle.bpu_info(w).btb_taken := io.f2_btb_resp.bits.taken
-      }
-   }
-
-
-   val f2_taken = Wire(init=false.B) // was a branch taken in the F2 stage?
-   when (f2_req.valid)
-   {
-      f2_taken := false.B // f2_req only ever requests nextline_pc or jump targets (which we don't track in ghistory).
-   }
-   .elsewhen (io.f2_bpu_request.valid)
-   {
-      f2_taken := io.f2_bpd_resp.bits.takens(io.f2_btb_resp.bits.cfi_idx)
-   }
-   .elsewhen (io.f2_btb_resp.valid)
-   {
-      f2_taken := io.f2_btb_resp.bits.taken
-   }
-
-
    // round off to nearest fetch boundary
-   val aligned_pc = ~(~io.imem.resp.bits.pc | (UInt(fetch_width*coreInstBytes-1)))
+   val f2_aligned_pc = ~(~io.imem.resp.bits.pc | (UInt(fetch_width*coreInstBytes-1)))
    val is_br     = Wire(Vec(fetch_width, Bool()))
    val is_jal    = Wire(Vec(fetch_width, Bool()))
    val is_jr     = Wire(Vec(fetch_width, Bool()))
@@ -209,7 +160,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
       bpd_decoder.io.inst := inst
       f2_fetch_bundle.insts(i) := inst
 
-      val pc = aligned_pc + UInt(i << 2)
+      val pc = f2_aligned_pc + UInt(i << 2)
       is_br(i) := io.imem.resp.valid && bpd_decoder.io.is_br && io.imem.resp.bits.mask(i)
       is_jal(i) := io.imem.resp.valid && bpd_decoder.io.is_jal  && io.imem.resp.bits.mask(i)
       is_jr(i) := io.imem.resp.valid && bpd_decoder.io.is_jalr  && io.imem.resp.bits.mask(i)
@@ -236,6 +187,72 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
                   (!is_jal.reduce(_|_) || (PriorityEncoder(is_jr.toBits) < PriorityEncoder(is_jal.toBits)))
 
 
+   // Does the BPD have a prediction to make (in the case of a BTB miss?)
+   // Calculate in F2 but don't redirect until F3.
+   val f2_bpd_predictions = is_br.asUInt & io.f2_bpd_resp.bits.takens
+   val f2_bpd_br_taken = f2_bpd_predictions.orR
+   val f2_bpd_br_idx = PriorityEncoder(f2_bpd_predictions)
+   val f2_bpd_target = br_targs(f2_bpd_br_idx)
+   val f2_bpd_may_redirect_taken = Wire(init=false.B) // request towards a taken branch target
+   val f2_bpd_may_redirect_next = Wire(init=false.B) // override a taken prediction and fetch the next line
+   val f2_bpd_may_redirect = f2_bpd_may_redirect_taken || f2_bpd_may_redirect_next
+   val f2_bpd_redirect_cfiidx = Mux(f2_bpd_may_redirect_taken, f2_bpd_br_idx, (fetch_width-1).U)
+   val f2_bpd_redirect_target =
+         Mux(f2_bpd_may_redirect_taken,
+            f2_bpd_target,
+            f2_aligned_pc + (fetch_width*coreInstBytes).U)
+
+   if (enableBpdF2Redirect)
+   {
+      // Listen to BPD only if BTB miss -- otherwise BPD in F2 has handled the BTB hit scenario.
+      f2_bpd_may_redirect_taken := io.f2_bpd_resp.valid && f2_bpd_br_taken && !io.f2_btb_resp.valid && enableBpdF3Redirect.B
+   }
+   else if (!enableBpdF2Redirect && enableBpdF3Redirect)
+   {
+      when (io.f2_btb_resp.valid)
+      {
+         // btb made a prediction
+         // Make a redirect request if:
+         //    - the BPD (br) comes earlier than the BTB's redirection.
+         //    - If both the BTB and the BPD predicted a branch, the BPD wins (if disagree).
+         //       * involves refetching the next cacheline and undoing the current packet's mask if we "undo" the BT's
+         //       taken branch.
+
+         val btb_idx = io.f2_btb_resp.bits.cfi_idx
+
+         when (BpredType.isAlwaysTaken(io.f2_btb_resp.bits.bpd_type))
+         {
+            f2_bpd_may_redirect_taken := io.f2_bpd_resp.valid && f2_bpd_br_taken && f2_bpd_br_idx < btb_idx
+
+            assert (io.f2_btb_resp.bits.taken)
+         }
+         .elsewhen (io.f2_btb_resp.bits.taken)
+         {
+            // does the bpd predict the branch is taken too? (assuming bpd_valid)
+            val bpd_agrees_with_btb = f2_bpd_predictions(btb_idx)
+            f2_bpd_may_redirect_taken := io.f2_bpd_resp.valid && f2_bpd_br_taken &&
+               (f2_bpd_br_idx < btb_idx || !bpd_agrees_with_btb)
+               // XXX in this scenario, ignore the btb mask and go with the bpd mask
+            f2_bpd_may_redirect_next := io.f2_bpd_resp.valid && !f2_bpd_br_taken
+
+            assert (BpredType.isBranch(io.f2_btb_resp.bits.bpd_type))
+         }
+         .elsewhen (!io.f2_btb_resp.bits.taken)
+         {
+            f2_bpd_may_redirect_taken := io.f2_bpd_resp.valid && f2_bpd_br_taken
+         }
+      }
+      .otherwise
+      {
+         // BTB made no prediction - let the BPD do what it wants
+         f2_bpd_may_redirect_taken := io.f2_bpd_resp.valid && f2_bpd_br_taken
+      }
+
+      assert (PopCount(Vec(f2_bpd_may_redirect_taken, f2_bpd_may_redirect_next)) <= UInt(1),
+         "[bpd_pipeline] mutually-exclusive signals firing")
+   }
+
+
    // catch any BTB mispredictions (and fix-up missed JALs)
    bchecker.io.is_valid  := Vec(io.imem.resp.bits.mask.toBools)
    bchecker.io.imem_resp_valid := io.imem.resp.valid
@@ -246,19 +263,27 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    bchecker.io.br_targs := br_targs
    bchecker.io.jal_targs := jal_targs
    bchecker.io.fetch_pc := io.imem.resp.bits.pc
-   bchecker.io.aligned_pc := aligned_pc
+   bchecker.io.aligned_pc := f2_aligned_pc
    bchecker.io.btb_resp := io.f2_btb_resp
    bchecker.io.bpd_resp := io.f2_bpd_resp
-   bchecker.io.f2_bpu_request  := io.f2_bpu_request
+   bchecker.io.f2_bpu_request := io.f2_bpu_request
 
-   f2_req.valid := bchecker.io.req.valid && f2_valid && !(f0_redirect_val && !io.f2_bpu_request.valid)
-   f2_req.bits  := bchecker.io.req.bits
+   // who wins? bchecker or bpd?
+   val f2_bpd_overrides_bcheck = f2_bpd_may_redirect && (!bchecker.io.req.valid || (f2_bpd_redirect_cfiidx < bchecker.io.req_cfi_idx))
 
-   io.f2_btb_update := bchecker.io.btb_update
+
+   f2_req.valid := (bchecker.io.req.valid || f2_bpd_may_redirect) && f2_valid && !(f0_redirect_val && !io.f2_bpu_request.valid)
+   f2_req.bits.addr := Mux(f2_bpd_overrides_bcheck, f2_bpd_redirect_target, bchecker.io.req.bits.addr)
+
+
+   io.f2_btb_update := bchecker.io.btb_update // XXX let f3_bpd_redirect update the BTB too? or let BRU handle it?
    io.f2_ras_update := bchecker.io.ras_update
 
    // mask out instructions after predicted branch
-   val f2_kill_mask = KillMask(f2_req.valid, bchecker.io.req_cfi_idx, fetchWidth)
+   val f2_kill_mask = KillMask(
+      f2_req.valid,
+      Mux(f2_bpd_overrides_bcheck, f2_bpd_redirect_cfiidx, bchecker.io.req_cfi_idx),
+      fetchWidth)
 
    val btb_mask = Mux(io.f2_btb_resp.valid && !io.f2_bpu_request.valid && !f2_req.valid,
                   io.f2_btb_resp.bits.mask,
@@ -267,6 +292,60 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
                   io.f2_bpu_request.bits.mask,
                   Fill(fetchWidth, UInt(1,1)))
    f2_fetch_bundle.mask := io.imem.resp.bits.mask & ~f2_kill_mask & btb_mask & bpd_mask
+
+
+   val f2_taken = Wire(init=false.B) // was a branch taken in the F2 stage?
+   when (f2_req.valid)
+   {
+      // f2_bpd only requests taken redirections on btb misses.
+      // f2_req via bchecker only ever requests nextline_pc or jump targets (which we don't track in ghistory).
+      f2_taken := Mux(f2_bpd_overrides_bcheck, f2_bpd_may_redirect_taken, false.B)
+   }
+   .elsewhen (io.f2_bpu_request.valid)
+   {
+      f2_taken := io.f2_bpd_resp.bits.takens(io.f2_btb_resp.bits.cfi_idx)
+   }
+   .elsewhen (io.f2_btb_resp.valid)
+   {
+      f2_taken := io.f2_btb_resp.bits.taken
+   }
+
+   f2_valid := io.imem.resp.valid && !io.clear_fetchbuffer && !f3_req.valid
+   f2_fetch_bundle.pc := io.imem.resp.bits.pc
+   f2_fetch_bundle.xcpt_if := io.imem.resp.bits.xcpt_if
+   f2_fetch_bundle.replay_if := io.imem.resp.bits.replay
+
+   for (w <- 0 until fetch_width)
+   {
+      f2_fetch_bundle.bpu_info(w).btb_blame     := false.B
+      f2_fetch_bundle.bpu_info(w).btb_hit       := io.f2_btb_resp.valid
+      f2_fetch_bundle.bpu_info(w).btb_taken     := false.B
+
+      f2_fetch_bundle.bpu_info(w).bpd_blame     := false.B
+      f2_fetch_bundle.bpu_info(w).bpd_hit       := io.f2_bpd_resp.valid
+      f2_fetch_bundle.bpu_info(w).bpd_taken     := io.f2_bpd_resp.bits.takens(w.U)
+      f2_fetch_bundle.bpu_info(w).bim_resp      := io.f2_btb_resp.bits.bim_resp
+      f2_fetch_bundle.bpu_info(w).bpd_resp      := io.f2_bpd_resp.bits
+
+      when (w.U === f2_bpd_br_idx && f2_bpd_overrides_bcheck)
+      {
+         f2_fetch_bundle.bpu_info(w).bpd_blame := true.B
+      }
+      .elsewhen (w.U === io.f2_btb_resp.bits.cfi_idx && io.f2_bpu_request.valid && !f2_req.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).bpd_blame := true.B
+      }
+      .elsewhen (w.U === io.f2_btb_resp.bits.cfi_idx && io.f2_btb_resp.valid && !f2_req.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).btb_blame := true.B
+      }
+
+      when (w.U === io.f2_btb_resp.bits.cfi_idx && io.f2_btb_resp.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).btb_taken := io.f2_btb_resp.bits.taken
+      }
+   }
+
 
    //-------------------------------------------------------------
    // **** F3 ****
@@ -296,7 +375,6 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
          f3_fetch_bundle.bpu_info(w).bpd_resp.history_ptr := io.f3_bpd_resp.bits.history_ptr
       }
    }
-
 
    io.f3_hist_update.valid := f3_valid && (f3_br_seen || f3_jr_seen) && !if_stalled
    io.f3_hist_update.bits.taken := f3_jr_seen || f3_taken
@@ -471,6 +549,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
 // Verify BTB predicted the type and target of instructions correctly.
 // Also catch any JALs and redirect the frontend.
+// Also look at BPD's full prediction and decide to use it if no BTB hit.
 // Combinational logic.
 // If an error is found, redirect the front-end to refetch and correct the misprediction.
 // Incoming signals may be garbage (if f2_valid not true); consumer will have to handle that scenario.
@@ -493,7 +572,7 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
       val aligned_pc    = UInt(INPUT, width=vaddrBitsExtended)
 
       val btb_resp      = Valid(new BTBsaResp).flip
-      val bpd_resp      = Valid(new BpdResp).flip //TODO XXX hook up TODO let bpd_resp guide new taken branches if disagreement?
+      val bpd_resp      = Valid(new BpdResp).flip
       val f2_bpu_request= Valid(new BpuRequest).flip
 
       val btb_update    = Valid(new BTBsaUpdate)
@@ -554,15 +633,6 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
 
    val btb_was_wrong = io.btb_resp.valid && (wrong_cfi || wrong_target || !io.is_valid(btb_idx))
 
-   // Redirect if:
-   //    - JAL comes before BT's cfi_idx
-   //       * kill everything behind JAL -- including BTB's predinfo
-   //    - BTB was wrong
-   //       * if JAL, take JAL (if valid instructions available)
-   //       * if !JAL, request nextline (set all masks to valid).
-   //    - No JAL, BTB correct
-   //       * do nothing
-
    val jal_idx = PriorityEncoder(io.is_jal.toBits)
    val btb_hit  = io.btb_resp.valid
    val jal_wins = io.is_jal.reduce(_|_) &&
@@ -571,6 +641,18 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
       (jal_idx < btb_idx) ||
       (!io.f2_bpu_request.valid && !io.btb_resp.bits.taken) ||
       (io.f2_bpu_request.valid && !bpd_predicted_taken))
+
+   //-------------------------------------------------------------
+   // Perform redirection & updates
+
+   // Redirect if:
+   //    - JAL comes before BT's cfi_idx
+   //       * kill everything behind JAL -- including BTB's predinfo
+   //    - BTB was wrong
+   //       * if JAL, take JAL (if valid instructions available)
+   //       * if !JAL, request nextline (set all masks to valid).
+   //    - No JAL, BTB correct
+   //       * do nothing
 
    io.req.valid := jal_wins || btb_was_wrong
    io.req.bits.addr := Mux(jal_wins, io.jal_targs(jal_idx), nextline_pc)

--- a/src/main/scala/fetch.scala
+++ b/src/main/scala/fetch.scala
@@ -18,10 +18,11 @@ import Chisel._
 import config.Parameters
 
 import util.Str
+import util.UIntToAugmentedUInt
 
 class FetchBundle(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val pc          = UInt(width = vaddrBits+1)
+   val pc          = UInt(width = vaddrBitsExtended)
    val insts       = Vec(FETCH_WIDTH, Bits(width = 32))
    val mask        = Bits(width = FETCH_WIDTH) // mark which words are valid instructions
    val xcpt_if     = Bool()
@@ -44,7 +45,10 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    {
       val imem              = new rocket.FrontendIO
       val f0_btb            = Valid(new BTBsaResp).flip
-      val f2_bpu_info       = Valid(new BTBsaResp).flip
+      val f2_bpu_request    = Valid(new BpuRequest).flip
+
+      val f2_btb_resp       = Valid(new BTBsaResp).flip
+      val f2_bpd_resp       = Valid(new BpdResp).flip
       val f2_btb_update     = Valid(new BTBsaUpdate)
       val f2_ras_update     = Valid(new RasUpdate)
 
@@ -70,7 +74,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
    val br_unit = io.br_unit
    val fseq_reg = Reg(init = UInt(0, xLen))
-   val f0_redirect_pc = Wire(UInt(width = vaddrBits+1))
+   val f0_redirect_pc = Wire(UInt(width = vaddrBitsExtended))
 
    val f2_valid = Wire(Bool())
    val f2_req = Wire(Valid(new PCReq()))
@@ -102,6 +106,7 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    val f0_redirect_val =
       br_unit.take_pc ||
       io.flush_take_pc ||
+      (io.f2_bpu_request.valid && !if_stalled && io.imem.resp.valid) ||
       (f3_req.valid && !if_stalled) // TODO this seems way too low-level to get backpressure signal correct
 
    io.imem.req.valid   := f0_redirect_val // tell front-end we had an unexpected change in the stream
@@ -110,9 +115,13 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    io.imem.resp.ready  := !(if_stalled)
 
    f0_redirect_pc :=
-      Mux(io.flush_take_pc, io.flush_pc,
-      Mux(br_unit.take_pc,  br_unit.target(vaddrBits,0),
-         f3_req.bits.addr))
+      Mux(io.flush_take_pc,
+         io.flush_pc,
+      Mux(br_unit.take_pc,
+         br_unit.target(vaddrBits,0),
+      Mux(f3_req.valid,
+         f3_req.bits.addr,
+         io.f2_bpu_request.bits.target)))
 
    io.imem.ext_btb.resp := io.f0_btb
 
@@ -135,15 +144,31 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
    for (w <- 0 until fetch_width)
    {
-      f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(false)
-      f2_fetch_bundle.bpu_info(w).btb_taken := Bool(false)
-      f2_fetch_bundle.bpu_info(w).bim_resp  := io.f2_bpu_info.bits.bim_resp
+      f2_fetch_bundle.bpu_info(w).btb_predicted := false.B
+      f2_fetch_bundle.bpu_info(w).btb_hit       := false.B
+      f2_fetch_bundle.bpu_info(w).btb_taken     := false.B
+      f2_fetch_bundle.bpu_info(w).bpd_predicted := false.B
+      f2_fetch_bundle.bpu_info(w).bpd_taken     := false.B
+      f2_fetch_bundle.bpu_info(w).bim_resp      := io.f2_btb_resp.bits.bim_resp
+      f2_fetch_bundle.bpu_info(w).bpd_resp      := io.f2_bpd_resp.bits
 
-      when (UInt(w) === io.f2_bpu_info.bits.cfi_idx && io.f2_bpu_info.valid && !f2_req.valid)
+      when (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_bpu_request.valid && !f2_req.valid)
       {
-         f2_fetch_bundle.bpu_info(w).btb_hit   := Bool(true)
-         f2_fetch_bundle.bpu_info(w).btb_taken := io.f2_bpu_info.bits.taken
+         f2_fetch_bundle.bpu_info(w).bpd_predicted := true.B
+         f2_fetch_bundle.bpu_info(w).bpd_taken     := io.f2_bpd_resp.bits.takens(w.U)
       }
+      .elsewhen (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_btb_resp.valid && !f2_req.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).btb_predicted := true.B
+         f2_fetch_bundle.bpu_info(w).btb_taken := io.f2_btb_resp.bits.taken
+      }
+
+      when (UInt(w) === io.f2_btb_resp.bits.cfi_idx && io.f2_btb_resp.valid)
+      {
+         f2_fetch_bundle.bpu_info(w).btb_hit := true.B
+      }
+
+      assert (!(f2_fetch_bundle.bpu_info(w).btb_predicted && f2_fetch_bundle.bpu_info(w).bpd_predicted))
    }
 
 
@@ -182,6 +207,8 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
 
    // catch any BTB mispredictions (and fix-up missed JALs)
+   bchecker.io.is_valid  := Vec(io.imem.resp.bits.mask.toBools)
+   bchecker.io.imem_resp_valid := io.imem.resp.valid
    bchecker.io.is_br  := is_br
    bchecker.io.is_jal := is_jal
    bchecker.io.is_jr  := is_jr
@@ -190,25 +217,28 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
    bchecker.io.jal_targs := jal_targs
    bchecker.io.fetch_pc := io.imem.resp.bits.pc
    bchecker.io.aligned_pc := aligned_pc
-   bchecker.io.bpu_info := io.f2_bpu_info
-   // TODO, fix up f2_bpu_info
+   bchecker.io.btb_resp := io.f2_btb_resp
+   bchecker.io.bpd_resp := io.f2_bpd_resp
+   bchecker.io.f2_bpu_request  := io.f2_bpu_request
 
-
-   f2_req.valid := bchecker.io.req.valid && !f0_redirect_val && f2_valid
+   f2_req.valid := bchecker.io.req.valid && f2_valid && !(f0_redirect_val && !io.f2_bpu_request.valid)
    f2_req.bits  := bchecker.io.req.bits
 
    io.f2_btb_update := bchecker.io.btb_update
    io.f2_ras_update := bchecker.io.ras_update
 
    // mask out instructions after predicted branch
-   val btb_kill_mask = KillMask(f2_req.valid, bchecker.io.cfi_idx, fetchWidth)
+//   val btb_kill_mask = KillMask(f2_req.valid, bchecker.io.cfi_idx, fetchWidth)
    val f2_kill_mask = KillMask(f2_req.valid, bchecker.io.cfi_idx, fetchWidth)
    //val jr_kill_mask = KillMask(is_jr.reduce(_||_), PriorityEncoder(is_jr.asUInt), fetchWidth)
 
-   val btb_mask = Mux(f2_req.valid || !io.f2_bpu_info.valid,
-                  Fill(fetchWidth, UInt(1,1)),
-                  io.f2_bpu_info.bits.mask)
-   f2_fetch_bundle.mask := io.imem.resp.bits.mask & ~f2_kill_mask & btb_mask
+   val btb_mask = Mux(io.f2_btb_resp.valid && !io.f2_bpu_request.valid && !f2_req.valid,
+                  io.f2_btb_resp.bits.mask,
+                  Fill(fetchWidth, UInt(1,1)))
+   val bpd_mask = Mux(io.f2_bpu_request.valid && !f2_req.valid,
+                  io.f2_bpu_request.bits.mask,
+                  Fill(fetchWidth, UInt(1,1)))
+   f2_fetch_bundle.mask := io.imem.resp.bits.mask & ~f2_kill_mask & btb_mask & bpd_mask
 
    //-------------------------------------------------------------
    // **** F3 ****
@@ -287,6 +317,63 @@ class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p
 
    assert (!(io.imem.resp.bits.btb.valid), "[bpd_pipeline] BTB predicted, but it's been disabled.")
 
+   // check if enqueue'd PC is a target of the previous valid enqueue'd PC.
+
+   // clear checking if misprediction/flush/etc.
+   val last_valid = Reg(init=false.B)
+   val last_pc = Reg(UInt(width=vaddrBitsExtended))
+   val last_target = Reg(UInt(width=vaddrBitsExtended))
+   val last_nextlinepc = Reg(UInt(width=vaddrBitsExtended))
+   val last_cfi_type = Reg(UInt(width=CfiType.SZ))
+
+   val cfi_idx = (fetch_width-1).U - PriorityEncoder(Reverse(f3_fetch_bundle.mask))
+   val fetch_pc = f3_fetch_bundle.pc
+   val curr_aligned_pc = ~(~fetch_pc | (UInt(fetch_width*coreInstBytes-1)))
+   val cfi_pc = curr_aligned_pc  + (cfi_idx << 2.U)
+
+   when (FetchBuffer.io.enq.fire() && !f3_fetch_bundle.replay_if && !f3_fetch_bundle.xcpt_if)
+   {
+      assert (f3_fetch_bundle.mask =/= 0.U)
+      val curr_inst = if (fetchWidth == 0) f3_fetch_bundle.insts(0) else f3_fetch_bundle.insts(cfi_idx)
+      last_valid := true.B
+      last_pc := cfi_pc
+      last_nextlinepc := curr_aligned_pc + UInt(fetch_width*coreInstBytes)
+
+      val cfi_type = GetCfiType(curr_inst)
+      last_cfi_type := cfi_type
+      last_target := Mux(cfi_type === CfiType.jal,
+         ComputeJALTarget(cfi_pc, curr_inst, xLen, coreInstBytes),
+         ComputeBranchTarget(cfi_pc, curr_inst, xLen, coreInstBytes))
+
+      when (last_valid)
+      {
+         // check for error
+         when (last_cfi_type === CfiType.none)
+         {
+            assert (fetch_pc ===  last_nextlinepc, "[fetch] A non-cfi instruction is followed by the wrong instruction.")
+         }
+         .elsewhen (last_cfi_type === CfiType.jal)
+         {
+            assert (fetch_pc === last_target, "[fetch] JAL is followed by the wrong instruction.")
+         }
+         .elsewhen (last_cfi_type === CfiType.branch)
+         {
+            assert (fetch_pc === last_nextlinepc || fetch_pc === last_target, "[fetch] branch is followed by the wrong instruction.")
+         }
+         .otherwise
+         {
+            // we can't verify JALR instruction stream integrity --  /throws hands up.
+            assert (last_cfi_type === CfiType.jalr, "[fetch] Should be a JALR if none of the others were valid.")
+         }
+      }
+   }
+
+   when (io.clear_fetchbuffer || (FetchBuffer.io.enq.fire() && (f3_fetch_bundle.replay_if || f3_fetch_bundle.xcpt_if)))
+   {
+      last_valid := false.B
+   }
+
+
    //-------------------------------------------------------------
    // **** Printfs ****
    //-------------------------------------------------------------
@@ -355,17 +442,22 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    {
       val req           = Valid(new PCReq)
 
+      val is_valid      = Vec(fetch_width, Bool()).asInput // valid instruction mask from I$
       val is_br         = Vec(fetch_width, Bool()).asInput
       val is_jal        = Vec(fetch_width, Bool()).asInput
       val is_jr         = Vec(fetch_width, Bool()).asInput
       val is_call       = Vec(fetch_width, Bool()).asInput
+      val imem_resp_valid= Bool(INPUT)
 
       val br_targs      = Vec(fetch_width, UInt(width=vaddrBitsExtended)).asInput
       val jal_targs     = Vec(fetch_width, UInt(width=vaddrBitsExtended)).asInput
       val fetch_pc      = UInt(INPUT, width=vaddrBitsExtended)
       val aligned_pc    = UInt(INPUT, width=vaddrBitsExtended)
 
-      val bpu_info      = Valid(new BTBsaResp).flip
+      val btb_resp      = Valid(new BTBsaResp).flip
+      val bpd_resp      = Valid(new BpdResp).flip //TODO XXX hook up TODO let bpd_resp guide new taken branches if disagreement?
+      val f2_bpu_request= Valid(new BpuRequest).flip
+
       val btb_update    = Valid(new BTBsaUpdate)
       val ras_update    = Valid(new RasUpdate)
 
@@ -373,37 +465,57 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
 
    }
 
-   // Step #1: did the BTB mispredict the cfi type?
-   // Step #2: did the BTB mispredict the cfi target?
+   // Did the BTB mispredict the cfi type?
+   // Did the BTB mispredict the cfi target?
+   // Did the BTB predict a masked-off instruction?
    val wrong_cfi = Wire(init = false.B)
    val wrong_target = Wire(init = false.B)
 
-   val btb_idx = io.bpu_info.bits.cfi_idx
-   val btb_target = io.bpu_info.bits.target
-   when (io.bpu_info.valid)
+   val btb_idx = io.btb_resp.bits.cfi_idx
+   val btb_target = io.btb_resp.bits.target.sextTo(vaddrBitsExtended)
+   val bpd_predicted_taken = io.bpd_resp.valid && io.bpd_resp.bits.takens(io.btb_resp.bits.cfi_idx)
+
+   when (io.btb_resp.valid)
    {
-      when (io.bpu_info.bits.cfi_type === CFIType.branch && io.bpu_info.bits.taken)
+      when (io.btb_resp.bits.cfi_type === CfiType.branch && (io.btb_resp.bits.taken || bpd_predicted_taken))
       {
          wrong_cfi := !io.is_br(btb_idx)
          wrong_target := io.br_targs(btb_idx) =/= btb_target
       }
-      .elsewhen (io.bpu_info.bits.cfi_type === CFIType.jal)
+      .elsewhen (io.btb_resp.bits.cfi_type === CfiType.jal)
       {
          wrong_cfi := !io.is_jal(btb_idx)
          wrong_target := io.jal_targs(btb_idx) =/= btb_target
       }
-      .elsewhen (io.bpu_info.bits.cfi_type === CFIType.jalr)
+      .elsewhen (io.btb_resp.bits.cfi_type === CfiType.jalr)
       {
          wrong_cfi := !io.is_jr(btb_idx)
       }
       .otherwise
       {
-         wrong_cfi := io.bpu_info.bits.cfi_type === CFIType.none && io.bpu_info.bits.taken
-         assert (!io.bpu_info.bits.cfi_type === CFIType.none, "[btb] predicted on a non-cfi type.")
+         wrong_cfi := io.btb_resp.bits.cfi_type === CfiType.none && io.btb_resp.bits.taken
+         assert (!io.btb_resp.bits.cfi_type === CfiType.none, "[fetch] predicted on a non-cfi type.")
       }
    }
+   .otherwise
+   {
+      assert (!io.f2_bpu_request.valid, "[fetch] F2 redirect despite no BTB hit.")
+   }
 
-   val btb_was_wrong = io.bpu_info.valid && (wrong_cfi || wrong_target)
+   val nextline_pc = io.aligned_pc + UInt(fetch_width*coreInstBytes)
+
+   when (io.f2_bpu_request.valid && io.imem_resp_valid)
+   {
+      // f2 stage (BPD) decided to disagree with the BTB.
+      assert (io.btb_resp.valid, "[fetch] f2 redirect but no btb hit.")
+      assert (io.btb_resp.bits.taken || bpd_predicted_taken, "[fetch] redirecting means one of these should be true.")
+      assert (!bpd_predicted_taken || btb_target === io.f2_bpu_request.bits.target,
+         "[fetch] redirecting target disagrees with BTB -- and it should have come from the BTB.")
+      assert (bpd_predicted_taken || nextline_pc === io.f2_bpu_request.bits.target,
+         "[fetch] BPD is redirecting PC to not-taken, but seems confused on what PC we're actually on!")
+   }
+
+   val btb_was_wrong = io.btb_resp.valid && (wrong_cfi || wrong_target || !io.is_valid(btb_idx))
 
    // Redirect if:
    //    - JAL comes before BT's cfi_idx
@@ -415,9 +527,13 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    //       * do nothing
 
    val jal_idx = PriorityEncoder(io.is_jal.toBits)
-   val btb_hit  = io.bpu_info.valid
-   val jal_wins = io.is_jal.reduce(_|_) && (!btb_hit || btb_was_wrong || !io.bpu_info.bits.taken || (jal_idx < btb_idx))
-   val nextline_pc = io.aligned_pc + UInt(fetch_width*coreInstBytes)
+   val btb_hit  = io.btb_resp.valid
+   val jal_wins = io.is_jal.reduce(_|_) &&
+      (!btb_hit ||
+      btb_was_wrong ||
+      (jal_idx < btb_idx) ||
+      (!io.f2_bpu_request.valid && !io.btb_resp.bits.taken) ||
+      (io.f2_bpu_request.valid && !bpd_predicted_taken))
 
    io.req.valid := jal_wins || btb_was_wrong
    io.req.bits.addr := Mux(jal_wins, io.jal_targs(jal_idx), nextline_pc)
@@ -432,7 +548,7 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    io.btb_update.bits.taken := true.B
    io.btb_update.bits.cfi_pc := jal_idx
    io.btb_update.bits.bpd_type := Mux(io.is_call(jal_idx), BpredType.call, BpredType.jump)
-   io.btb_update.bits.cfi_type := CFIType.jal
+   io.btb_update.bits.cfi_type := CfiType.jal
 
    io.ras_update.valid := jal_wins && io.is_call(jal_idx)
    io.ras_update.bits.is_call := true.B

--- a/src/main/scala/fppipeline.scala
+++ b/src/main/scala/fppipeline.scala
@@ -65,7 +65,8 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p)
                                  exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum - 1 +
                                     num_ll_ports,
                                  fLen+1,
-                                 ENABLE_REGFILE_BYPASSING))// TODO disable for FP
+                                 exe_units.bypassable_write_port_mask
+                                 ))
                           else
                               Module(new RegisterFileSeq(numFpPhysRegs,
                                  exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_read_ports).sum,
@@ -73,7 +74,8 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p)
                                  exe_units.withFilter(_.uses_iss_unit).map(e => e.num_rf_write_ports).sum - 1 +
                                     num_ll_ports,
                                  fLen+1,
-                                 ENABLE_REGFILE_BYPASSING))
+                                 exe_units.bypassable_write_port_mask
+                                 ))
    val fregister_read   = Module(new RegisterRead(
                            issue_unit.issue_width,
                            exe_units.withFilter(_.uses_iss_unit).map(_.supportedFuncUnits),

--- a/src/main/scala/functional_unit.scala
+++ b/src/main/scala/functional_unit.scala
@@ -401,18 +401,18 @@ class ALUUnit(is_branch_unit: Boolean = false, num_stages: Int = 1)(implicit p: 
          when (pc_sel === PC_PLUS4)
          {
             mispredict :=
-               Mux(uop.br_prediction.wasBTB,
+               Mux(uop.br_prediction.btb_blame,
                   btb_mispredict,
-               Mux(uop.br_prediction.bpd_predicted,
+               Mux(uop.br_prediction.bpd_blame,
                   bpd_mispredict,
                   false.B)) // if neither BTB nor BPD predicted and it's not-taken, then no misprediction occurred.
          }
          when (pc_sel === PC_BRJMP)
          {
             mispredict :=
-               Mux(uop.br_prediction.wasBTB,
+               Mux(uop.br_prediction.btb_blame,
                   btb_mispredict,
-               Mux(uop.br_prediction.bpd_predicted,
+               Mux(uop.br_prediction.bpd_blame,
                   bpd_mispredict,
                   true.B)) // if neither BTB nor BPD predicted and it's taken, then a misprediction occurred.
 
@@ -450,8 +450,8 @@ class ALUUnit(is_branch_unit: Boolean = false, num_stages: Int = 1)(implicit p: 
       brinfo.taken          := is_taken
       brinfo.btb_mispredict := btb_mispredict
       brinfo.bpd_mispredict := bpd_mispredict
-      brinfo.btb_made_pred  := uop.br_prediction.wasBTB
-      brinfo.bpd_made_pred  := uop.br_prediction.bpd_predicted
+      brinfo.btb_made_pred  := uop.br_prediction.btb_blame
+      brinfo.bpd_made_pred  := uop.br_prediction.bpd_blame
 
       br_unit.brinfo := brinfo
 
@@ -502,7 +502,7 @@ class ALUUnit(is_branch_unit: Boolean = false, num_stages: Int = 1)(implicit p: 
       br_unit.bpd_update.bits.brob_idx         := io.get_rob_pc.curr_brob_idx
       br_unit.bpd_update.bits.taken            := is_taken
       br_unit.bpd_update.bits.mispredict       := mispredict
-      br_unit.bpd_update.bits.bpd_predict_val  := uop.br_prediction.bpd_predicted
+      br_unit.bpd_update.bits.bpd_predict_val  := uop.br_prediction.bpd_hit
       br_unit.bpd_update.bits.bpd_mispredict   := bpd_mispredict
       br_unit.bpd_update.bits.pc               := fetch_pc
       br_unit.bpd_update.bits.br_pc            := uop_pc_

--- a/src/main/scala/functional_unit.scala
+++ b/src/main/scala/functional_unit.scala
@@ -400,11 +400,22 @@ class ALUUnit(is_branch_unit: Boolean = false, num_stages: Int = 1)(implicit p: 
          }
          when (pc_sel === PC_PLUS4)
          {
-            mispredict := Mux(uop.br_prediction.wasBTB, btb_mispredict, bpd_mispredict)
+            mispredict :=
+               Mux(uop.br_prediction.wasBTB,
+                  btb_mispredict,
+               Mux(uop.br_prediction.bpd_predicted,
+                  bpd_mispredict,
+                  false.B)) // if neither BTB nor BPD predicted and it's not-taken, then no misprediction occurred.
          }
          when (pc_sel === PC_BRJMP)
          {
-            mispredict := Mux(uop.br_prediction.wasBTB, btb_mispredict, bpd_mispredict)
+            mispredict :=
+               Mux(uop.br_prediction.wasBTB,
+                  btb_mispredict,
+               Mux(uop.br_prediction.bpd_predicted,
+                  bpd_mispredict,
+                  true.B)) // if neither BTB nor BPD predicted and it's taken, then a misprediction occurred.
+
          }
       }
 

--- a/src/main/scala/gshare.scala
+++ b/src/main/scala/gshare.scala
@@ -68,10 +68,9 @@ class GShareBrPredictor(
    //------------------------------------------------------------
    // Get prediction.
 
-   val stall = !io.resp.ready //TODO XXX? Do we need to know if a redirect is happening which kills stalled instructions? Correct answer is probably to change io.req_pc to s1_pc.
+   val stall = !io.resp.ready
 
-   val s0_pc = io.req_pc
-   val s1_pc = RegEnable(s0_pc, !stall) // CODE REVIEW
+   val s1_pc = io.req_pc
    val s1_ridx = Hash(s1_pc, this.ghistory)
 
    counters.io.s1_r_idx := s1_ridx

--- a/src/main/scala/gshare.scala
+++ b/src/main/scala/gshare.scala
@@ -68,16 +68,19 @@ class GShareBrPredictor(
    //------------------------------------------------------------
    // Get prediction.
 
-   val stall = !io.resp.ready
+   val stall = !io.resp.ready //TODO XXX? Do we need to know if a redirect is happening which kills stalled instructions? Correct answer is probably to change io.req_pc to s1_pc.
 
-   val r_idx = Hash(io.req_pc, this.ghistory)
-   counters.io.s0_r_idx := r_idx
+   val s0_pc = io.req_pc
+   val s1_pc = RegEnable(s0_pc, !stall) // CODE REVIEW
+   val s1_ridx = Hash(s1_pc, this.ghistory)
+
+   counters.io.s1_r_idx := s1_ridx
    counters.io.stall := stall
 
    val resp_info = Wire(new GShareResp(log2Up(num_entries)))
-   resp_info.index      := RegNext(RegNext(r_idx))
+   resp_info.index      := RegNext(s1_ridx)
    io.resp.bits.takens  := counters.io.s2_r_out
-   io.resp.bits.info    := resp_info.toBits
+   io.resp.bits.info    := resp_info.asUInt
 
    // Always overrule the BTB, which will almost certainly have less history.
    io.resp.valid := Bool(true) && !this.disable_bpd

--- a/src/main/scala/gskew.scala
+++ b/src/main/scala/gskew.scala
@@ -209,14 +209,16 @@ class GSkewBrPredictor(fetch_width: Int,
    gsh1_table.io.stall := stall
    meta_table.io.stall := stall
 
-   val bimo_idx = BimoIdxHash(io.req_pc, this.ghistory, bimo_idx_sz)
-   val gsh0_idx = Gsh0IdxHash(io.req_pc, this.ghistory, gsh0_idx_sz)
-   val gsh1_idx = Gsh1IdxHash(io.req_pc, this.ghistory, gsh1_idx_sz)
-   val meta_idx = MetaIdxHash(io.req_pc, this.ghistory, meta_idx_sz)
-   bimo_table.io.s0_r_idx := bimo_idx
-   gsh0_table.io.s0_r_idx := gsh0_idx
-   gsh1_table.io.s0_r_idx := gsh1_idx
-   meta_table.io.s0_r_idx := meta_idx
+   val s0_pc = io.req_pc
+   val s1_pc = RegEnable(s0_pc, !stall)
+   val bimo_idx = BimoIdxHash(s1_pc, this.ghistory, bimo_idx_sz)
+   val gsh0_idx = Gsh0IdxHash(s1_pc, this.ghistory, gsh0_idx_sz)
+   val gsh1_idx = Gsh1IdxHash(s1_pc, this.ghistory, gsh1_idx_sz)
+   val meta_idx = MetaIdxHash(s1_pc, this.ghistory, meta_idx_sz)
+   bimo_table.io.s1_r_idx := bimo_idx
+   gsh0_table.io.s1_r_idx := gsh0_idx
+   gsh1_table.io.s1_r_idx := gsh1_idx
+   meta_table.io.s1_r_idx := meta_idx
    bimo_out  := bimo_table.io.s2_r_out
    gsh0_out  := gsh0_table.io.s2_r_out
    gsh1_out  := gsh1_table.io.s2_r_out
@@ -246,10 +248,10 @@ class GSkewBrPredictor(fetch_width: Int,
 
    io.resp.bits.takens := takens.asUInt
 
-   resp_info.bimo_index := RegNext(RegNext(bimo_idx))
-   resp_info.gsh0_index := RegNext(RegNext(gsh0_idx))
-   resp_info.gsh1_index := RegNext(RegNext(gsh1_idx))
-   resp_info.meta_index := RegNext(RegNext(meta_idx))
+   resp_info.bimo_index := RegNext(bimo_idx)
+   resp_info.gsh0_index := RegNext(gsh0_idx)
+   resp_info.gsh1_index := RegNext(gsh1_idx)
+   resp_info.meta_index := RegNext(meta_idx)
    resp_info.bimo       := bimo_out
    resp_info.gsh0       := gsh0_out
    resp_info.gsh1       := gsh1_out

--- a/src/main/scala/gskew.scala
+++ b/src/main/scala/gskew.scala
@@ -209,8 +209,7 @@ class GSkewBrPredictor(fetch_width: Int,
    gsh1_table.io.stall := stall
    meta_table.io.stall := stall
 
-   val s0_pc = io.req_pc
-   val s1_pc = RegEnable(s0_pc, !stall)
+   val s1_pc = io.req_pc
    val bimo_idx = BimoIdxHash(s1_pc, this.ghistory, bimo_idx_sz)
    val gsh0_idx = Gsh0IdxHash(s1_pc, this.ghistory, gsh0_idx_sz)
    val gsh1_idx = Gsh1IdxHash(s1_pc, this.ghistory, gsh1_idx_sz)

--- a/src/main/scala/lsu.scala
+++ b/src/main/scala/lsu.scala
@@ -1262,7 +1262,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
    {
       val l_temp = laq_tail + UInt(w)
       laq_is_full = ((l_temp === laq_head || l_temp === (laq_head + UInt(num_ld_entries))) && laq_maybe_full) | laq_is_full
-      val s_temp = stq_tail + UInt(w+1) // TODO XXX this +1 is almost certainly wrong - look at this again
+      val s_temp = stq_tail + UInt(w+1) // +1 since we don't do let SAQ completely fill up.
       stq_is_full = (s_temp === stq_head || s_temp === (stq_head + UInt(num_st_entries))) | stq_is_full
    }
 
@@ -1274,6 +1274,8 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
    io.new_stq_idx := stq_tail
 
    io.lsu_fencei_rdy := stq_empty && io.dmem_is_ordered
+
+   assert (!(stq_empty ^ stq_entry_val.asUInt === 0.U), "[lsu] mismatch in SAQ empty logic.")
 
    //-------------------------------------------------------------
    // Debug & Counter outputs

--- a/src/main/scala/lsu.scala
+++ b/src/main/scala/lsu.scala
@@ -380,6 +380,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: uncore.tilelink
    val ma_ld = io.exe_resp.valid && io.exe_resp.bits.mxcpt.valid && exe_tlb_uop.is_load
    val pf_ld = dtlb.io.req.valid && dtlb.io.resp.xcpt_ld && exe_tlb_uop.is_load
    val pf_st = dtlb.io.req.valid && dtlb.io.resp.xcpt_st && exe_tlb_uop.is_store
+   // TODO check for xcpt_if and verify that never happens on non-speculative instructions.
    val mem_xcpt_valid = Reg(next=((dtlb.io.req.valid && (pf_ld || pf_st)) ||
                                  (io.exe_resp.valid && io.exe_resp.bits.mxcpt.valid)) &&
                                  !io.exception &&

--- a/src/main/scala/microop.scala
+++ b/src/main/scala/microop.scala
@@ -36,7 +36,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val br_mask          = UInt(width = MAX_BR_COUNT)  // which branches are we being speculated under?
    val br_tag           = UInt(width = BR_TAG_SZ)
 
-   val br_prediction    = new BranchPrediction
+   val br_prediction    = new BranchPredInfo
 
    // stat tracking of committed instructions
    val stat_brjmp_mispredicted = Bool()                 // number of mispredicted branches/jmps
@@ -131,6 +131,17 @@ class DebugStageEvents extends Bundle()
 {
    // Track the sequence number of each instruction fetched.
    val fetch_seq        = UInt(width = 32)
+}
+
+// What type of Control-Flow Instruction is it?
+object CFIType
+{
+   def SZ = 3
+   def apply() = UInt(width = SZ)
+   def none = 0.U
+   def branch = 1.U
+   def jal = 2.U
+   def jalr = 3.U
 }
 
 class MicroOpWithData(data_sz: Int)(implicit p: Parameters) extends BoomBundle()(p)

--- a/src/main/scala/microop.scala
+++ b/src/main/scala/microop.scala
@@ -134,7 +134,7 @@ class DebugStageEvents extends Bundle()
 }
 
 // What type of Control-Flow Instruction is it?
-object CFIType
+object CfiType
 {
    def SZ = 3
    def apply() = UInt(width = SZ)

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -22,22 +22,24 @@ case class BoomCoreParams(
    numIntPhysRegisters: Int = 96,
    numFpPhysRegisters: Int = 64,
    maxBrCount: Int = 4,
-   fetchBufferSz: Int = 4,
+   fetchBufferSz: Int = 8,
    enableAgePriorityIssue: Boolean = true,
    enablePrefetching: Boolean = false,
-   enableFetchBufferFlowThrough: Boolean = false,
+   enableFetchBufferFlowThrough: Boolean = true,
    enableBrResolutionRegister: Boolean = true,
    enableCommitMapTable: Boolean = false,
    enableBTBContainsBranches: Boolean = true,
-   enableBranchPredictor: Boolean = true,
+   enableBIM: Boolean = true,
+   enableBranchPredictor: Boolean = false,
    enableBpdUModeOnly: Boolean = false,
    enableBpdUSModeHistory: Boolean = false,
+   btb: BTBsaParameters = BTBsaParameters(),
    tage: Option[TageParameters] = None,
    gshare: Option[GShareParameters] = None,
    gskew: Option[GSkewParameters] = None,
    intToFpLatency: Int = 2,
    imulLatency: Int = 3,
-   fetchLatency: Int = 2,
+   fetchLatency: Int = 3,
    renameLatency: Int = 2,
    regreadLatency: Int = 1
 )
@@ -94,6 +96,7 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    val intToFpLatency = boomParams.intToFpLatency
 
    val fetchLatency = boomParams.fetchLatency // how many cycles does fetch occupy?
+   require (fetchLatency == 3) // do not currently support changing this
    val renameLatency = boomParams.renameLatency // how many cycles does rename occupy?
    val regreadLatency = boomParams.regreadLatency // how many cycles does rrd occupy?
    require (regreadLatency == 0 || regreadLatency == 1)
@@ -105,7 +108,7 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
 
    val issueParams: Seq[IssueParams] = boomParams.issueParams
    val enableAgePriorityIssue = boomParams.enableAgePriorityIssue
-   
+
    // currently, only support one of each.
    require (issueParams.count(_.iqType == IQT_FP.litValue) == 1)
    require (issueParams.count(_.iqType == IQT_MEM.litValue) == 1)
@@ -116,13 +119,14 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    val dcacheParams: DCacheParams = tileParams.dcache.get
    val nTLBEntries = dcacheParams.nTLBEntries
 
+   val icacheParams: ICacheParams = tileParams.icache.get
+
    //************************************
    // Branch Prediction
 
-   val enableBTB = tileParams.btb.isDefined
-   val btbParams: rocket.BTBParams = tileParams.btb.get
-
+   val enableBTB = true
    val enableBTBContainsBranches = boomParams.enableBTBContainsBranches
+   val enableBIM = boomParams.enableBIM
 
    val ENABLE_BRANCH_PREDICTOR = boomParams.enableBranchPredictor
    val ENABLE_BPD_UMODE_ONLY = boomParams.enableBpdUModeOnly

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -21,6 +21,8 @@ case class BoomCoreParams(
    numLsuEntries: Int = 8,
    numIntPhysRegisters: Int = 96,
    numFpPhysRegisters: Int = 64,
+   enableCustomRf: Boolean = false,
+   enableCustomRfModel: Boolean = true,
    maxBrCount: Int = 4,
    fetchBufferSz: Int = 8,
    enableAgePriorityIssue: Boolean = true,
@@ -218,6 +220,12 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    require (isPow2(NUM_LSU_ENTRIES))
    require ((NUM_LSU_ENTRIES-1) > DECODE_WIDTH)
 
+
+   //************************************
+   // Custom Logic
+
+   val enableCustomRf      = boomParams.enableCustomRf
+   val enableCustomRfModel = boomParams.enableCustomRfModel
 
    //************************************
    // Non-BOOM parameters

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -33,6 +33,7 @@ case class BoomCoreParams(
    enableBranchPredictor: Boolean = false,
    enableBpdUModeOnly: Boolean = false,
    enableBpdUSModeHistory: Boolean = false,
+   enableBpdF2Redirect: Boolean = true,
    btb: BTBsaParameters = BTBsaParameters(),
    tage: Option[TageParameters] = None,
    gshare: Option[GShareParameters] = None,
@@ -129,6 +130,10 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
    val enableBIM = boomParams.enableBIM
 
    val ENABLE_BRANCH_PREDICTOR = boomParams.enableBranchPredictor
+
+   // allow the BPD to redirect the PC in the F2 stage (hurts critical path).
+   val enableBpdF2Redirect = boomParams.enableBpdF2Redirect
+
    val ENABLE_BPD_UMODE_ONLY = boomParams.enableBpdUModeOnly
    val ENABLE_BPD_USHISTORY = boomParams.enableBpdUSModeHistory
    // What is the maximum length of global history tracked?

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -35,7 +35,8 @@ case class BoomCoreParams(
    enableBranchPredictor: Boolean = false,
    enableBpdUModeOnly: Boolean = false,
    enableBpdUSModeHistory: Boolean = false,
-   enableBpdF2Redirect: Boolean = true,
+   enableBpdF2Redirect: Boolean = false,
+   enableBpdF3Redirect: Boolean = true,
    btb: BTBsaParameters = BTBsaParameters(),
    tage: Option[TageParameters] = None,
    gshare: Option[GShareParameters] = None,
@@ -135,6 +136,7 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
 
    // allow the BPD to redirect the PC in the F2 stage (hurts critical path).
    val enableBpdF2Redirect = boomParams.enableBpdF2Redirect
+   val enableBpdF3Redirect = boomParams.enableBpdF3Redirect
 
    val ENABLE_BPD_UMODE_ONLY = boomParams.enableBpdUModeOnly
    val ENABLE_BPD_USHISTORY = boomParams.enableBpdUSModeHistory

--- a/src/main/scala/parameters.scala
+++ b/src/main/scala/parameters.scala
@@ -186,7 +186,6 @@ trait HasBoomCoreParameters extends tile.HasCoreParameters
 
    //************************************
    // Extra Knobs and Features
-   val ENABLE_REGFILE_BYPASSING  = true  // bypass regfile write ports to read ports
    val ENABLE_COMMIT_MAP_TABLE = boomParams.enableCommitMapTable
 
    //************************************

--- a/src/main/scala/regfile-custom.scala
+++ b/src/main/scala/regfile-custom.scala
@@ -67,8 +67,10 @@ class RegisterFileSeqCustomArray(
       }
 
       //printf("regfile.WS(%d)=%d, ws_OH=0x%x\n", i.U, regfile.io.WS(i), write_select_OH(i))
-      assert(PopCount(write_select_OH(i).toBools) <= 1.U,
-         "[regfile] write-select has too many writers to this register p[" + i + "]")
+      if (i > 0) {
+         assert(PopCount(write_select_OH(i).toBools) <= 1.U,
+            "[regfile] write-select has too many writers to this register p[" + i + "]")
+      }
    }
 
 

--- a/src/main/scala/regfile-custom.scala
+++ b/src/main/scala/regfile-custom.scala
@@ -1,0 +1,266 @@
+//******************************************************************************
+// Copyright (c) 2015, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// RISCV Processor Datapath Register File (Custom Blackboxes and Models)
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+package boom
+
+import Chisel._
+import config.Parameters
+
+import scala.collection.mutable.ArrayBuffer
+
+class RegisterFileSeqCustomArray(
+   num_registers: Int,
+   num_read_ports: Int,
+   num_write_ports: Int,
+   register_width: Int,
+   bypassable_array: Seq[Boolean])
+   (implicit p: Parameters)
+   extends RegisterFile(num_registers, num_read_ports, num_write_ports, register_width, bypassable_array)
+{
+
+   // --------------------------------------------------------------
+
+   val regfile =
+      if (enableCustomRfModel)
+         Module(new RegisterFileArrayModel(num_registers, num_read_ports, num_write_ports, register_width))
+      else
+         Module(new RegisterFileArray(num_registers, num_read_ports, num_write_ports, register_width))
+   regfile.io.clock := clock
+
+  // Decode addr
+   val waddr_OH = Wire(Vec(num_write_ports, UInt(width = num_registers)))
+   val raddr_OH = Reg(Vec(num_read_ports, UInt(width = num_registers)))
+   val write_select_OH = Wire(Vec(num_registers, UInt(width = num_write_ports)))
+
+   for (w <-0 until num_write_ports) {
+      regfile.io.WD(w) := io.write_ports(w).bits.data
+      waddr_OH(w) := UIntToOH(io.write_ports(w).bits.addr)
+      io.write_ports(w).ready := Bool(true)
+   }
+
+   val read_data = Wire(Vec(num_read_ports, UInt(width = register_width)))
+   for (r <-0 until num_read_ports) {
+      read_data(r) := Mux(RegNext(io.read_ports(r).addr === 0.U), 0.U, regfile.io.RD(r))
+      raddr_OH(r) := UIntToOH(io.read_ports(r).addr)
+   }
+
+   for (i <- 0 until num_registers) {
+      regfile.io.OE(i) := Cat(raddr_OH(5)(i), raddr_OH(4)(i), raddr_OH(3)(i), raddr_OH(2)(i), raddr_OH(1)(i), raddr_OH(0)(i))
+      write_select_OH(i) := Cat(
+         waddr_OH(2)(i) && io.write_ports(2).valid,
+         waddr_OH(1)(i) && io.write_ports(1).valid,
+         waddr_OH(0)(i) && io.write_ports(0).valid)
+      regfile.io.WE(i) := write_select_OH(i).orR
+      regfile.io.WS(i) := OHToUInt(write_select_OH(i))
+
+      //printf("regfile.WS(%d)=%d, ws_OH=0x%x\n", i.U, regfile.io.WS(i), write_select_OH(i))
+      assert(PopCount(write_select_OH(i).toBools) <= 1.U,
+         "[regfile] write-select has too many writers to this register p[" + i + "]")
+   }
+
+
+   // --------------------------------------------------------------
+   // Bypass out of the ALU's write ports.
+
+   require (bypassable_array.length == io.write_ports.length)
+
+   if (bypassable_array.reduce(_||_))
+   {
+      val bypassable_wports = ArrayBuffer[DecoupledIO[RegisterFileWritePort]]()
+      io.write_ports zip bypassable_array map { case (wport, b) => if (b) { bypassable_wports += wport} }
+
+      for (i <- 0 until num_read_ports)
+      {
+         val bypass_ens = bypassable_wports.map(x => x.valid &&
+                                                  x.bits.addr =/= UInt(0) &&
+                                                  x.bits.addr === RegNext(io.read_ports(i).addr))
+
+         val bypass_data = Mux1H(Vec(bypass_ens), Vec(bypassable_wports.map(_.bits.data)))
+
+         io.read_ports(i).data := Mux(bypass_ens.reduce(_|_), bypass_data, read_data(i))
+      }
+   }
+   else
+   {
+      for (i <- 0 until num_read_ports)
+      {
+         io.read_ports(i).data := read_data(i)
+      }
+   }
+}
+
+class RegisterFileArray(
+   num_registers: Int,
+   num_read_ports: Int,
+   num_write_ports: Int,
+   register_width: Int)
+   extends BlackBox
+{
+   val io = new Bundle {
+      val clock = Clock(INPUT)
+      val WE = Vec(num_registers, Bool()).asInput
+      val WD = Vec(num_write_ports, UInt(width = register_width)).asInput
+      val RD = Vec(num_read_ports, UInt(width = register_width)).asOutput
+      val WS = Vec(num_registers, UInt(width = 2)).asInput
+      val OE = Vec(num_registers, UInt(width = num_read_ports)).asInput
+   }
+}
+
+
+// This is a model of the above blackbox RegisterFileArray. Don't ship this.
+class RegisterFileArrayModel(
+   num_registers: Int,
+   num_read_ports: Int,
+   num_write_ports: Int,
+   register_width: Int)
+   extends Module
+{
+   val io = new Bundle {
+      val clock = Clock(INPUT)
+      val WE = Vec(num_registers, Bool()).asInput
+      val WS = Vec(num_registers, UInt(width = 2)).asInput
+      val WD = Vec(num_write_ports, UInt(width = register_width)).asInput
+      val OE = Vec(num_registers, UInt(width = num_read_ports)).asInput
+      val RD = Vec(num_read_ports, UInt(width = register_width)).asOutput
+   }
+
+   // Where we're going, we don't need roads. Or parameterization.
+   require (num_read_ports == 6)
+   require (num_write_ports == 3)
+   require (register_width == 64)
+
+   for (i <- 0 until num_registers) yield
+   {
+      val register = Module(new RegisterFile6r3wRegisterModel())
+      register.io.we := io.WE(i)
+      register.io.ws := io.WS(i)
+      register.io.wd0 := io.WD(0)
+      register.io.wd1 := io.WD(1)
+      register.io.wd2 := io.WD(2)
+      register.io.oe  := io.OE(i)
+
+      // cheat a bit, since we don't simulate tri-states fighting over a single wire.
+      when (io.OE(i)(0)) { io.RD(0) := register.io.rd0 }
+      when (io.OE(i)(1)) { io.RD(1) := register.io.rd1 }
+      when (io.OE(i)(2)) { io.RD(2) := register.io.rd2 }
+      when (io.OE(i)(3)) { io.RD(3) := register.io.rd3 }
+      when (io.OE(i)(4)) { io.RD(4) := register.io.rd4 }
+      when (io.OE(i)(5)) { io.RD(5) := register.io.rd5 }
+   }
+
+   // assert only one reader set for each read port.
+   assert (PopCount(io.OE.map(e => e(0))) <= 1.U, "[rf] OE(*)(0) has too many enables set.")
+   assert (PopCount(io.OE.map(e => e(1))) <= 1.U, "[rf] OE(*)(1) has too many enables set.")
+   assert (PopCount(io.OE.map(e => e(2))) <= 1.U, "[rf] OE(*)(2) has too many enables set.")
+   assert (PopCount(io.OE.map(e => e(3))) <= 1.U, "[rf] OE(*)(3) has too many enables set.")
+   assert (PopCount(io.OE.map(e => e(4))) <= 1.U, "[rf] OE(*)(4) has too many enables set.")
+   assert (PopCount(io.OE.map(e => e(5))) <= 1.U, "[rf] OE(*)(5) has too many enables set.")
+}
+
+
+// This is a model of a register file row (which covers one register). Don't ship this either.
+class RegisterFile6r3wRegisterModel extends Module
+{
+   val io = new Bundle {
+      val we  = Bool(INPUT)
+      val ws  = UInt(INPUT, width = 2)
+      val wd0 = UInt(INPUT, width = 64)
+      val wd1 = UInt(INPUT, width = 64)
+      val wd2 = UInt(INPUT, width = 64)
+      val oe  = UInt(INPUT, width = 6)
+      val rd0 = UInt(OUTPUT, width = 64)
+      val rd1 = UInt(OUTPUT, width = 64)
+      val rd2 = UInt(OUTPUT, width = 64)
+      val rd3 = UInt(OUTPUT, width = 64)
+      val rd4 = UInt(OUTPUT, width = 64)
+      val rd5 = UInt(OUTPUT, width = 64)
+   }
+
+   val rd0 = Wire(Vec(64, Bool()))
+   val rd1 = Wire(Vec(64, Bool()))
+   val rd2 = Wire(Vec(64, Bool()))
+   val rd3 = Wire(Vec(64, Bool()))
+   val rd4 = Wire(Vec(64, Bool()))
+   val rd5 = Wire(Vec(64, Bool()))
+
+   for (i <- 0 until 64) yield
+   {
+      val bit = Module(new Rf6r3wBitModel())
+      bit.io.we := io.we
+      bit.io.ws := io.ws
+      bit.io.wd0 := io.wd0(i)
+      bit.io.wd1 := io.wd1(i)
+      bit.io.wd2 := io.wd2(i)
+      bit.io.oe := io.oe
+      rd0(i) := bit.io.rd0
+      rd1(i) := bit.io.rd1
+      rd2(i) := bit.io.rd2
+      rd3(i) := bit.io.rd3
+      rd4(i) := bit.io.rd4
+      rd5(i) := bit.io.rd5
+   }
+
+   io.rd0 := rd0.asUInt
+   io.rd1 := rd1.asUInt
+   io.rd2 := rd2.asUInt
+   io.rd3 := rd3.asUInt
+   io.rd4 := rd4.asUInt
+   io.rd5 := rd5.asUInt
+
+}
+
+
+// This is only a model of a register file bit. Warranty voided if synthesized.
+class Rf6r3wBitModel extends Module
+{
+   val io = new Bundle {
+      val we  = Bool(INPUT)
+      val ws  = UInt(INPUT, width = 2)
+      val wd0 = Bool(INPUT)
+      val wd1 = Bool(INPUT)
+      val wd2 = Bool(INPUT)
+      val oe  = UInt(INPUT, width = 6)
+      val rd0 = Bool(OUTPUT)
+      val rd1 = Bool(OUTPUT)
+      val rd2 = Bool(OUTPUT)
+      val rd3 = Bool(OUTPUT)
+      val rd4 = Bool(OUTPUT)
+      val rd5 = Bool(OUTPUT)
+   }
+
+   val din = Wire(Bool())
+   val dout = Wire(Bool())
+
+   // I don't have a way to specify Z... let's give it something else instead.
+   val z = true.B
+   io.rd0 := Mux(io.oe(0), dout, z)
+   io.rd1 := Mux(io.oe(1), dout, z)
+   io.rd2 := Mux(io.oe(2), dout, z)
+   io.rd3 := Mux(io.oe(3), dout, z)
+   io.rd4 := Mux(io.oe(4), dout, z)
+   io.rd5 := Mux(io.oe(5), dout, z)
+
+   val mux_out =
+      Mux(io.ws === 0.U, io.wd0,
+      Mux(io.ws === 1.U, io.wd1,
+      Mux(io.ws === 2.U, io.wd2,
+         z)))
+   din := mux_out
+
+   assert (!(io.we && io.ws === 3.U), "[rfbitmodel] write-select set to invalid value.")
+
+   val dff = Reg(Bool())
+   when (io.we)
+   {
+      dff := din
+   }
+   dout := dff
+
+}
+

--- a/src/main/scala/regfile-custom.scala
+++ b/src/main/scala/regfile-custom.scala
@@ -51,13 +51,20 @@ class RegisterFileSeqCustomArray(
    }
 
    for (i <- 0 until num_registers) {
-      regfile.io.OE(i) := Cat(raddr_OH(5)(i), raddr_OH(4)(i), raddr_OH(3)(i), raddr_OH(2)(i), raddr_OH(1)(i), raddr_OH(0)(i))
-      write_select_OH(i) := Cat(
-         waddr_OH(2)(i) && io.write_ports(2).valid,
-         waddr_OH(1)(i) && io.write_ports(1).valid,
-         waddr_OH(0)(i) && io.write_ports(0).valid)
-      regfile.io.WE(i) := write_select_OH(i).orR
-      regfile.io.WS(i) := OHToUInt(write_select_OH(i))
+      if (i == 0) {
+         // P0 is always zero.
+         regfile.io.OE(0) := 0.U
+         regfile.io.WE(0) := false.B
+         regfile.io.WS(0) := 0.U
+      } else {
+         regfile.io.OE(i) := Cat(raddr_OH(5)(i), raddr_OH(4)(i), raddr_OH(3)(i), raddr_OH(2)(i), raddr_OH(1)(i), raddr_OH(0)(i))
+         write_select_OH(i) := Cat(
+            waddr_OH(2)(i) && io.write_ports(2).valid,
+            waddr_OH(1)(i) && io.write_ports(1).valid,
+            waddr_OH(0)(i) && io.write_ports(0).valid)
+         regfile.io.WE(i) := write_select_OH(i).orR
+         regfile.io.WS(i) := OHToUInt(write_select_OH(i))
+      }
 
       //printf("regfile.WS(%d)=%d, ws_OH=0x%x\n", i.U, regfile.io.WS(i), write_select_OH(i))
       assert(PopCount(write_select_OH(i).toBools) <= 1.U,

--- a/src/main/scala/regfile.scala
+++ b/src/main/scala/regfile.scala
@@ -16,6 +16,8 @@ package boom
 import Chisel._
 import config.Parameters
 
+import scala.collection.mutable.ArrayBuffer
+
 class RegisterFileReadPortIO(addr_width: Int, data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val addr = UInt(INPUT, addr_width)
@@ -53,7 +55,7 @@ abstract class RegisterFile(
    num_read_ports: Int,
    num_write_ports: Int,
    register_width: Int,
-   enable_bypassing: Boolean)
+   bypassable_array: Seq[Boolean]) // which write ports can be bypassed to the read ports?
    (implicit p: Parameters) extends BoomModule()(p)
 {
    val io = new BoomBundle()(p)
@@ -77,9 +79,9 @@ class RegisterFileComb(
    num_read_ports: Int,
    num_write_ports: Int,
    register_width: Int,
-   enable_bypassing: Boolean)
+   bypassable_array: Seq[Boolean])
    (implicit p: Parameters)
-   extends RegisterFile(num_registers, num_read_ports, num_write_ports, register_width, enable_bypassing)
+   extends RegisterFile(num_registers, num_read_ports, num_write_ports, register_width, bypassable_array)
 {
    // --------------------------------------------------------------
 
@@ -101,15 +103,20 @@ class RegisterFileComb(
    // --------------------------------------------------------------
    // Bypass out of the ALU's write ports.
 
-   if (enable_bypassing)
+   require (bypassable_array.length == io.write_ports.length)
+
+   if (bypassable_array.reduce(_||_))
    {
+      val bypassable_wports = ArrayBuffer[DecoupledIO[RegisterFileWritePort]]()
+      io.write_ports zip bypassable_array map { case (wport, b) => if (b) { bypassable_wports += wport} }
+
       for (i <- 0 until num_read_ports)
       {
-         val bypass_ens = io.write_ports.map(x => x.valid &&
+         val bypass_ens = bypassable_wports.map(x => x.valid &&
                                                   x.bits.addr =/= UInt(0) &&
                                                   x.bits.addr === io.read_ports(i).addr)
 
-         val bypass_data = Mux1H(Vec(bypass_ens), Vec(io.write_ports.map(_.bits.data)))
+         val bypass_data = Mux1H(Vec(bypass_ens), Vec(bypassable_wports.map(_.bits.data)))
 
          io.read_ports(i).data := Mux(bypass_ens.reduce(_|_), bypass_data, read_data(i))
       }
@@ -143,9 +150,9 @@ class RegisterFileSeq(
    num_read_ports: Int,
    num_write_ports: Int,
    register_width: Int,
-   enable_bypassing: Boolean)
+   bypassable_array: Seq[Boolean])
    (implicit p: Parameters)
-   extends RegisterFile(num_registers, num_read_ports, num_write_ports, register_width, enable_bypassing)
+   extends RegisterFile(num_registers, num_read_ports, num_write_ports, register_width, bypassable_array)
 {
 
    // --------------------------------------------------------------
@@ -170,15 +177,20 @@ class RegisterFileSeq(
    // --------------------------------------------------------------
    // Bypass out of the ALU's write ports.
 
-   if (enable_bypassing)
+   require (bypassable_array.length == io.write_ports.length)
+
+   if (bypassable_array.reduce(_||_))
    {
+      val bypassable_wports = ArrayBuffer[DecoupledIO[RegisterFileWritePort]]()
+      io.write_ports zip bypassable_array map { case (wport, b) => if (b) { bypassable_wports += wport} }
+
       for (i <- 0 until num_read_ports)
       {
-         val bypass_ens = io.write_ports.map(x => x.valid &&
+         val bypass_ens = bypassable_wports.map(x => x.valid &&
                                                   x.bits.addr =/= UInt(0) &&
                                                   x.bits.addr === RegNext(io.read_ports(i).addr))
 
-         val bypass_data = Mux1H(Vec(bypass_ens), Vec(io.write_ports.map(_.bits.data)))
+         val bypass_data = Mux1H(Vec(bypass_ens), Vec(bypassable_wports.map(_.bits.data)))
 
          io.read_ports(i).data := Mux(bypass_ens.reduce(_|_), bypass_data, read_data(i))
       }
@@ -190,7 +202,6 @@ class RegisterFileSeq(
          io.read_ports(i).data := read_data(i)
       }
    }
-
 
    // --------------------------------------------------------------
    // Write ports.

--- a/src/main/scala/rename.scala
+++ b/src/main/scala/rename.scala
@@ -49,7 +49,7 @@ class RenameStageIO(
    val ren2_mask  = Vec(pl_width, Bool().asOutput) // mask of valid instructions
    val ren2_uops  = Vec(pl_width, new MicroOp().asOutput)
 
-   val ren_pred_info = new BranchPredictionResp().asInput
+   val ren_pred_info = Vec(pl_width, new BranchPredInfo()).asInput
 
    // branch resolution (execute)
    val brinfo    = new BrResolutionInfo().asInput
@@ -151,18 +151,20 @@ class RenameStage(
    // Each branch prediction must snapshot the predictor (history state, etc.).
    // On a mispredict, the snapshot must be used to reset the predictor.
    // TODO use Mem(), but it chokes on the undefines in VCS
-   val prediction_copies = Reg(Vec(MAX_BR_COUNT, new BranchPredictionResp))
+//   val prediction_copies = Reg(Vec(MAX_BR_COUNT, new BranchPredictionResp))
+   // This info is sent to the BRU and deallocated after Execute.
+   val prediction_copies = Reg(Vec(MAX_BR_COUNT, new BranchPredInfo))
 
    for (w <- 0 until pl_width)
    {
       when(ren1_br_vals(w)) {
-         prediction_copies(ren1_uops(w).br_tag) := io.ren_pred_info
+         prediction_copies(ren1_uops(w).br_tag) := io.ren_pred_info(w)
       }
    }
 
    io.get_pred.info := prediction_copies(io.get_pred.br_tag)
 
-   val temp = Wire(new BranchPredictionResp)
+   val temp = Wire(new BranchPredInfo)
    println("\t\tPrediction Snapshots: " + temp.toBits.getWidth + "-bits, " + MAX_BR_COUNT + " entries")
 
    //-------------------------------------------------------------

--- a/src/main/scala/rob.scala
+++ b/src/main/scala/rob.scala
@@ -239,7 +239,7 @@ class Rob(width: Int,
    }
    def GetBankIdx(rob_idx: UInt): UInt =
    {
-      if(width == 1) { return UInt(0) }
+      if(width == 1) { return 0.U }
       else           { return rob_idx(log2Up(width)-1, 0).toUInt }
    }
 
@@ -287,7 +287,9 @@ class Rob(width: Int,
 
    // What if the next-pc is in the current row? I.e., a JR that wasn't handled in the front-end.
    val curr_idx = GetBankIdx(io.get_pc.rob_idx) + 1.U
-   val curr_row_next_pc_val = rob_getpc_curr_vals(curr_idx) && curr_idx =/= 0.U
+   val curr_row_next_pc_val = Wire(Bool())
+   if (fetchWidth == 1) { curr_row_next_pc_val := false.B }
+   else { curr_row_next_pc_val := rob_getpc_curr_vals(curr_idx) && curr_idx =/= 0.U }
    val curr_row_next_pc = curr_row_pc + Cat(curr_idx, UInt(0,2))
 
 

--- a/src/main/scala/seqmem_util.scala
+++ b/src/main/scala/seqmem_util.scala
@@ -80,7 +80,7 @@ class SeqMem1rwTransformable (
    val roff = getOffset(io.raddr)
    val r_offset = RegEnable(roff, io.ren)
    // returned cycle s1
-   val s1_rrow = smem.read(ridx, io.ren).toBits
+   val s1_rrow = smem.read(ridx, io.ren).asUInt
    io.rout := (s1_rrow >> r_offset)(l_width-1, 0)
 }
 

--- a/src/main/scala/tage-table.scala
+++ b/src/main/scala/tage-table.scala
@@ -301,8 +301,7 @@ class TageTable(
 
    val stall = !io.bp2_resp.ready
 
-   val s0_pc = io.if_req_pc
-   val s1_pc = RegEnable(s0_pc, !stall) // CODE REVIEW
+   val s1_pc = io.if_req_pc
    val p_idx = IdxHash(s1_pc)
    val p_tag = TagHash(s1_pc)
 

--- a/src/main/scala/tage-table.scala
+++ b/src/main/scala/tage-table.scala
@@ -301,21 +301,23 @@ class TageTable(
 
    val stall = !io.bp2_resp.ready
 
-   val p_idx       = IdxHash(io.if_req_pc)
-   val p_tag       = TagHash(io.if_req_pc)
+   val s0_pc = io.if_req_pc
+   val s1_pc = RegEnable(s0_pc, !stall) // CODE REVIEW
+   val p_idx = IdxHash(s1_pc)
+   val p_tag = TagHash(s1_pc)
 
-   counter_table.io.s0_r_idx := p_idx
-   tag_table.io.s0_r_idx := p_idx
+   counter_table.io.s1_r_idx := p_idx
+   tag_table.io.s1_r_idx := p_idx
    counter_table.io.stall := stall
    tag_table.io.stall := stall
 
    val s2_tag      = tag_table.io.s2_r_out
-   val bp2_tag_hit = s2_tag === RegEnable(RegEnable(p_tag, !stall), !stall)
+   val bp2_tag_hit = s2_tag === RegEnable(p_tag, !stall)
 
    io.bp2_resp.valid       := bp2_tag_hit
    io.bp2_resp.bits.takens := counter_table.io.s2_r_out
-   io.bp2_resp.bits.index  := RegEnable(RegEnable(p_idx, !stall), !stall)(index_sz-1,0)
-   io.bp2_resp.bits.tag    := RegEnable(RegEnable(p_tag, !stall), !stall)(tag_sz-1,0)
+   io.bp2_resp.bits.index  := RegEnable(p_idx, !stall)(index_sz-1,0)
+   io.bp2_resp.bits.tag    := RegEnable(p_tag, !stall)(tag_sz-1,0)
 
    io.bp2_resp.bits.idx_csr  := idx_csr.io.value
    io.bp2_resp.bits.tag_csr1 := tag_csr1.io.value

--- a/src/main/scala/tage-tagmemory.scala
+++ b/src/main/scala/tage-tagmemory.scala
@@ -35,8 +35,8 @@ class TageTagMemory(
       // the reader is not ready; stall the read pipeline.
       val stall = Bool(INPUT)
 
-      // send read addr on cycle 0, get data out on cycle 2.
-      val s0_r_idx = UInt(INPUT, width = index_sz)
+      // send read addr on cycle 1, get data out on cycle 2.
+      val s1_r_idx = UInt(INPUT, width = index_sz)
       val s2_r_out = UInt(OUTPUT, width = memwidth)
 
       val w_en = Bool(INPUT)
@@ -66,12 +66,10 @@ class TageTagMemory(
    val idx = Wire(UInt())
    val last_idx = RegNext(idx)
 
-   idx := Mux(io.stall, last_idx, io.s0_r_idx)
+   idx := Mux(io.stall, last_idx, io.s1_r_idx)
 
-   val r_s1_out = smem.read(idx, !io.stall)
-   val r_s2_out = RegEnable(r_s1_out, !io.stall)
+   val r_s2_out = smem.read(idx, !io.stall)
    io.s2_r_out := r_s2_out
-
 
    when (io.w_en)
    {

--- a/src/main/scala/tage.scala
+++ b/src/main/scala/tage.scala
@@ -213,7 +213,7 @@ class TageBrPredictor(
       table.if_req_pc := io.req_pc
 
       // update CSRs. ---
-      table.br_resolution <> io.br_resolution
+      table.br_resolution <> io.exe_bpd_update
       table.flush := io.flush
 
       // Update ghistory speculatively once a prediction is made.

--- a/src/main/scala/tage.scala
+++ b/src/main/scala/tage.scala
@@ -263,7 +263,7 @@ class TageBrPredictor(
    resp_info.alt_hit := p_alt_hit
    resp_info.alt_id  := p_alt_id
    resp_info.alt_predicted_takens := Vec(predictions.map(_.takens))(p_alt_id)
-   resp_info.debug_br_pc := RegEnable(RegEnable(io.req_pc, !stall), !stall)
+   resp_info.debug_br_pc := RegEnable(io.req_pc, !stall)
 
    io.resp.bits.info := resp_info.toBits
 


### PR DESCRIPTION
   * Add a cycle to the Fetch Unit to address critical path on BPD redirections
   * Add a BOOM-specific set-associative BTB.
   * Allow option for BPD to redirect PC from F2 (using the BTB target) in addition 
      to  F3 (using actual target).
   * Other misc. critical path fixes.
   * Added a blackbox for a 6r3w integer register file.