### PR TITLE
Fixes to get BOOM working in project-template and Firesim

### DIFF
--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -25,6 +25,7 @@ trait BOOMDebugConstants
    val COMMIT_LOG_PRINTF   = false // dump commit state, for comparision against ISA sim
    val O3PIPEVIEW_PRINTF   = false // dump trace for O3PipeView from gem5
    val O3_CYCLE_TIME       = (1000)// "cycle" time expected by o3pipeview.py
+   val IDLE_TIMEOUT        = 0     // Number of stalled cycles before assertion failure (0 means no assertion)
 
    // turn off stuff to dramatically reduce Chisel node count
    val DEBUG_PRINTF_LSU    = true && DEBUG_PRINTF

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -1028,9 +1028,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //-------------------------------------------------------------
 
    // detect pipeline freezes and throw error
-   val idle_cycles = freechips.rocketchip.util.WideCounter(32)
-   when (rob.io.commit.valids.asUInt.orR || reset.toBool) { idle_cycles := 0.U }
-   assert (!(idle_cycles.value(13)), "Pipeline has hung.")
+   if (IDLE_TIMEOUT > 0) {
+      val idle_cycles = freechips.rocketchip.util.WideCounter(32)
+      when (rob.io.commit.valids.asUInt.orR || reset.toBool) { idle_cycles := 0.U }
+      assert (!(idle_cycles.value(IDLE_TIMEOUT)), "Pipeline has hung.")
+   }
 
    fp_pipeline.io.debug_tsc_reg := debug_tsc_reg
 

--- a/src/main/scala/microop.scala
+++ b/src/main/scala/microop.scala
@@ -101,6 +101,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val xcpt_pf_if       = Bool()             // I-TLB page fault.
    val replay_if        = Bool()             // I$ wants us to replay our ifetch request
    val xcpt_ma_if       = Bool()             // Misaligned fetch (jal/brjumping to misaligned addr).
+   val xcpt_ae_if       = Bool()             // Access exception
 
    // purely debug information
    val debug_wdata      = UInt(width=xLen)


### PR DESCRIPTION
Add xcpt_ae_if to the MicroOp bundle to fix compilation error.

Disable pipeline hang assertion by default.