### PR TITLE
[fppipeline] Convert to chisel3. Manually prune IOs.

### DIFF
--- a/src/main/scala/common/microop.scala
+++ b/src/main/scala/common/microop.scala
@@ -50,7 +50,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val stat_bpd_mispredicted   = Bool()                 // denominator: all committed branches
 
    // Index into FTQ to figure out our fetch PC.
-   val ftq_idx          = UInt(width = ftqSz)
+   val ftq_idx          = UInt(width = log2Ceil(ftqSz))
    // Low-order bits of our own PC. Combine with ftq[ftq_idx] to get PC.
    // Aligned to a cache-line size, as that is the greater fetch granularity.
    val pc_lob           = UInt(width = log2Ceil(icBlockBytes).W)

--- a/src/main/scala/exu/fppipeline.scala
+++ b/src/main/scala/exu/fppipeline.scala
@@ -104,7 +104,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
    // Input (Dispatch)
    for (w <- 0 until DISPATCH_WIDTH)
    {
-      issue_unit.io.dis_valids(w) := io.dis_valids(w) && io.dis_uops(w).iqtype === UInt(issue_unit.iqType)
+      issue_unit.io.dis_valids(w) := io.dis_valids(w) && io.dis_uops(w).iqtype === issue_unit.iqType.U
       issue_unit.io.dis_uops(w) := io.dis_uops(w)
 
       // Or... add STDataGen micro-op for FP stores.
@@ -113,7 +113,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
          issue_unit.io.dis_uops(w).uopc := uopSTD
          issue_unit.io.dis_uops(w).fu_code := FUConstants.FU_FPU
          issue_unit.io.dis_uops(w).lrs1_rtype := RT_X
-         issue_unit.io.dis_uops(w).prs1_busy := Bool(false)
+         issue_unit.io.dis_uops(w).prs1_busy := false.B
       }
    }
    io.dis_readys := issue_unit.io.dis_readys
@@ -132,7 +132,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
       if (exe_units(i).supportedFuncUnits.fdiv && regreadLatency > 0)
       {
          val fdiv_issued = iss_valids(i) && iss_uops(i).fu_code_is(FU_FDV)
-         fu_types = fu_types & RegNext(~Mux(fdiv_issued, FU_FDV, Bits(0)))
+         fu_types = fu_types & RegNext(~Mux(fdiv_issued, FU_FDV, 0.U))
       }
       issue_unit.io.fu_types(i) := fu_types
 
@@ -175,7 +175,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
       // TODO HACK only let one FPU issue port issue these.
       require (w == 0)
       when (fregister_read.io.exe_reqs(w).bits.uop.uopc === uopSTD) {
-         ex.io.req.valid :=  Bool(false)
+         ex.io.req.valid :=  false.B
       }
 
       io.tosdq.valid    := fregister_read.io.exe_reqs(w).bits.uop.uopc === uopSTD

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -17,6 +17,7 @@ package boom.ifu
 
 import chisel3._
 import chisel3.util._
+import chisel3.core.DontCare
 import chisel3.experimental.dontTouch
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.Str
@@ -251,6 +252,8 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
       if (DEBUG_PRINTF) printf("FTQ: no dequeue\n")
       io.bim_update.valid := false.B
       io.bpd_update.valid := false.B
+      io.bim_update.bits := DontCare
+      io.bpd_update.bits := DontCare
    }
 
    //-------------------------------------------------------------
@@ -343,5 +346,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    // force to show up in the waveform
    val debug_deq_ptr = deq_ptr.value
    dontTouch(debug_deq_ptr)
+
+   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 


### PR DESCRIPTION
   * Convert to chisel3 and fix unconnected wire issues.
   * Convert some Valid IOs to Decoupled IOs to match its connecting partner.
   * Add asserts for these new ready signals we expect will always be true.
   * Manually add some DontCares to the dispatched uops going into the
      fppipeline that we want pruned from the Verilog output.
   * This pruning is important when the fppipeline is the top-level module
      targeted for synthesis and there is no opportunity for cross-module
      I/O optimizations.