### PR TITLE
It was fixed that if the reset of 1 or 2 measures could cause errors

### DIFF
--- a/src/main/scala/bpu/brpredictor.scala
+++ b/src/main/scala/bpu/brpredictor.scala
@@ -222,7 +222,7 @@ abstract class BrPredictor(fetch_width: Int, val history_length: Int)(implicit p
    val r_vlh = new VeryLongHistoryRegister(history_length, VLHR_LENGTH)
 
    val in_usermode = io.status_prv === UInt(freechips.rocketchip.rocket.PRV.U)
-   val disable_bpd = in_usermode && Bool(ENABLE_BPD_UMODE_ONLY)
+   val disable_bpd = (!in_usermode) && Bool(ENABLE_BPD_UMODE_ONLY)
 
    val ghistory_all =
       r_ghistory.value(

--- a/src/main/scala/lsu/dcacheshim.scala
+++ b/src/main/scala/lsu/dcacheshim.scala
@@ -322,7 +322,7 @@ class DCacheShim(implicit p: Parameters) extends BoomModule()(p)
    // handle nacks from the cache (or from the IFLB or the LSU)
 
    io.core.nack.valid     := (io.dmem.s2_nack) || Reg(next=io.core.req.bits.kill) || Reg(next=iflb_kill) ||
-                              Reg(next=Reg(next=(io.core.req.valid && !(io.dmem.req.ready))))
+                              Reg(next=Reg(next=(io.core.req.valid && !(io.dmem.req.ready)), init = Bool(false)))
    io.core.nack.lsu_idx   := Mux(m2_req_uop.is_load, m2_req_uop.ldq_idx, m2_req_uop.stq_idx)
    io.core.nack.isload    := m2_req_uop.is_load
    io.core.nack.cache_nack:= io.dmem.s2_nack ||


### PR DESCRIPTION
It was fixed that if the reset of 1 or 2 measures could cause errors: "lsu.scala: 498 assert" or "rob.scala: 579 assert".
+ fixed a bug in unused functionality in Branch Predictor.