### PR TITLE
[icache] Banked I$ fetch.

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -44,7 +44,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
       btb = Some(BTBParams(nEntries = 0, updatesOutOfOrder = true)),
       dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8, nMSHRs=4, nTLBEntries=16)),
-      icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8))
+      icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=4))
       )}
    // Set TL network to 128bits wide
    case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 16)
@@ -62,7 +62,7 @@ class WithNPerfCounters(n: Int) extends Config((site, here, up) => {
 class WithSmallBooms extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r =>r.copy(
       core = r.core.copy(
-         fetchWidth = 2,
+         fetchWidth = 4,
          decodeWidth = 1,
          numRobEntries = 16,
          issueParams = Seq(
@@ -71,14 +71,14 @@ class WithSmallBooms extends Config((site, here, up) => {
             IssueParams(issueWidth=1, numEntries=4, iqType=IQT_FP.litValue)),
          numIntPhysRegisters = 56,
          numFpPhysRegisters = 48,
-         numLsuEntries = 4,
+         numLsuEntries = 8,
          maxBrCount = 4,
          tage = Some(TageParameters(enabled=false)),
          bpdBaseOnly = Some(BaseOnlyParameters(enabled=true)),
          nPerfCounters = 2),
-      icache = Some(r.icache.get.copy(fetchBytes=2*4))
+      icache = Some(r.icache.get.copy(fetchBytes=4*4))
       )}
-   case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 8)
+   case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 16)
 })
 
 

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -62,7 +62,7 @@ class WithNPerfCounters(n: Int) extends Config((site, here, up) => {
 class WithSmallBooms extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r =>r.copy(
       core = r.core.copy(
-         fetchWidth = 4,
+         fetchWidth = 2,
          decodeWidth = 1,
          numRobEntries = 16,
          issueParams = Seq(
@@ -76,9 +76,9 @@ class WithSmallBooms extends Config((site, here, up) => {
          tage = Some(TageParameters(enabled=false)),
          bpdBaseOnly = Some(BaseOnlyParameters(enabled=true)),
          nPerfCounters = 2),
-      icache = Some(r.icache.get.copy(fetchBytes=4*4))
+      icache = Some(r.icache.get.copy(fetchBytes=2*4))
       )}
-   case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 16)
+   case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 8)
 })
 
 

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -113,21 +113,21 @@ class WithMediumBooms extends Config((site, here, up) => {
 class WithMegaBooms extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r =>r.copy(
       core = r.core.copy(
-         fetchWidth = 4,
+         fetchWidth = 8,
          decodeWidth = 4,
          numRobEntries = 128,
          issueParams = Seq(
             IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue),
             IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue),
-            IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)), // TODO make this 2-wide issue
+            IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)),
          numIntPhysRegisters = 128,
-         numFpPhysRegisters = 64,
+         numFpPhysRegisters = 128,
          numLsuEntries = 32,
          maxBrCount = 16,
          btb = BTBsaParameters(nSets=512, nWays=2, nRAS=16, tagSz=20),
          tage = Some(TageParameters())),
       dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=16, nMSHRs=4, nTLBEntries=8)),
-      icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=8))
+      icache = Some(ICacheParams(fetchBytes = 8*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=8))
       )}
    // Set TL network to 128bits wide
    case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 16)

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -26,6 +26,12 @@ trait BOOMDebugConstants
    val O3PIPEVIEW_PRINTF   = false // dump trace for O3PipeView from gem5
    val O3_CYCLE_TIME       = (1000)// "cycle" time expected by o3pipeview.py
 
+   // When enabling DEBUG_PRINTF, the vertical whitespace can be padded out
+   // such that viewing the *.out file in vim can line up veritically to
+   // enable ctrl+f/ctrl+b to advance the *.out file one cycle without
+   // moving the structures.
+   val debugScreenheight  = 79
+
    // turn off stuff to dramatically reduce Chisel node count
    val DEBUG_PRINTF_LSU    = true && DEBUG_PRINTF
    val DEBUG_PRINTF_ROB    = true && DEBUG_PRINTF

--- a/src/main/scala/common/microop.scala
+++ b/src/main/scala/common/microop.scala
@@ -47,14 +47,11 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val stat_bpd_made_pred      = Bool()                 // the BPD made the prediction
    val stat_bpd_mispredicted   = Bool()                 // denominator: all committed branches
 
-   // TODO remove fetch_pc_lob (no longer needed with FTQ?).
-   val fetch_pc_lob     = UInt(width = log2Up(fetchWidth*coreInstBytes)) // track which PC was used to fetch this
-                                                                          // instruction
-
    // Index into FTQ to figure out our fetch PC.
    val ftq_idx          = UInt(width = ftqSz)
    // Low-order bits of our own PC. Combine with ftq[ftq_idx] to get PC.
