### PR TITLE
[access] Fix failing rv64mi/access test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 *.out
 lib
+project/build.properties

--- a/src/main/scala/system/BoomTestSuites.scala
+++ b/src/main/scala/system/BoomTestSuites.scala
@@ -9,7 +9,7 @@ object BoomTestSuites
   import freechips.rocketchip.system.DefaultTestSuites._
   
   // We do not currently support breakpoints, so override the rv64mi and its descendents. 
-  val rv64miNames = rv32miNames
+  val rv64miNames = rv32miNames + "access"
   val rv64mi = new freechips.rocketchip.system.AssemblyTestSuite("rv64mi", rv64miNames)(_)
   val rv64i = List(rv64ui, rv64si, rv64mi)
   val rv64pi = List(rv64ui, rv64mi)


### PR DESCRIPTION
   * Add rv64mi/access to the list of riscv-tests we execute.
   * Fix vaddr computation regarding the high-order bits.
   * Add project/build.properties to gitignore as it is built by our
      build system.