### PR TITLE
icache: vaddr to index the cache for lookups and refills

### DIFF
--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -220,6 +220,7 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
   icache.io.req.valid := s0_valid
   icache.io.req.bits.addr := s0_pc
   icache.io.invalidate := io.cpu.flush_icache
+  icache.io.s1_vaddr := s1_pc
   icache.io.s1_paddr := tlb.io.resp.paddr
   icache.io.s2_vaddr := s2_pc
   icache.io.s1_kill := s2_redirect || tlb.io.resp.miss || s2_replay


### PR DESCRIPTION
Currently, the icache uses the physical address to compute the tag
index for tag checks and the refills which restricted the ways to
be upto 4KB. This commit allows for ways to be larger than 4KB.
NOTE: The scratchpad behavior should be mostly not affected.