### PR TITLE
[core] Added optional tracing for retired instructions

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -65,6 +65,9 @@ class WithNPerfCounters(n: Int) extends Config((site, here, up) => {
    ))}
 })
 
+class WithTrace extends Config((site, here, up) => {
+   case BoomTilesKey => up(BoomTilesKey, site) map { r => r.copy(trace = true) }
+})
 
 // Small BOOM! Try to be fast to compile and easier to debug.
 class WithSmallBooms extends Config((site, here, up) => {

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -224,6 +224,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    // Extra Knobs and Features
    val ENABLE_COMMIT_MAP_TABLE = boomParams.enableCommitMapTable
 
+
    //************************************
    // Implicitly calculated constants
    val NUM_ROB_ROWS      = NUM_ROB_ENTRIES/decodeWidth

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -35,6 +35,8 @@ class jtagMegaBoomConfig extends Config(new WithMegaBooms ++ new DefaultBoomConf
 class SmallIntBoomConfig extends Config(new WithoutBoomFPU ++ new WithSmallBooms ++ new DefaultBoomConfig ++ new WithNBoomCores(1) ++ new WithoutTLMonitors ++ new freechips.rocketchip.system.BaseConfig)
 // scalastyle:on
 
+class TracedSmallBoomConfig extends Config(new WithTrace ++ new WithSmallBooms ++ new DefaultBoomConfig ++ new WithNBoomCores(1) ++ new WithoutTLMonitors ++ new freechips.rocketchip.system.BaseConfig)
+
 
 // Allow for some number N BOOM cores.
 class WithNBoomCores(n: Int) extends Config((site, here, up) => {


### PR DESCRIPTION
The retired instruction trace is generated by storing fetched PCs and insns in the ROB. This is not ideal for  actual hardware, but is acceptable for debugging simulations on FPGA.