### PR TITLE
Decouple frontend and backend widths.

### DIFF
--- a/src/main/scala/bpu/bpd-pipeline.scala
+++ b/src/main/scala/bpu/bpd-pipeline.scala
@@ -40,7 +40,7 @@ class BranchPredInfo(implicit p: Parameters) extends BoomBundle()(p)
    val bpd_taken         = Bool() // did the bpd predict taken for this instruction?
 
    val bim_resp         = new BimResp
-   val bpd_resp         = new BpdResp // TODO XXX this can be very expensive -- don't give to every instruction? And break into separate toBRU/Exe and toCom versions.
+   val bpd_resp         = new BpdResp
 }
 
 class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)

--- a/src/main/scala/bpu/brpredictor.scala
+++ b/src/main/scala/bpu/brpredictor.scala
@@ -32,7 +32,7 @@ import freechips.rocketchip.rocket.RocketCoreParams
 // expecting to receive it back when it needs to perform an update.
 class BpdResp(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val takens = UInt(width = FETCH_WIDTH)
+   val takens = UInt(width = fetchWidth)
 
    // Roughly speaking, track the outcome of the last N branches.
    // The purpose of these is for resetting the global history on a branch

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -26,7 +26,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
    // Core Parameters
    case BoomTilesKey => up(BoomTilesKey, site) map { r => r.copy(
       core = r.core.copy(
-         fetchWidth = 2,
+         fetchWidth = 4,
          decodeWidth = 2,
          numRobEntries = 80,
          issueParams = Seq(
@@ -44,8 +44,10 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
       btb = Some(BTBParams(nEntries = 0, updatesOutOfOrder = true)),
       dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8, nMSHRs=4, nTLBEntries=16)),
-      icache = Some(ICacheParams(fetchBytes = 2*4, rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8))
+      icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8))
       )}
+   // Set TL network to 128bits wide
+   case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 16)
 })
 
 