-   val pc_lob           = UInt(width = log2Up(fetchWidth*coreInstBytes))
+   // Aligned to a cache-line size, as that is the greater fetch granularity.
+   val pc_lob           = UInt(width = log2Ceil(icBlockBytes).W)
 
 
    val imm_packed       = UInt(width = LONGEST_IMM_SZ) // densely pack the imm in decode...

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -151,9 +151,8 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    //************************************
    // Load/Store Unit
    val dcacheParams: DCacheParams = tileParams.dcache.get
-   val nTLBEntries = dcacheParams.nTLBEntries
-
    val icacheParams: ICacheParams = tileParams.icache.get
+   val icBlockBytes = icacheParams.blockBytes
 
    //************************************
    // Branch Prediction

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -658,7 +658,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    csr.io.retire    := PopCount(rob.io.commit.valids.asUInt)
    csr.io.exception := rob.io.com_xcpt.valid
    // csr.io.pc used for setting EPC during exception or CSR.io.trace.
-   csr.io.pc        := AlignPC(io.ifu.com_fetch_pc, fetchWidth*coreInstBytes) + rob.io.com_xcpt.bits.pc_lob
+   csr.io.pc        := AlignPCToBoundary(io.ifu.com_fetch_pc, icBlockBytes) + rob.io.com_xcpt.bits.pc_lob
    csr.io.cause     := rob.io.com_xcpt.bits.cause
    csr.io.tval      := Mux(csr.io.cause === Causes.illegal_instruction.U, 0.U, rob.io.com_xcpt.bits.badvaddr)
 
@@ -1109,10 +1109,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       println("\n Chisel Printout Enabled\n")
 
       val numFtqWhitespace = if (DEBUG_PRINTF_FTQ) (ftqSz/4)+1 else 0
-      val screenheight = 79
-//      val screenheight = 61
-//      val screenheight = 56
-       var whitespace = (screenheight - 25 + 3 -10 + 3 - decodeWidth - NUM_LSU_ENTRIES -
+       var whitespace = (debugScreenheight - 25 + 3 -10 + 3 - decodeWidth - NUM_LSU_ENTRIES -
          issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numFtqWhitespace
      )
 

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1109,8 +1109,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       println("\n Chisel Printout Enabled\n")
 
       val numFtqWhitespace = if (DEBUG_PRINTF_FTQ) (ftqSz/4)+1 else 0
-       var whitespace = (debugScreenheight - 25 + 3 -10 + 3 - decodeWidth - NUM_LSU_ENTRIES -
-         issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) - numFtqWhitespace
+      val fetchWhitespace = if (fetchWidth >= 8) 2 else 0
+       var whitespace = (debugScreenheight - 25 + 3 -10 + 3 + 4 - decodeWidth - NUM_LSU_ENTRIES -
+         issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) -
+         numFtqWhitespace - fetchWhitespace
      )
 
       println("Whitespace padded: " + whitespace)

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -116,7 +116,7 @@ class CommitSignals(implicit p: Parameters) extends BoomBundle()(p)
 class CommitExceptionSignals(implicit p: Parameters) extends BoomBundle()(p)
 {
    val ftq_idx    = UInt(width = log2Up(ftqSz))
-   val pc_lob     = UInt(width = log2Up(fetchWidth*coreInstBytes))
+   val pc_lob     = UInt(width = log2Ceil(icBlockBytes).W)
    val cause      = UInt(width = xLen)
    val badvaddr   = UInt(width = xLen)
 }
@@ -126,7 +126,7 @@ class CommitExceptionSignals(implicit p: Parameters) extends BoomBundle()(p)
 class FlushSignals(implicit p: Parameters) extends BoomBundle()(p)
 {
    val ftq_idx = UInt(width=log2Up(ftqSz).W)
-   val pc_lob = UInt(width=log2Up(fetchWidth*coreInstBytes).W)
+   val pc_lob = UInt(width=log2Ceil(icBlockBytes).W)
    val flush_typ = FlushTypes()
 }
 

--- a/src/main/scala/ifu/branchchecker.scala
+++ b/src/main/scala/ifu/branchchecker.scala
@@ -24,6 +24,7 @@ import freechips.rocketchip.config.Parameters
 // NOTE: Incoming signals may be garbage (if f2_valid not true); consumer will
 // have to handle that scenario.
 class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule()(p)
