### PR TITLE
[util] Generalize killable uop queues

### DIFF
--- a/src/main/scala/common/microop.scala
+++ b/src/main/scala/common/microop.scala
@@ -14,6 +14,10 @@ import freechips.rocketchip.config.Parameters
 import boom.bpu.BranchPredInfo
 import boom.exu.FUConstants
 
+abstract trait HasBoomUOP extends BoomBundle {
+  val uop = new MicroOp()
+}
+
 class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    with freechips.rocketchip.rocket.constants.MemoryOpConstants
    with freechips.rocketchip.rocket.constants.ScalarOpConstants
@@ -161,8 +165,8 @@ object CfiType
 }
 
 class MicroOpWithData(data_sz: Int)(implicit p: Parameters) extends BoomBundle()(p)
+  with HasBoomUOP
 {
-   val uop = new MicroOp()
    val data = UInt(width = data_sz)
    override def cloneType = new MicroOpWithData(data_sz)(p).asInstanceOf[this.type]
 }

--- a/src/main/scala/exu/functional_unit.scala
+++ b/src/main/scala/exu/functional_unit.scala
@@ -93,9 +93,8 @@ class GetPredictionInfo(implicit p: Parameters) extends BoomBundle()(p)
 }
 
 class FuncUnitReq(data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+  with HasBoomUOP
 {
-   val uop = new MicroOp()
-
    val num_operands = 3
 
    val rs1_data = UInt(width = data_width)
@@ -108,8 +107,8 @@ class FuncUnitReq(data_width: Int)(implicit p: Parameters) extends BoomBundle()(
 }
 
 class FuncUnitResp(data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+  with HasBoomUOP
 {
-   val uop = new MicroOp()
    val data = UInt(width = data_width)
    val fflags = new ValidIO(new FFlagsResp)
    val addr = UInt(width = vaddrBits+1) // only for maddr -> LSU

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -14,7 +14,7 @@ import Chisel._
 import freechips.rocketchip.rocket.Instructions._
 import freechips.rocketchip.rocket._
 import boom.common.MicroOp
-import boom.exu.{BrResolutionInfo, ExeUnitResp}
+import boom.exu.{BrResolutionInfo}
 
 
 // XOR fold an input that is full_length sized down to a compressed_length.
@@ -315,15 +315,15 @@ object AgePriorityEncoder
 
 
 // Assumption: enq.valid only high if not killed by branch (so don't check IsKilled on io.enq).
-class QueueForMicroOpWithData(entries: Int, data_width: Int)
+class BranchKillableQueue[T <: boom.common.HasBoomUOP](gen: T, entries: Int)
    (implicit p: freechips.rocketchip.config.Parameters)
    extends boom.common.BoomModule()(p)
    with boom.common.HasBoomCoreParameters
 {
    val io = IO(new Bundle
    {
-      val enq     = Decoupled(new ExeUnitResp(data_width)).flip
-      val deq     = Decoupled(new ExeUnitResp(data_width))
+      val enq     = Decoupled(gen).flip
+      val deq     = Decoupled(gen)
 
       val brinfo  = new BrResolutionInfo().asInput
       val flush   = Bool(INPUT)
@@ -332,7 +332,7 @@ class QueueForMicroOpWithData(entries: Int, data_width: Int)
       val count   = UInt(OUTPUT, log2Up(entries))
    })
 
-   private val ram     = Mem(entries, new ExeUnitResp(data_width))
+   private val ram     = Mem(entries, gen)
    private val valids  = Reg(init = Vec.fill(entries) {Bool(false)})
    private val brmasks = Reg(Vec(entries, UInt(width = MAX_BR_COUNT)))
 


### PR DESCRIPTION
Create a general module for queues containing BOOM MicroOps which may be killed by branch resolution. 