### PR TITLE
fix device-tree entry, output of cat /proc/cpuinfo

### DIFF
--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -90,7 +90,7 @@ class BoomTile(
 
   val cpuDevice = new Device {
     def describe(resources: ResourceBindings): Description =
-      toDescription(resources)("sifive,rocket0", dtimProperty ++ itimProperty)
+      toDescription(resources)("ucb-bar,boom0", dtimProperty ++ itimProperty)
   }
 
   ResourceBinding {


### PR DESCRIPTION
Works on the FPGA in FireSim

```
# cat /proc/cpuinfo
hart    : 0
isa     : rv64imafd
mmu     : sv39
uarch   : ucb-bar,boom0
```