+   with HasL1ICacheBankedParameters
 {
    val io = IO(new Bundle
    {
@@ -87,7 +88,7 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
       }
    }
 
-   val nextline_pc = io.aligned_pc + UInt(fetch_width*coreInstBytes)
+   val nextline_pc = nextFetchStart(io.aligned_pc)
 
    val btb_was_wrong = io.btb_resp.valid && (wrong_cfi || wrong_target || !io.inst_mask(btb_idx))
 

--- a/src/main/scala/ifu/fetch.scala
+++ b/src/main/scala/ifu/fetch.scala
@@ -711,13 +711,26 @@ class FetchControlUnit(fetch_width: Int)(implicit p: Parameters) extends BoomMod
             , io.imem_resp.bits.data(coreInstBits-1,0)
             )
       }
-      else if (fetch_width >= 4)
+      else if (fetch_width == 4)
       {
          printf("DASM(%x)DASM(%x)DASM(%x)DASM(%x) "
             , io.imem_resp.bits.data(4*coreInstBits-1, 3*coreInstBits)
             , io.imem_resp.bits.data(3*coreInstBits-1, 2*coreInstBits)
             , io.imem_resp.bits.data(2*coreInstBits-1, 1*coreInstBits)
             , io.imem_resp.bits.data(1*coreInstBits-1,0)
+            )
+      }
+      else if (fetch_width == 8)
+      {
+         printf("\n      DASM(%x)DASM(%x)DASM(%x)DASM(%x)\n      DASM(%x)DASM(%x)DASM(%x)DASM(%x) "
+            , io.imem_resp.bits.data(8*coreInstBits-1, 7*coreInstBits)
+            , io.imem_resp.bits.data(7*coreInstBits-1, 6*coreInstBits)
+            , io.imem_resp.bits.data(6*coreInstBits-1, 5*coreInstBits)
+            , io.imem_resp.bits.data(5*coreInstBits-1, 4*coreInstBits)
+            , io.imem_resp.bits.data(4*coreInstBits-1, 3*coreInstBits)
+            , io.imem_resp.bits.data(3*coreInstBits-1, 2*coreInstBits)
+            , io.imem_resp.bits.data(2*coreInstBits-1, 1*coreInstBits)
+            , io.imem_resp.bits.data(1*coreInstBits-1, 0)
             )
       }
 

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -288,9 +288,8 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    io.take_pc.bits.addr := Mux(FlushTypes.useSamePC(io.flush.bits.flush_typ), com_pc, com_pc_plus4)
 
    // TODO CLEANUP this is wonky: the exception occurs 1 cycle faster than flushing,
-   io.com_fetch_pc := AlignPC(ram(io.com_ftq_idx).fetch_pc, fetchWidth*coreInstBytes)
-//   val xcpt_pc := AlignPC(ram(io.flush.bits.ftq_idx).fetch_pc, fetchWidth*coreInstBytes)
-   com_pc := RegNext(io.com_fetch_pc) + io.flush.bits.pc_lob
+   io.com_fetch_pc := ram(io.com_ftq_idx).fetch_pc
+   com_pc := RegNext(AlignPCToBoundary(io.com_fetch_pc, icBlockBytes)) + io.flush.bits.pc_lob
    com_pc_plus4 := com_pc + 4.U // TODO RVC
 
    assert (RegNext(io.com_ftq_idx) === io.flush.bits.ftq_idx, "[ftq] this code depends on this assumption")

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -373,7 +373,8 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters, edge: freechips.rocke
                      Mux(will_fire_load_retry, laq_addr(laq_retry_idx),
                                                io.exe_resp.bits.addr.asUInt))
 
-   val dtlb = Module(new rocket.TLB(instruction = false, lgMaxSize = log2Ceil(coreDataBytes), nEntries = nTLBEntries))
+   val dtlb = Module(new rocket.TLB(
+      instruction = false, lgMaxSize = log2Ceil(coreDataBytes), nEntries = dcacheParams.nTLBEntries))
 
    io.ptw <> dtlb.io.ptw
    dtlb.io.req.valid := will_fire_load_incoming ||

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -200,15 +200,14 @@ object WrapDec
 }
 
 // Mask off lower bits of a PC to align to a "b" Byte boundary.
-object AlignPC
+object AlignPCToBoundary
 {
-   def apply(x: UInt, b: Int): UInt =
+   def apply(pc: UInt, b: Int): UInt =
    {
-   // Invert for scenario where x longer than b
+   // Invert for scenario where pc longer than b
    // (which would clear all bits above size(b)).
-      ~(~x | (b-1).U)
+      ~(~pc | (b-1).U)
    }
-
 }
 
 


### PR DESCRIPTION
   * For wider fetch widths (>8B), bank the I$ within a cache line.
   * Supports 32B and 16B fetch width with a 4 cycle refill.
   * Supports 16B fetch width with an 8 cycle refill.
   * Supports 4B and 8B fetch with 16 and 8 cycle refills respectively.
   * Do not currently support a refillWidth that is greater than the bankWidth.