### PR TITLE
Valid predictors

### DIFF
--- a/src/main/scala/bpu/bim.scala
+++ b/src/main/scala/bpu/bim.scala
@@ -327,7 +327,8 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
    //************************************************
    // Output.
 
-   io.resp.valid := !Mux1H(UIntToOH(s2_bank_idx), s2_conflict) || fsm_state =/= s_idle
+   val s2_fsm_idle = RegNext(RegNext(fsm_state === s_idle, false.B), false.B)
+   io.resp.valid := !Mux1H(UIntToOH(s2_bank_idx), s2_conflict) && s2_fsm_idle
    io.resp.bits.rowdata := Mux1H(UIntToOH(s2_bank_idx), s2_read_out)
    io.resp.bits.entry_idx := s2_logical_idx
 

--- a/src/main/scala/bpu/dense-btb.scala
+++ b/src/main/scala/bpu/dense-btb.scala
@@ -252,7 +252,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
    val data_sel = Wire(init = UInt(0, width = way_idx_sz))
    val hits_oh  = Wire(init = Vec.fill(nWays){ false.B })
    for (i <- 0 until nWays) {
-      when (data_out(i).cfi_idx === sel_cfi_idx && hits(i)) {
+      when (data_out(i).cfi_idx === sel_cfi_idx && hits(i) && bim.io.resp.valid) {
          data_sel   := i.U
          hits_oh(i) := true.B
       }

--- a/src/main/scala/bpu/tage-table.scala
+++ b/src/main/scala/bpu/tage-table.scala
@@ -214,7 +214,7 @@ class TageTable(
 
    val s2_tag_hit = s2_out.tag === RegEnable(s1_tag, s1_valid)
 
-   io.bp2_resp.valid     := s2_tag_hit
+   io.bp2_resp.valid     := s2_tag_hit && RegNext(fsm_state === s_idle, false.B)
    io.bp2_resp.bits.tag  := s2_out.tag
    io.bp2_resp.bits.cntr := s2_out.cntr
    io.bp2_resp.bits.cidx := s2_out.cidx

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -102,7 +102,7 @@ class WithMediumBooms extends Config((site, here, up) => {
          maxBrCount = 8,
          regreadLatency = 1,
          renameLatency = 2,
-         btb = BoomBTBParameters(nSets=64, nWays=2, nRAS=8, tagSz=20, bypassCalls=false, rasCheckForEmpty=false),
+         btb = BoomBTBParameters(btbsa=true, nSets=64, nWays=2, nRAS=8, tagSz=20, bypassCalls=false, rasCheckForEmpty=false),
          gshare = Some(GShareParameters(enabled=true, history_length=23, num_sets=4096)),
          nPerfCounters = 6,
          fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
@@ -128,7 +128,7 @@ class WithMegaBooms extends Config((site, here, up) => {
          numFpPhysRegisters = 128,
          numLsuEntries = 32,
          maxBrCount = 16,
-         btb = BoomBTBParameters(nSets=512, nWays=2, nRAS=16, tagSz=20),
+         btb = BoomBTBParameters(nSets=512, nWays=4, nRAS=16, tagSz=20),
          tage = Some(TageParameters())),
       dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=16, nMSHRs=8, nTLBEntries=32)),
       icache = Some(ICacheParams(fetchBytes = 8*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=128, nWays=4))


### PR DESCRIPTION
1. Fixed that MegaBoomConfig was not compiled
The requirement was not fulfilled:
https://github.com/ucb-bar/riscv-boom/blob/aaf42c950cd1620d7b6c4e6cc22b43aa306f3739/src/main/scala/bpu/dense-btb.scala#L100

2. Fixed that bim, dense-btb, tage could make invalid predictions
See issue:
https://github.com/ucb-bar/riscv-boom/issues/85