### PR TITLE
[dec] Fix CSR decode

### DIFF
--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -371,7 +371,7 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    io.csr_decode.csr := uop.inst(31,20)
 	val csr_en = cs.csr_cmd.isOneOf(CSR.S, CSR.C, CSR.W)
 	val csr_ren = cs.csr_cmd.isOneOf(CSR.S, CSR.C) && uop.lrs1 === 0.U
-	val system_insn = cs.csr_cmd >= CSR.I
+	val system_insn = cs.csr_cmd === CSR.I
 	val sfence = cs.uopc === uopSFENCE
 
    val cs_legal = cs.legal


### PR DESCRIPTION
This matches rocket-chip. Resolves broken `rv64mi-p-illegal` test.

https://github.com/freechipsproject/rocket-chip/blob/e03605a934ee1b276ef9b743fa3f5d1c009788ed/src/main/scala/rocket/RocketCore.scala#L251

@ccelio I'm curious why was this ever set to `>=`?