@@ -61,7 +63,7 @@ class WithSmallBooms extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r =>r.copy(
       core = r.core.copy(
          fetchWidth = 2,
-         decodeWidth = 2,
+         decodeWidth = 1,
          numRobEntries = 16,
          issueParams = Seq(
             IssueParams(issueWidth=1, numEntries=4, iqType=IQT_MEM.litValue),

--- a/src/main/scala/common/microop.scala
+++ b/src/main/scala/common/microop.scala
@@ -48,7 +48,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val stat_bpd_mispredicted   = Bool()                 // denominator: all committed branches
 
    // TODO remove fetch_pc_lob (no longer needed with FTQ?).
-   val fetch_pc_lob     = UInt(width = log2Up(FETCH_WIDTH*coreInstBytes)) // track which PC was used to fetch this
+   val fetch_pc_lob     = UInt(width = log2Up(fetchWidth*coreInstBytes)) // track which PC was used to fetch this
                                                                           // instruction
 
    // Index into FTQ to figure out our fetch PC.

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -69,7 +69,6 @@ case class BoomCoreParams(
 ) extends freechips.rocketchip.tile.CoreParams
 {
    val retireWidth: Int = decodeWidth
-   require (fetchWidth == decodeWidth)
    val useCompressed: Boolean = false
 	require (useCompressed == false)
    val instBits: Int = if (useCompressed) 16 else 32
@@ -88,15 +87,18 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
 
    //************************************
    // Superscalar Widths
-   val FETCH_WIDTH      = boomParams.fetchWidth       // number of insts we can fetch
-   val DECODE_WIDTH     = boomParams.decodeWidth
-   val DISPATCH_WIDTH   = DECODE_WIDTH                // number of insts put into the IssueWindow
+
+   // fetchWidth provided by CoreParams class.
+   // decodeWidth provided by CoreParams class.
+   // retireWidth provided by BoomCoreParams class.
+//   val decodeWidth     = boomParams.decodeWidth
+   val DISPATCH_WIDTH   = decodeWidth                // number of insts put into the IssueWindow
    val COMMIT_WIDTH     = boomParams.retireWidth
 
-   require (DECODE_WIDTH == COMMIT_WIDTH)
+   require (decodeWidth == COMMIT_WIDTH)
    require (DISPATCH_WIDTH == COMMIT_WIDTH)
-   require (isPow2(FETCH_WIDTH))
-   require (DECODE_WIDTH <= FETCH_WIDTH)
+   require (isPow2(fetchWidth))
+   require (decodeWidth <= fetchWidth)
 
    //************************************
    // Data Structure Sizes
@@ -217,7 +219,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
 
    //************************************
    // Implicitly calculated constants
-   val NUM_ROB_ROWS      = NUM_ROB_ENTRIES/DECODE_WIDTH
+   val NUM_ROB_ROWS      = NUM_ROB_ENTRIES/decodeWidth
    val ROB_ADDR_SZ       = log2Up(NUM_ROB_ENTRIES)
    // the f-registers are mapped into the space above the x-registers
    val LOGICAL_REG_COUNT = if (usingFPU) 64 else 32
@@ -232,13 +234,13 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    val NUM_BROB_ENTRIES  = NUM_ROB_ROWS //TODO explore smaller BROBs
    val BROB_ADDR_SZ      = log2Up(NUM_BROB_ENTRIES)
 
-   require (numIntPhysRegs >= (32 + DECODE_WIDTH))
-   require (numFpPhysRegs >= (32 + DECODE_WIDTH))
+   require (numIntPhysRegs >= (32 + decodeWidth))
+   require (numFpPhysRegs >= (32 + decodeWidth))
    require (MAX_BR_COUNT >=2)
    require (NUM_ROB_ROWS % 2 == 0)
-   require (NUM_ROB_ENTRIES % DECODE_WIDTH == 0)
+   require (NUM_ROB_ENTRIES % decodeWidth == 0)
    require (isPow2(NUM_LSU_ENTRIES))
-   require ((NUM_LSU_ENTRIES-1) > DECODE_WIDTH)
+   require ((NUM_LSU_ENTRIES-1) > decodeWidth)
 
 
    //************************************

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -26,7 +26,7 @@ case class BoomCoreParams(
    enableCustomRf: Boolean = false,
    enableCustomRfModel: Boolean = true,
    maxBrCount: Int = 4,
-   fetchBufferSz: Int = 4,
+   fetchBufferSz: Int = 8,
    enableAgePriorityIssue: Boolean = true,
    enablePrefetching: Boolean = false,
    enableBrResolutionRegister: Boolean = true,

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -29,7 +29,6 @@ case class BoomCoreParams(
    fetchBufferSz: Int = 4,
    enableAgePriorityIssue: Boolean = true,
    enablePrefetching: Boolean = false,
-   enableFetchBufferFlowThrough: Boolean = true,
    enableBrResolutionRegister: Boolean = true,
    enableCommitMapTable: Boolean = false,
    enableBTBContainsBranches: Boolean = true,
@@ -110,8 +109,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    val numIntPhysRegs   = boomParams.numIntPhysRegisters // size of the integer physical register file
    val numFpPhysRegs    = boomParams.numFpPhysRegisters  // size of the floating point physical register file
 
-
-   val enableFetchBufferFlowThrough = boomParams.enableFetchBufferFlowThrough
 
    //************************************
    // Functional Units

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1107,10 +1107,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       println("\n Chisel Printout Enabled\n")
 
       val numFtqWhitespace = if (DEBUG_PRINTF_FTQ) (ftqSz/4)+1 else 0
-//      val screenheight = 79
+      val screenheight = 79
 //      val screenheight = 61
-      val screenheight = 57
-       var whitespace = (screenheight - 25 + 3 -3 -1 - NUM_LSU_ENTRIES -
+//      val screenheight = 56
+       var whitespace = (screenheight - 25 + 3 -10 + 3 - decodeWidth - NUM_LSU_ENTRIES -
          issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numFtqWhitespace
      )
 

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -462,13 +462,9 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // TODO for now, assume worst-case all instructions will dispatch towards one issue unit.
    val dis_readys = issue_units.map(_.io.dis_readys.asUInt).reduce(_&_) & fp_pipeline.io.dis_readys.asUInt
    rename_stage.io.dis_inst_can_proceed := dis_readys.toBools
-   rename_stage.io.ren_pred_info := Vec(dec_fbundle.uops.map(_.br_prediction))
 
    rename_stage.io.kill     := io.ifu.clear_fetchbuffer // mispredict or flush
    rename_stage.io.brinfo   := br_unit.brinfo
-   rename_stage.io.get_pred.br_tag        := (if (regreadLatency == 1) RegNext(iss_uops(brunit_idx).br_tag)
-                                             else iss_uops(brunit_idx).br_tag)
-   exe_units(brunit_idx).io.get_pred.info := RegNext(rename_stage.io.get_pred.info)
 
    rename_stage.io.flush_pipeline := rob.io.flush.valid
    rename_stage.io.debug_rob_empty := rob.io.empty

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -860,7 +860,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    rob.io.enq_valids := rename_stage.io.ren1_mask
    rob.io.enq_uops   := rename_stage.io.ren1_uops
    rob.io.enq_new_packet := dec_finished_mask === 0.U
-   rob.io.enq_partial_stall := !dec_rdy && !dec_will_fire(decodeWidth-1)
+//   rob.io.enq_partial_stall := !dec_rdy && !dec_will_fire(decodeWidth-1)
+   rob.io.enq_partial_stall := !dec_rdy // TODO come up with better ROB compacting scheme.
    rob.io.debug_tsc := debug_tsc_reg
    rob.io.csr_stall := csr.io.csr_stall
 
@@ -1108,8 +1109,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       val numFtqWhitespace = if (DEBUG_PRINTF_FTQ) (ftqSz/4)+1 else 0
 //      val screenheight = 79
 //      val screenheight = 61
-      val screenheight = 56
-       var whitespace = (screenheight - 25 + 3 -3 - NUM_LSU_ENTRIES -
+      val screenheight = 57
+       var whitespace = (screenheight - 25 + 3 -3 -1 - NUM_LSU_ENTRIES -
          issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numFtqWhitespace
      )
 

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -27,6 +27,7 @@
 package boom
 
 import Chisel._
+import chisel3.core.DontCare
 import chisel3.experimental.dontTouch
 import freechips.rocketchip.config.Parameters
 
@@ -282,7 +283,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    io.ifu.flush_pc          := RegNext(csr.io.evec)
    io.ifu.com_ftq_idx       := rob.io.com_xcpt.bits.ftq_idx
 
-   io.ifu.clear_fetchbuffer := br_unit.brinfo.mispredict || 
+   io.ifu.clear_fetchbuffer := br_unit.brinfo.mispredict ||
                                rob.io.flush.valid ||
                                io.ifu.sfence_take_pc
 
@@ -1358,8 +1359,47 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //-------------------------------------------------------------
    //-------------------------------------------------------------
 
-   // we do not support RoCC (yet)
+   // We do not support RoCC.
    io.rocc.cmd.valid := false.B
+   io.rocc.cmd.bits <> DontCare
    io.rocc.resp.ready := false.B
+   io.rocc.exception := false.B
+   io.rocc.mem.req.bits := DontCare
+   io.rocc.mem.resp.bits.replay := false.B
+   io.rocc.mem.s2_xcpt.pf.st := false.B
+   io.rocc.mem.s2_xcpt.pf.ld := false.B
+   io.rocc.mem.resp.bits.tag := 0.U
+   io.rocc.mem.resp.valid := false.B
+   io.rocc.mem.replay_next := false.B
+   io.rocc.mem.resp.bits.data_word_bypass := false.B
+   io.rocc.mem.perf.acquire := false.B
+   io.rocc.mem.resp.bits.addr := false.B
+   io.rocc.mem.resp.bits.store_data := false.B
+   io.rocc.mem.resp.bits.typ := false.B
+   io.rocc.mem.req.ready := false.B
+   io.rocc.mem.resp.bits.cmd := false.B
+   io.rocc.mem.perf.tlbMiss := false.B
+   io.rocc.mem.s2_xcpt.ae.st := false.B
+   io.rocc.mem.s2_xcpt.ae.ld := false.B
+   io.rocc.mem.ordered := false.B
+   io.rocc.mem.resp.bits.data := 0.U
+   io.rocc.mem.resp.bits.has_data := false.B
+   io.rocc.mem.resp.bits.data_raw := false.B
+   io.rocc.mem.perf.release := false.B
+   io.rocc.mem.s2_nack := false.B
+   io.rocc.mem.s2_xcpt.ma.st := false.B
+   io.rocc.mem.s2_xcpt.ma.ld := false.B
+
+
+   // Wire off other unused CoreIO signals.
+   io.fpu <> DontCare
+   io.fpu.valid := false.B
+   io.fpu.inst := 0.U
+
+   //io.trace := csr.io.trace unused
+   io.trace <> DontCare
+   io.trace map (t => t.valid := false.B)
+
+   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -33,7 +33,7 @@ abstract trait DecodeConstants
             //     |  |  |  |                 |        dst     |       |       |  |     |  |  |  |  |  mem    mem   |                    |  |  |  |  |  is unique? (clear pipeline for it)
             //     |  |  |  |                 |        regtype |       |       |  |     |  |  |  |  |  cmd    msk   |                    |  |  |  |  |  |  flush on commit
             //     |  |  |  |                 |        |       |       |       |  |     |  |  |  |  |  |      |     |                    |  |  |  |  |  |  |  csr cmd
-              List(N, N, X, uopX   , IQT_INT, FU_X   ,RT_X,BitPat.DC(2),BitPat.DC(2),X,IS_X,X,X,X,X,N, M_X,   MT_X, BitPat.DC(2),        X, X, X, X, N, N, X, CSR.X)
+              List(N, N, X, uopX   , IQT_INT, FU_X   ,RT_X,BitPat.dontCare(2),BitPat.dontCare(2),X,IS_X,X,X,X,X,N, M_X,   MT_X, BitPat.dontCare(2),        X, X, X, X, N, N, X, CSR.X)
 
   val table: Array[(BitPat, List[BitPat])]
 // scalastyle:on

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -605,9 +605,6 @@ class FetchSerializerNtoM(implicit p: Parameters) extends BoomModule()(p)
    // Pipe valid straight through, since conceptually,
    // we are just an extension of the Fetch Buffer
    io.deq.valid := io.enq.valid
-   // TODO XXX HACK bpd_resp is associated with a "fetch packet", so only copy the first one.
-   // Ideally, separate out which parts of bpu_info are "per packet"/"per instruction" and "commit info" and "exe info".
-   io.deq.bits.bpd_resp := io.enq.bits.bpu_info(0).bpd_resp
 
 }
 

--- a/src/main/scala/exu/execute.scala
+++ b/src/main/scala/exu/execute.scala
@@ -59,7 +59,6 @@ class ExecutionUnitIO(
    // only used by the branch unit
    val br_unit = new BranchUnitResp().asOutput
    val get_ftq_pc = new GetPCFromFtqIO().flip
-   val get_pred = new GetPredictionInfo
    val status = new freechips.rocketchip.rocket.MStatus().asInput
 
    // only used by the fpu unit
@@ -199,7 +198,6 @@ class ALUExeUnit(
    {
       io.br_unit <> alu.io.br_unit
       alu.io.get_ftq_pc <> io.get_ftq_pc
-      io.get_pred <> alu.io.get_pred
       alu.io.status <> io.status
    }
    else
@@ -649,7 +647,6 @@ class ALUMemExeUnit(
    {
       io.br_unit <> alu.io.br_unit
       alu.io.get_ftq_pc <> io.get_ftq_pc
-      io.get_pred <> alu.io.get_pred
       alu.io.status <> io.status
    }
    else

--- a/src/main/scala/exu/execute.scala
+++ b/src/main/scala/exu/execute.scala
@@ -65,7 +65,7 @@ class ExecutionUnitIO(
    val fcsr_rm = Bits(INPUT, tile.FPConstants.RM_SZ)
 
    // only used by the mem unit
-   val lsu_io = new LoadStoreUnitIO(DECODE_WIDTH).flip
+   val lsu_io = new LoadStoreUnitIO(decodeWidth).flip
    val dmem   = new DCMemPortIO() // TODO move this out of ExecutionUnit
    val com_exception = Bool(INPUT)
 }

--- a/src/main/scala/exu/execution_units.scala
+++ b/src/main/scala/exu/execution_units.scala
@@ -18,7 +18,7 @@ class ExecutionUnits(fpu: Boolean = false)(implicit val p: Parameters) extends H
 {
    val totalIssueWidth = issueParams.map(_.issueWidth).sum
    if (!fpu) {
-      println("\n   ~*** " + Seq("One","Two","Three","Four")(DECODE_WIDTH-1) + "-wide Machine ***~\n")
+      println("\n   ~*** " + Seq("One","Two","Three","Four")(decodeWidth-1) + "-wide Machine ***~\n")
       println("    -== " + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue ==- \n")
    }
 

--- a/src/main/scala/exu/functional_unit.scala
+++ b/src/main/scala/exu/functional_unit.scala
@@ -470,7 +470,7 @@ class ALUUnit(is_branch_unit: Boolean = false, num_stages: Int = 1)(implicit p: 
       br_unit.brinfo := brinfo
 
       // updates the BTB same cycle as PC redirect
-      val lsb = log2Ceil(FETCH_WIDTH*coreInstBytes)
+      val lsb = log2Ceil(fetchWidth*coreInstBytes)
 
       // did a branch or jalr occur AND did we mispredict? AND was it taken? (i.e., should we update the BTB)
       val fetch_pc = ((uop_pc_ >> lsb) << lsb) + uop.fetch_pc_lob

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -283,7 +283,7 @@ class Rob(
          rob_fflags(rob_tail)    := 0.U
          rob_uop(rob_tail).stat_brjmp_mispredicted := false.B
 
-         assert (rob_val(rob_tail) === false.B,"[rob] overwriting a valid entry.")
+         assert (rob_val(rob_tail) === false.B, "[rob] overwriting a valid entry.")
          assert ((io.enq_uops(w).rob_idx >> log2Ceil(width)) === rob_tail)
       }
       .elsewhen (io.enq_valids.reduce(_|_) && !rob_val(rob_tail))

--- a/src/main/scala/ifu/fetch.scala
+++ b/src/main/scala/ifu/fetch.scala
@@ -100,6 +100,7 @@ class FetchControlUnit(fetch_width: Int)(implicit p: Parameters) extends BoomMod
    val bchecker = Module (new BranchChecker(fetchWidth))
    val ftq = Module(new FetchTargetQueue(num_entries = ftqSz))
    val fb = Module(new FetchBuffer(num_entries=fetchBufferSz))
+   val monitor = Module(new FetchMonitor)
 
    val br_unit = io.br_unit
    val fseq_reg = Reg(init = UInt(0, xLen))
@@ -534,6 +535,10 @@ class FetchControlUnit(fetch_width: Int)(implicit p: Parameters) extends BoomMod
 
    io.fetchpacket.bits.uops map {_ := DontCare }
    io.fetchpacket <> fb.io.deq
+
+   monitor.io.fire := io.fetchpacket.fire()
+   monitor.io.uops := io.fetchpacket.bits.uops
+   monitor.io.clear := io.clear_fetchbuffer
 
 
    //-------------------------------------------------------------

--- a/src/main/scala/ifu/fetch.scala
+++ b/src/main/scala/ifu/fetch.scala
@@ -32,18 +32,18 @@ class FetchBundle(implicit p: Parameters) extends BoomBundle()(p)
 {
    val pc            = UInt(width = vaddrBitsExtended)
    val ftq_idx       = UInt(width = log2Up(ftqSz))
-   val insts         = Vec(FETCH_WIDTH, Bits(width = 32))
-   val mask          = Bits(width = FETCH_WIDTH) // mark which words are valid instructions
+   val insts         = Vec(fetchWidth, Bits(width = 32))
+   val mask          = Bits(width = fetchWidth) // mark which words are valid instructions
    val xcpt_pf_if    = Bool() // I-TLB miss (instruction fetch fault).
    val xcpt_ae_if    = Bool() // Access exception.
    val replay_if     = Bool() // the I$ demands we replay the instruction fetch.
-   val xcpt_ma_if_oh = UInt(width = FETCH_WIDTH)
+   val xcpt_ma_if_oh = UInt(width = fetchWidth)
                             // A cfi branched to a misaligned address --
                             // one-hot encoding (1:1 with insts).
 
-   val bpu_info      = Vec(FETCH_WIDTH, new BranchPredInfo) // TODO remove
+   val bpu_info      = Vec(fetchWidth, new BranchPredInfo) // TODO remove
 
-   val debug_events  = Vec(FETCH_WIDTH, new DebugStageEvents)
+   val debug_events  = Vec(fetchWidth, new DebugStageEvents)
 
   override def cloneType: this.type = new FetchBundle().asInstanceOf[this.type]
 }

--- a/src/main/scala/ifu/fetch.scala
+++ b/src/main/scala/ifu/fetch.scala
@@ -3,9 +3,12 @@
 // All Rights Reserved. See LICENSE for license details.
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-// Fetch Unit
+// Fetch Control Unit
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
+//
+// This has lots of the brains behind fetching instructions and managing the
+// branch predictors and deciding which instructions to fetch next.
 //
 // Stages:
 //    * F0 -- next PC select
@@ -46,7 +49,7 @@ class FetchBundle(implicit p: Parameters) extends BoomBundle()(p)
 }
 
 
-class FetchUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)
+class FetchControlUnit(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)
    with HasBoomCoreParameters
 {
    val io = IO(new BoomBundle()(p)

--- a/src/main/scala/ifu/fetchbuffer.scala
+++ b/src/main/scala/ifu/fetchbuffer.scala
@@ -1,0 +1,67 @@
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Fetch Buffer
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//
+// Takes a FetchBundle and converts into a vector of MicroOps.
+
+package boom
+
+import chisel3._
+import chisel3.util._
+import chisel3.core.DontCare
+import freechips.rocketchip.config.Parameters
+
+
+class FetchBufferResp(implicit p: Parameters) extends BoomBundle()(p)
+{
+   val uops = Vec(DECODE_WIDTH, new MicroOp())
+}
+
+class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()(p)
+   with HasBoomCoreParameters
+{
+   val io = IO(new BoomBundle()(p)
+   {
+      // use withReset to clear out the fetch buffer.
+      val enq = Flipped(Decoupled(new FetchBundle()))
+      val deq = new DecoupledIO(new FetchBufferResp())
+   })
+
+   val queue =
+      Module(new Queue(
+         gen=new FetchBundle,
+         entries=num_entries,
+         pipe=false,
+         flow=false))
+
+   queue.io.enq <> io.enq
+
+   io.deq.valid <> queue.io.deq.valid
+   io.deq.ready <> queue.io.deq.ready
+
+   require (DECODE_WIDTH == FETCH_WIDTH)
+
+   for (i <- 0 until DECODE_WIDTH)
+   {
+      // 1:1, so pass everything straight through!
+      require (coreInstBytes==4)
+      io.deq.bits.uops(i)                := DontCare
+      io.deq.bits.uops(i).valid          := queue.io.deq.bits.mask(i)
+      io.deq.bits.uops(i).pc             := (queue.io.deq.bits.pc.asSInt & SInt(-(FETCH_WIDTH*coreInstBytes))).asUInt + (i << 2).U
+      io.deq.bits.uops(i).fetch_pc_lob   := queue.io.deq.bits.pc
+      io.deq.bits.uops(i).ftq_idx        := queue.io.deq.bits.ftq_idx
+      io.deq.bits.uops(i).pc_lob         := ~(~queue.io.deq.bits.pc | (fetchWidth*coreInstBytes-1).U) + (i << 2).U
+      io.deq.bits.uops(i).inst           := queue.io.deq.bits.insts(i)
+      io.deq.bits.uops(i).xcpt_pf_if     := queue.io.deq.bits.xcpt_pf_if
+      io.deq.bits.uops(i).xcpt_ae_if     := queue.io.deq.bits.xcpt_ae_if
+      io.deq.bits.uops(i).replay_if      := queue.io.deq.bits.replay_if
+      io.deq.bits.uops(i).xcpt_ma_if     := queue.io.deq.bits.xcpt_ma_if_oh(i)
+      io.deq.bits.uops(i).br_prediction  := queue.io.deq.bits.bpu_info(i)
+      io.deq.bits.uops(i).debug_events   := queue.io.deq.bits.debug_events(i)
+   }
+
+   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
+}
+

--- a/src/main/scala/ifu/fetchbuffer.scala
+++ b/src/main/scala/ifu/fetchbuffer.scala
@@ -30,13 +30,8 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
 
       // Was the pipeline redirected? Clear/reset the fetchbuffer.
       val clear = Input(Bool())
-      // The mask comes too late to use, so we might need to mask off
-      // instructions that were enqueued on the previous cycle.
-//      val s1_mask = UInt(width=fetchWidth.W) // TODO XXX
    })
 
-
-   // TODO blackbox with a bitvector for read-addrs, write-addrs.
    require (num_entries > 1)
    private val num_elements = num_entries*fetchWidth
    private val ram = Mem(num_elements, new MicroOp())

--- a/src/main/scala/ifu/fetchbuffer.scala
+++ b/src/main/scala/ifu/fetchbuffer.scala
@@ -19,48 +19,135 @@ class FetchBufferResp(implicit p: Parameters) extends BoomBundle()(p)
    val uops = Vec(DECODE_WIDTH, new MicroOp())
 }
 
+// num_entries: effectively the number of full-sized fetch packets we can hold.
 class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()(p)
    with HasBoomCoreParameters
 {
    val io = IO(new BoomBundle()(p)
    {
-      // use withReset to clear out the fetch buffer.
       val enq = Flipped(Decoupled(new FetchBundle()))
       val deq = new DecoupledIO(new FetchBufferResp())
+
+      val clear = Input(Bool())
+      // The mask comes too late to use, so we might need to mask off
+      // instructions that were enqueued on the previous cycle.
+//      val s1_mask = UInt(width=fetchWidth.W) // TODO XXX
    })
 
-   val queue =
-      Module(new Queue(
-         gen=new FetchBundle,
-         entries=num_entries,
-         pipe=false,
-         flow=false))
 
-   queue.io.enq <> io.enq
+   // TODO blackbox with a bitvector for read-addrs, write-addrs.
+   private val num_elements = num_entries*fetchWidth
+   private val ram = Mem(num_elements, new MicroOp())
+   private val write_ptr = RegInit(0.asUInt(width=log2Ceil(num_elements).W))
+   private val read_ptr = RegInit(0.asUInt(width=log2Ceil(num_elements).W))
+   private val count = RegInit(0.asUInt(width=log2Ceil(num_elements).W))
 
-   io.deq.valid <> queue.io.deq.valid
-   io.deq.ready <> queue.io.deq.ready
-
-   require (DECODE_WIDTH == FETCH_WIDTH)
-
+   val uops = Wire(Vec(fetchWidth, new MicroOp()))
+ 
    for (i <- 0 until DECODE_WIDTH)
    {
-      // 1:1, so pass everything straight through!
       require (coreInstBytes==4)
-      io.deq.bits.uops(i)                := DontCare
-      io.deq.bits.uops(i).valid          := queue.io.deq.bits.mask(i)
-      io.deq.bits.uops(i).pc             := (queue.io.deq.bits.pc.asSInt & SInt(-(FETCH_WIDTH*coreInstBytes))).asUInt + (i << 2).U
-      io.deq.bits.uops(i).fetch_pc_lob   := queue.io.deq.bits.pc
-      io.deq.bits.uops(i).ftq_idx        := queue.io.deq.bits.ftq_idx
-      io.deq.bits.uops(i).pc_lob         := ~(~queue.io.deq.bits.pc | (fetchWidth*coreInstBytes-1).U) + (i << 2).U
-      io.deq.bits.uops(i).inst           := queue.io.deq.bits.insts(i)
-      io.deq.bits.uops(i).xcpt_pf_if     := queue.io.deq.bits.xcpt_pf_if
-      io.deq.bits.uops(i).xcpt_ae_if     := queue.io.deq.bits.xcpt_ae_if
-      io.deq.bits.uops(i).replay_if      := queue.io.deq.bits.replay_if
-      io.deq.bits.uops(i).xcpt_ma_if     := queue.io.deq.bits.xcpt_ma_if_oh(i)
-      io.deq.bits.uops(i).br_prediction  := queue.io.deq.bits.bpu_info(i)
-      io.deq.bits.uops(i).debug_events   := queue.io.deq.bits.debug_events(i)
+      uops(i)                := DontCare
+      uops(i).valid          := io.enq.valid && io.enq.bits.mask(i)
+      uops(i).pc             := (io.enq.bits.pc.asSInt & SInt(-(FETCH_WIDTH*coreInstBytes))).asUInt + (i << 2).U
+      uops(i).fetch_pc_lob   := io.enq.bits.pc
+      uops(i).ftq_idx        := io.enq.bits.ftq_idx
+      uops(i).pc_lob         := ~(~io.enq.bits.pc | (fetchWidth*coreInstBytes-1).U) + (i << 2).U
+      uops(i).inst           := io.enq.bits.insts(i)
+      uops(i).xcpt_pf_if     := io.enq.bits.xcpt_pf_if
+      uops(i).xcpt_ae_if     := io.enq.bits.xcpt_ae_if
+      uops(i).replay_if      := io.enq.bits.replay_if
+      uops(i).xcpt_ma_if     := io.enq.bits.xcpt_ma_if_oh(i)
+      uops(i).br_prediction  := io.enq.bits.bpu_info(i)
+      uops(i).debug_events   := io.enq.bits.debug_events(i)
    }
+
+   io.enq.ready := count < (num_elements-fetchWidth).U
+
+   var woffset = WireInit(0.asUInt(width=(log2Ceil(fetchWidth)+1).W))
+   for (i <- 0 until fetchWidth)
+   {
+      when (io.enq.fire() && io.enq.bits.mask(i))
+      {
+         ram(write_ptr+woffset) := uops(i)
+      }
+      woffset = woffset + Mux(io.enq.fire() && io.enq.bits.mask(i), 1.U, 0.U)
+//      printf("i=%d %d m:%d woffset: %d\n", i.U, io.enq.fire(), io.enq.bits.mask(i), woffset)
+   }
+
+   val enq_count = Mux(io.enq.fire(), PopCount(io.enq.bits.mask), 0.U)
+   val deq_count =
+      Mux(io.deq.ready,
+         Mux(count < DECODE_WIDTH.U, count, DECODE_WIDTH.U),
+         0.U)
+   count := count + enq_count - deq_count
+
+   // TODO turn into bit-vector
+   write_ptr := write_ptr + woffset
+   read_ptr := read_ptr + deq_count
+
+
+
+   // Dequeue uops.
+
+   io.deq.valid := count > 0.U
+   for (w <- 0 until DECODE_WIDTH)
+   {
+      io.deq.bits.uops(w) := ram(read_ptr + w.U)
+      io.deq.bits.uops(w).valid := count > w.U
+   }
+
+
+   when (io.clear)
+   {
+      count := 0.U
+      write_ptr := 0.U
+      read_ptr := 0.U
+   }
+
+
+   // print out WENs. (F3).
+   // print out RENs. (dec).
+   // print out valids.
+
+   if (DEBUG_PRINTF)
+   {
+      // TODO a problem if we don't check the f3_valid?
+      printf(" Fetch3 : (%d mask: %x) pc=0x%x enq_count (%d) %d\n",
+         io.enq.valid,
+         io.enq.bits.mask,
+         io.enq.bits.pc,
+         enq_count,
+         io.clear
+         )
+
+      printf(" FB RAM :     count (%d) WA: %d, RA: %d ",
+         count,
+         write_ptr,
+         read_ptr
+         )
+
+//      for (i <- 0 until num_elements)
+//      {
+//         printf("%d", ram(i.U).valid)
+//      }
+
+      printf("\n Fetch4 : deq_count (%d)\n",
+         deq_count
+         )
+   }
+    
+   assert (count >= deq_count, "[fetchbuffer] Trying to dequeue more uops than are available.")
+ 
+//   var debug_valid_count = WireInit(0.asUInt(width=log2Ceil(num_elements).W))
+//   for (i <- 0 until num_elements)
+//   {
+//      debug_valid_count = debug_valid_count + Mux(ram(i.U).valid, 1.U, 0.U)
+//   }
+//   assert (count === debug_valid_count, "[fetchbuffer] count also wrong")
+ 
+   assert (woffset === enq_count, "[fetchbuffer] woffset =/= enqcount")
+
 
    override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }

--- a/src/main/scala/ifu/fetchmonitor.scala
+++ b/src/main/scala/ifu/fetchmonitor.scala
@@ -1,0 +1,172 @@
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Fetch Monitor
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//
+// Monitor a vector of MicroOps and their PCs and verify it is a valid sequence.
+//
+// NOTE: I should not be synthesized!
+
+package boom
+
+import chisel3._
+import chisel3.util._
+import chisel3.core.DontCare
+import freechips.rocketchip.config.Parameters
+
+class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
+   with HasBoomCoreParameters
+{
+   val io = IO(new BoomBundle()(p)
+   {
+      // The stream is valid and accepted by the backend.
+      val fire = Input(Bool())
+      // The stream of uops being sent to the backend.
+      val uops = Input(Vec(decodeWidth, new MicroOp()))
+      // Was the pipeline redirected? Clear/reset the fetchbuffer.
+      val clear = Input(Bool())
+   })
+
+   //-------------------------------------------------------------
+   // **** Assertions ****
+   //-------------------------------------------------------------
+
+   // Check that within a sequence the PCs are correct.
+
+   // Was the previous uop valid?
+   var prev_valid  = WireInit(false.B)
+   // What was the previous uop's PC?
+   var prev_pc = WireInit(0.asUInt(width=vaddrBitsExtended.W))
+   var prev_cfitype = WireInit(CfiType.none)
+   // What is the straight-line next PC for the previous uop?
+   var prev_npc = WireInit(0.asUInt(width=vaddrBitsExtended.W))
+   // What is the target of the previous PC if a CFI.
+   var prev_target = WireInit(0.asUInt(width=vaddrBitsExtended.W))
+
+   for ((uop,i) <- io.uops.zipWithIndex)
+   {
+      if (DEBUG_PRINTF)
+      {
+         printf("monitor F4[" + i + "] %d 0x%x\n", uop.valid, uop.pc)
+      }
+   }
+
+   for (uop <- io.uops)
+   {
+      when (prev_valid && uop.valid)
+      {
+         when (prev_cfitype === CfiType.none)
+         {
+            assert (uop.pc === prev_npc, "[fetchmonitor] non-cfi went to bad next-pc.")
+         }
+         .elsewhen (prev_cfitype === CfiType.branch)
+         {
+            assert (uop.pc === prev_npc || uop.pc === prev_target,
+               "[fetchmonitor] branch went to bad next-pc.")
+         }
+         .elsewhen (prev_cfitype === CfiType.jal)
+         {
+            assert (uop.pc === prev_target, "[fetchmonitor] JAL went to bad target.")
+         }
+         .otherwise
+         {
+            // should only be here if a JALR.
+            assert (prev_cfitype === CfiType.jalr, "[fetchmonitor CFI type not JALR.")
+         }
+      }
+
+      prev_valid = uop.valid
+      prev_pc = uop.pc
+      prev_npc = prev_pc + 4.U
+      prev_cfitype = GetCfiType(uop.inst)
+      require (coreInstBytes == 4)
+      prev_target =
+         Mux(prev_cfitype === CfiType.jal,
+            ComputeJALTarget(uop.pc, uop.inst, xLen),
+            ComputeBranchTarget(uop.pc, uop.inst, xLen))
+   }
+
+
+
+   // Check if the enqueue'd PC is a target of the previous valid enqueue'd PC.
+
+   // Was the last uop from the previous decode group valid?
+   var last_valid  = RegInit(false.B)
+   // What was the previous decode group's last uop's PC?
+   var last_pc = RegInit(0.asUInt(width=vaddrBitsExtended.W))
+   var last_cfitype = RegInit(CfiType.none)
+   // What is the straight-line next PC for the previous uop?
+   var last_npc = RegInit(0.asUInt(width=vaddrBitsExtended.W))
+   // What is the target of the previous PC if a CFI.
+   var last_target = RegInit(0.asUInt(width=vaddrBitsExtended.W))
+
+   when (io.fire)
+   {
+      last_valid := true.B
+
+      val valid_mask = VecInit(io.uops map {u => u.valid}).asUInt
+      assert (valid_mask =/= 0.U)
+      val end_idx = (fetchWidth-1).U - PriorityEncoder(Reverse(valid_mask))
+      val end_uop = io.uops(end_idx)
+      val end_pc = end_uop.pc
+
+      last_pc := end_pc
+      last_npc := end_pc + 4.U; require (coreInstBytes == 4)
+      last_cfitype := GetCfiType(end_uop.inst)
+      last_target :=
+         Mux(GetCfiType(end_uop.inst) === CfiType.jal,
+            ComputeJALTarget(end_uop.pc, end_uop.inst, xLen),
+            ComputeBranchTarget(end_uop.pc, end_uop.inst, xLen))
+
+
+      when (last_valid)
+      {
+         val first_idx = PriorityEncoder(valid_mask)
+         val first_pc = io.uops(first_idx).pc
+         when (last_cfitype === CfiType.none)
+         {
+            when (first_pc =/= last_npc)
+            {
+               printf("  first_pc: 0x%x last_npc: 0x%x  ",
+                  first_pc, last_npc)
+            }
+            assert (first_pc === last_npc,
+               "[fetchmonitor] A non-cfi instruction is followed by the wrong instruction.")
+         }
+         .elsewhen (last_cfitype === CfiType.jal)
+         {
+            // ignore misaligned fetches.
+            val f_pc = first_pc(vaddrBitsExtended-1, log2Ceil(coreInstBytes))
+            val targ = last_target(vaddrBitsExtended-1, log2Ceil(coreInstBytes))
+            assert (f_pc === targ,
+               "[fetchmonitor] A jump is followed by the wrong instruction.")
+         }
+         .elsewhen (last_cfitype === CfiType.branch)
+         {
+            // ignore misaligned fetches.
+            val f_pc = first_pc(vaddrBitsExtended-1, log2Ceil(coreInstBytes))
+            val targ = last_target(vaddrBitsExtended-1, log2Ceil(coreInstBytes))
+            assert (first_pc === last_npc || f_pc === targ,
+               "[fetchmonitor] A branch is followed by the wrong instruction.")
+         }
+         .otherwise
+         {
+            // we can't verify JALR instruction stream integrity --  /throws hands up.
+            assert (last_cfitype === CfiType.jalr,
+               "[fetchmonitor] Should be a JALR if none of the others were valid.")
+         }
+      }
+   }
+
+
+   when (io.clear)
+   {
+      last_valid := false.B
+   }
+
+
+
+   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
+}
+

--- a/src/main/scala/ifu/fetchmonitor.scala
+++ b/src/main/scala/ifu/fetchmonitor.scala
@@ -48,33 +48,33 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
    {
       if (DEBUG_PRINTF)
       {
-         printf("monitor F4[" + i + "] %d 0x%x\n", uop.valid, uop.pc)
+         printf("monitor F4[" + i + "] %d %d 0x%x\n", io.fire, uop.valid, uop.pc)
       }
    }
 
    for (uop <- io.uops)
    {
-      when (prev_valid && uop.valid)
-      {
-         when (prev_cfitype === CfiType.none)
-         {
-            assert (uop.pc === prev_npc, "[fetchmonitor] non-cfi went to bad next-pc.")
-         }
-         .elsewhen (prev_cfitype === CfiType.branch)
-         {
-            assert (uop.pc === prev_npc || uop.pc === prev_target,
-               "[fetchmonitor] branch went to bad next-pc.")
-         }
-         .elsewhen (prev_cfitype === CfiType.jal)
-         {
-            assert (uop.pc === prev_target, "[fetchmonitor] JAL went to bad target.")
-         }
-         .otherwise
-         {
-            // should only be here if a JALR.
-            assert (prev_cfitype === CfiType.jalr, "[fetchmonitor CFI type not JALR.")
-         }
-      }
+      //when (prev_valid && uop.valid)
+      //{
+      //   when (prev_cfitype === CfiType.none)
+      //   {
+      //      assert (uop.pc === prev_npc, "[fetchmonitor] non-cfi went to bad next-pc.")
+      //   }
+      //   .elsewhen (prev_cfitype === CfiType.branch)
+      //   {
+      //      assert (uop.pc === prev_npc || uop.pc === prev_target,
+      //         "[fetchmonitor] branch went to bad next-pc.")
+      //   }
+      //   .elsewhen (prev_cfitype === CfiType.jal)
+      //   {
+      //      assert (uop.pc === prev_target, "[fetchmonitor] JAL went to bad target.")
+      //   }
+      //   .otherwise
+      //   {
+      //      // should only be here if a JALR.
+      //      assert (prev_cfitype === CfiType.jalr, "[fetchmonitor CFI type not JALR.")
+      //   }
+      //}
 
       prev_valid = uop.valid
       prev_pc = uop.pc

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -299,7 +299,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    // **** Printfs ****
    //-------------------------------------------------------------
 
-   if (DEBUG_PRINTF)
+   if (DEBUG_PRINTF && DEBUG_PRINTF_FTQ)
    {
       printf("FTQ: %c %c: %d; commit: %c:%d brinfo: %c:%d [%d %d %d]\n",
          Mux(io.enq.valid, Str("V"), Str("-")),

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -49,7 +49,7 @@ import chisel3.internal.sourceinfo.SourceInfo
 class BoomFrontendIO(implicit p: Parameters) extends BoomBundle()(p)
 {
    // Give the backend a packet of instructions.
-   val fetchpacket       = new DecoupledIO(new FetchBundle).flip
+   val fetchpacket       = new DecoupledIO(new FetchBufferResp).flip
 
    val br_unit           = new BranchUnitResp().asOutput
    val get_pc            = new GetPCFromFtqIO().flip

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -1290,7 +1290,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: freechips.rocke
    // TODO refactor this logic
    require (isPow2(num_ld_entries))
    require (isPow2(num_st_entries))
-   for (w <- 0 until DECODE_WIDTH)
+   for (w <- 0 until decodeWidth)
    {
       val l_temp = laq_tail + w.U
       laq_is_full = ((l_temp === laq_head || l_temp === (laq_head + UInt(num_ld_entries))) && laq_maybe_full) | laq_is_full


### PR DESCRIPTION
  * Added fetchbuffer that decouples the number of fetched instructions from the 
    number of decoded instructions.
  * Maintains the same timings as before.
  * Adds a monitor to check the validity of the PC stream going into the backend.
  * Change default BoomConfig to fetch 4 instructions, decode/commit 2 instructions.