### PR TITLE
BOOM Chisel3 update

### DIFF
--- a/src/main/scala/bpu/base-only.scala
+++ b/src/main/scala/bpu/base-only.scala
@@ -17,7 +17,8 @@
 
 package boom.bpu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.core.withReset
 import freechips.rocketchip.config.{Parameters, Field}
 import boom.util.ElasticReg
@@ -52,7 +53,7 @@ class BaseOnlyBrPredictor(
    //------------------------------------------------------------
    // Get prediction in F2, buffer, and provide prediction in F3.
 
-   val q_s3_resp = withReset(reset || io.fe_clear || io.f4_redirect)
+   val q_s3_resp = withReset(reset.toBool || io.fe_clear || io.f4_redirect)
       {Module(new ElasticReg(Valid(new BimResp)))}
 
    q_s3_resp.io.enq.valid := io.f2_valid

--- a/src/main/scala/bpu/base-only.scala
+++ b/src/main/scala/bpu/base-only.scala
@@ -58,6 +58,7 @@ class BaseOnlyBrPredictor(
 
    q_s3_resp.io.enq.valid := io.f2_valid
    q_s3_resp.io.enq.bits := io.f2_bim_resp
+   q_s3_resp.io.deq.ready := DontCare
 
    io.resp.valid := q_s3_resp.io.deq.valid && q_s3_resp.io.deq.bits.valid
    io.resp.bits.takens := q_s3_resp.io.deq.bits.bits.getTakens

--- a/src/main/scala/bpu/bim.scala
+++ b/src/main/scala/bpu/bim.scala
@@ -23,7 +23,8 @@
 
 package boom.bpu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.Str
 import boom.common._
@@ -46,8 +47,8 @@ trait HasBimParameters extends HasBoomCoreParameters
    val nUpdateQueueEntries = bimParams.nUpdateQueueEntries
    val nWriteQueueEntries = bimParams.nWriteQueueEntries
 
-   val idx_sz = log2Up(nSets)
-   val row_idx_sz = log2Up(nSets)-log2Up(nBanks)
+   val idx_sz = log2Ceil(nSets)
+   val row_idx_sz = log2Ceil(nSets)-log2Ceil(nBanks)
    val row_sz = fetchWidth*2
 }
 
@@ -58,8 +59,8 @@ abstract class BimBundle(implicit val p: Parameters) extends freechips.rocketchi
 // The output from the BIM table.
 class BimResp(implicit p: Parameters) extends BimBundle()(p)
 {
-   val rowdata = UInt(width = row_sz)
-   val entry_idx = UInt(width = log2Up(nSets)) // what (logical) entry in the set is the prediction coming from?
+   val rowdata = UInt(row_sz.W)
+   val entry_idx = UInt(log2Ceil(nSets).W) // what (logical) entry in the set is the prediction coming from?
 
    def isTaken(cfi_idx: UInt) =
    {
@@ -77,7 +78,7 @@ class BimResp(implicit p: Parameters) extends BimBundle()(p)
    // Get a fetchWidth length bit-vector of taken/not-takens.
    def getTakens(): UInt =
    {
-      val takens = Wire(init=Vec.fill(fetchWidth){false.B})
+      val takens = WireInit(VecInit(Seq.fill(fetchWidth){false.B}))
       for (i <- 0 until fetchWidth)
       {
          // assumes 2-bits per branch.
@@ -92,12 +93,12 @@ class BimResp(implicit p: Parameters) extends BimBundle()(p)
 // Only store one branch worth of info.
 class BimStorage(implicit p: Parameters) extends BimBundle()(p)
 {
-   val value = UInt(width = 2) // save the old value -- needed for updating entry.
-   val entry_idx = UInt(width = log2Up(nSets)) // what (logical) entry in the set is the prediction coming from?
+   val value = UInt(2.W) // save the old value -- needed for updating entry.
+   val entry_idx = UInt(log2Ceil(nSets).W) // what (logical) entry in the set is the prediction coming from?
 
    // TODO make sure these two signals aren't stored-- push them into CfiMissInfo instead.
    val br_seen = Bool() // Track that there was a branch in the fetch packet (this storage info is valid).
-   val cfi_idx = UInt(width = log2Up(fetchWidth))
+   val cfi_idx = UInt(log2Ceil(fetchWidth).W)
 
    def isTaken = value(1)
 }
@@ -105,9 +106,9 @@ class BimStorage(implicit p: Parameters) extends BimBundle()(p)
 
 class BimUpdate(implicit p: Parameters) extends BimBundle()(p)
 {
-   val entry_idx = UInt(width = log2Up(nSets))
-   val cfi_idx = UInt(width = log2Up(fetchWidth))
-   val cntr_value = UInt(width = 2)
+   val entry_idx = UInt(log2Ceil(nSets).W)
+   val cfi_idx = UInt(log2Ceil(fetchWidth).W)
+   val cntr_value = UInt(2.W)
    val mispredicted = Bool()
    val taken = Bool()
 }
@@ -115,9 +116,9 @@ class BimUpdate(implicit p: Parameters) extends BimBundle()(p)
 
 class BimWrite(implicit p: Parameters) extends BimBundle()(p)
 {
-   val addr = UInt(width = row_idx_sz)
-   val data = UInt(width = row_sz)
-   val mask = UInt(width = row_sz)
+   val addr = UInt(row_idx_sz.W)
+   val data = UInt(row_sz.W)
+   val mask = UInt(row_sz.W)
 }
 
 
@@ -128,32 +129,32 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
       // req.valid is false if stalling (aka, we won't read and use BTB results, on cycle S1).
       // req.bits.addr is available on cycle S0.
       // resp is expected on cycle S2.
-      val req = Valid(new PCReq).flip
+      val req = Flipped(Valid(new PCReq))
       val resp = Valid(new BimResp)
       // Reset the table to some initialization state.
-      val do_reset = Bool(INPUT)
+      val do_reset = Input(Bool())
 
       // supress S1/upcoming S2 valids.
-      val flush = Bool(INPUT)
+      val flush = Input(Bool())
 
-      val update = Valid(new BimUpdate).flip
+      val update = Flipped(Valid(new BimUpdate))
    })
 
    // Which (conceptual) index do we map to?
-   private def getIdx (addr: UInt): UInt = addr >> log2Up(fetchWidth*coreInstBytes)
+   private def getIdx (addr: UInt): UInt = addr >> log2Ceil(fetchWidth*coreInstBytes)
    // Which physical row do we map to?
    private def getRowFromIdx (idx: UInt): UInt = idx >> log2Ceil(nBanks)
    // Which physical bank do we map to?
    // TODO which bits are the best to get the bank from?
-   private def getBankFromIdx (idx: UInt): UInt = idx(log2Up(nBanks)-1, 0)
+   private def getBankFromIdx (idx: UInt): UInt = idx(log2Ceil(nBanks)-1, 0)
 
 
    // for initializing the BIM, this is the value to reset the row to.
    private def initRowValue (): Vec[Bool] =
    {
-      val row = Wire(UInt(width=row_sz))
+      val row = Wire(UInt(row_sz.W))
       row := Fill(fetchWidth, 2.U)
-      Vec(row.toBools)
+      VecInit(row.toBools)
    }
 
    private def generateWriteInfo(update: BimUpdate): (UInt, UInt, UInt) =
@@ -183,9 +184,9 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
    // Return the new row.
    private def updateCounterInRow(old_row: UInt, cfi_idx: UInt, taken: Bool): UInt =
    {
-      val row = Wire(UInt(width=row_sz))
+      val row = Wire(UInt(row_sz.W))
       val shamt = cfi_idx << 1.U
-      val mask = Wire(UInt(width=row_sz))
+      val mask = Wire(UInt(row_sz.W))
       mask := ~(0x3.U << shamt)
       val old_cntr = (old_row >> shamt) & 0x3.U
       val new_cntr = updateCounter(old_cntr, taken)
@@ -198,7 +199,7 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
 
    val stall = !io.req.valid
    // Logical Index gets broken down into RowIdx and BankIdx.
-   val s0_logical_idx = Wire(UInt(width=idx_sz))
+   val s0_logical_idx = Wire(UInt(idx_sz.W))
    val last_idx = RegNext(s0_logical_idx)
    val new_idx = getIdx(io.req.bits.addr)
    s0_logical_idx := Mux(stall, last_idx, new_idx)
@@ -218,22 +219,22 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
    }
 
    // prediction
-   val s2_read_out = Reg(Vec(nBanks, UInt(width=row_sz)))
-   val s2_conflict = Reg(init = Vec.fill(nBanks){Bool(false)})
+   val s2_read_out = Reg(Vec(nBanks, UInt(row_sz.W)))
+   val s2_conflict = RegInit(VecInit(Seq.fill(nBanks){false.B}))
 
    // updates
    val r_update = Pipe(io.update)
 
    // reset/initialization
-   val s_reset :: s_wait :: s_clear :: s_idle :: Nil = Enum(UInt(), 4)
-   val fsm_state = Reg(init = s_reset)
+   val s_reset :: s_wait :: s_clear :: s_idle :: Nil = Enum(4)
+   val fsm_state = RegInit(s_reset)
    val (lag_counter, lag_done) = Counter(fsm_state === s_wait, nResetLagCycles)
    val (clear_row_addr, clear_done) = Counter(fsm_state === s_clear, nSets/nBanks)
 
 
    for (w <- 0 until nBanks)
    {
-      val ram = SeqMem(nSets/nBanks, Vec(row_sz, Bool()))
+      val ram = SyncReadMem(nSets/nBanks, Vec(row_sz, Bool()))
       ram.suggestName("bimDataArray")
 
       val ren = Wire(Bool())
@@ -257,9 +258,9 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
       // If a misprediction occurs, read out the counters and then enqueue update onto wq.
       val s0_rmw_valid = uq.io.deq.fire()
       s2_rmw_valid    := RegNext(RegNext(s0_rmw_valid))
-      val s2_rmw_row   = Wire(UInt(width = row_idx_sz))
-      val s2_rmw_data  = Wire(UInt(width = row_sz))
-      val s2_rmw_mask  = Wire(UInt(width = row_sz))
+      val s2_rmw_row   = Wire(UInt(row_idx_sz.W))
+      val s2_rmw_data  = Wire(UInt(row_sz.W))
+      val s2_rmw_mask  = Wire(UInt(row_sz.W))
 
       wq.io.enq.valid     := (uq.io.deq.valid && !uq.io.deq.bits.mispredicted) || s2_rmw_valid
       wq.io.enq.bits.addr := Mux(s2_rmw_valid, s2_rmw_row,  u_waddr)
@@ -274,11 +275,11 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
       when (wen)
       {
          val waddr = Mux(fsm_state === s_clear, clear_row_addr, wq.io.deq.bits.addr)
-         val wdata = Mux(fsm_state === s_clear, initRowValue(), Vec(wq.io.deq.bits.data.toBools))
+         val wdata = Mux(fsm_state === s_clear, initRowValue(), VecInit(wq.io.deq.bits.data.toBools))
          val wmask = Mux(fsm_state === s_clear, Fill(row_sz, 1.U), wq.io.deq.bits.mask).toBools
 
          ram.write(waddr, wdata, wmask)
-         if (DEBUG_PRINTF) printf("w:W (%d==%x) %x %x ", waddr, waddr, wdata.asUInt, Vec(wmask).asUInt)
+         if (DEBUG_PRINTF) printf("w:W (%d==%x) %x %x ", waddr, waddr, wdata.asUInt, VecInit(wmask).asUInt)
       }
       .otherwise
       {

--- a/src/main/scala/bpu/bpd-pipeline.scala
+++ b/src/main/scala/bpu/bpd-pipeline.scala
@@ -19,7 +19,8 @@
 
 package boom.bpu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.core.withReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.{Str, UIntToAugmentedUInt}
@@ -49,41 +50,41 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
    val io = IO(new BoomBundle()(p)
    {
       // Fetch0
-      val s0_req        = Valid(new freechips.rocketchip.rocket.BTBReq).flip
-      val debug_imemresp_pc= UInt(INPUT, width = vaddrBitsExtended) // For debug -- make sure I$ and BTB are synchronised.
+      val s0_req        = Flipped(Valid(new freechips.rocketchip.rocket.BTBReq))
+      val debug_imemresp_pc= Input(UInt(vaddrBitsExtended.W)) // For debug -- make sure I$ and BTB are synchronised.
 
       // Fetch1
 
       // Fetch2
-      val f2_valid      = Bool(INPUT) // f2 stage may proceed into the f3 stage.
+      val f2_valid      = Input(Bool()) // f2 stage may proceed into the f3 stage.
       val f2_btb_resp   = Valid(new BoomBTBResp)
-      val f2_stall      = Bool(INPUT) // f3 is not ready -- back-pressure the f2 stage.
-      val f2_replay     = Bool(INPUT) // I$ is replaying S2 PC into S0 again (S2 backed up or failed).
-      val f2_redirect   = Bool(INPUT) // I$ is being redirected from F2.
+      val f2_stall      = Input(Bool()) // f3 is not ready -- back-pressure the f2 stage.
+      val f2_replay     = Input(Bool()) // I$ is replaying S2 PC into S0 again (S2 backed up or failed).
+      val f2_redirect   = Input(Bool()) // I$ is being redirected from F2.
 
       // Fetch3
-      val f3_is_br      = Vec(fetch_width, Bool()).asInput // mask of branches from I$
+      val f3_is_br      = Input(Vec(fetch_width, Bool())) // mask of branches from I$
       val f3_bpd_resp   = Valid(new BpdResp)
-      val f3_btb_update = Valid(new BoomBTBUpdate).flip
-      val f3_ras_update = Valid(new RasUpdate).flip
-      val f3_stall      = Bool(INPUT) // f4 is not ready -- back-pressure the f3 stage.
+      val f3_btb_update = Flipped(Valid(new BoomBTBUpdate))
+      val f3_ras_update = Flipped(Valid(new RasUpdate))
+      val f3_stall      = Input(Bool()) // f4 is not ready -- back-pressure the f3 stage.
 
       // Fetch4
-      val f4_redirect   = Bool(INPUT) // I$ is being redirected from F4.
-      val f4_taken      = Bool(INPUT) // I$ is being redirected from F4 (and it is to take a CFI).
+      val f4_redirect   = Input(Bool()) // I$ is being redirected from F4.
+      val f4_taken      = Input(Bool()) // I$ is being redirected from F4 (and it is to take a CFI).
 
       // Commit
-      val bim_update    = Valid(new BimUpdate).flip
-      val bpd_update    = Valid(new BpdUpdate).flip
+      val bim_update    = Flipped(Valid(new BimUpdate))
+      val bpd_update    = Flipped(Valid(new BpdUpdate))
 
       // Other
-      val br_unit       = new BranchUnitResp().asInput
-      val fe_clear      = Bool(INPUT) // The FrontEnd needs to be cleared (due to redirect or flush).
-      val ftq_restore   = Valid(new RestoreHistory).flip
-      val flush         = Bool(INPUT) // pipeline flush from ROB TODO CODEREVIEW (redudant with fe_clear?)
-      val redirect      = Bool(INPUT)
-      val status_prv    = UInt(INPUT, width = freechips.rocketchip.rocket.PRV.SZ)
-      val status_debug  = Bool(INPUT)
+      val br_unit       = Input(new BranchUnitResp())
+      val fe_clear      = Input(Bool()) // The FrontEnd needs to be cleared (due to redirect or flush).
+      val ftq_restore   = Flipped(Valid(new RestoreHistory))
+      val flush         = Input(Bool()) // pipeline flush from ROB TODO CODEREVIEW (redudant with fe_clear?)
+      val redirect      = Input(Bool())
+      val status_prv    = Input(UInt(freechips.rocketchip.rocket.PRV.SZ.W))
+      val status_debug  = Input(Bool())
    })
 
    //************************************************

--- a/src/main/scala/bpu/brpredictor.scala
+++ b/src/main/scala/bpu/brpredictor.scala
@@ -168,6 +168,7 @@ abstract class BrPredictor(
    private def UpdateHistoryHash(old: UInt, addr: UInt): UInt =
    {
       val ret = Wire(UInt(history_length.W))
+      ret := DontCare
 
       //ret := ((addr >> 4.U) & 0xf.U) | (old << 4.U) -- for debugging
       val pc = addr >> log2Ceil(coreInstBytes)
@@ -188,8 +189,8 @@ abstract class BrPredictor(
          val h2 = (o1 ^ (o1 >> (sz0/2).U))(sz0/2-1,0)
          val min = h0.getWidth + h1.getWidth
          ret := Cat(old(history_length-1, min), h2, h1, h0)
+         ret
       }
-      ret
    }
 
 

--- a/src/main/scala/bpu/btb.scala
+++ b/src/main/scala/bpu/btb.scala
@@ -12,7 +12,8 @@
 
 package boom.bpu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import boom.common._
 import boom.exu._
@@ -58,7 +59,7 @@ trait HasBoomBTBParameters extends HasBoomCoreParameters
 object BpredType
 {
    def SZ = 3
-   def apply() = UInt(width = SZ)
+   def apply() = UInt(SZ.W)
    def branch = 0.U
    def jump = 1.U
    def ret =  (2+1).U
@@ -85,12 +86,12 @@ abstract class BoomBTBBundle(implicit val p: Parameters) extends freechips.rocke
 class BoomBTBResp(implicit p: Parameters) extends BoomBTBBundle()(p)
 {
    val taken     = Bool()   // is BTB predicting a taken cfi?
-   val target    = UInt(width = vaddrBits) // what target are we predicting?
-   val mask      = UInt(width = fetchWidth) // mask of valid instructions.
-   val cfi_idx   = UInt(width = log2Up(fetchWidth)) // where is cfi we are predicting?
+   val target    = UInt(vaddrBits.W) // what target are we predicting?
+   val mask      = UInt(fetchWidth.W) // mask of valid instructions.
+   val cfi_idx   = UInt(log2Ceil(fetchWidth).W) // where is cfi we are predicting?
    val bpd_type  = BpredType() // which predictor should we use?
    val cfi_type  = CfiType()  // what type of instruction is this?
-   val fetch_pc  = UInt(width = vaddrBits) // the PC we're predicting on (start of the fetch packet).
+   val fetch_pc  = UInt(vaddrBits.W) // the PC we're predicting on (start of the fetch packet).
 
    val bim_resp  = Valid(new BimResp) // Output from the bimodal table. Valid if prediction provided.
 }
@@ -100,10 +101,10 @@ class BoomBTBResp(implicit p: Parameters) extends BoomBTBBundle()(p)
 //  - "cfi_pc" is the PC of the branch instruction.
 class BoomBTBUpdate(implicit p: Parameters) extends BoomBTBBundle()(p)
 {
-   val pc = UInt(width = vaddrBits)
-   val target = UInt(width = vaddrBits)
+   val pc = UInt(vaddrBits.W)
+   val target = UInt(vaddrBits.W)
    val taken = Bool()
-   val cfi_pc = UInt(width = vaddrBits)
+   val cfi_pc = UInt(vaddrBits.W)
    val bpd_type = BpredType()
    val cfi_type = CfiType()
 }
@@ -112,12 +113,12 @@ class RasUpdate(implicit p: Parameters) extends BoomBTBBundle()(p)
 {
    val is_call = Bool()
    val is_ret = Bool()
-   val return_addr = UInt(width = vaddrBits)
+   val return_addr = UInt(vaddrBits.W)
 }
 
 class PCReq(implicit p: Parameters) extends BoomBTBBundle()(p)
 {
-   val addr = UInt(width = vaddrBitsExtended)
+   val addr = UInt(vaddrBitsExtended.W)
 }
 
 //------------------------------------------------------------------------------
@@ -129,21 +130,21 @@ class RAS(nras: Int, coreInstBytes: Int)
    def push(addr: UInt): Unit =
    {
       when (count < nras.U) { count := count + 1.U }
-      val nextPos = Mux(Bool(isPow2(nras)) || pos < UInt(nras-1), pos+1.U, 0.U)
-      stack(nextPos) := addr >> log2Up(coreInstBytes)
+      val nextPos = Mux(isPow2(nras).B || pos < (nras-1).U, pos+1.U, 0.U)
+      stack(nextPos) := addr >> log2Ceil(coreInstBytes)
       pos := nextPos
    }
-   def peek: UInt = Cat(stack(pos), UInt(0, log2Up(coreInstBytes)))
+   def peek: UInt = Cat(stack(pos), 0.U(log2Ceil(coreInstBytes).W))
    def pop(): Unit = when (!isEmpty)
    {
       count := count - 1.U
-      pos := Mux(Bool(isPow2(nras)) || pos > 0.U, pos-1.U, UInt(nras-1))
+      pos := Mux(isPow2(nras).B || pos > 0.U, pos-1.U, (nras-1).U)
    }
-   //def clear(): Unit = count := UInt(0)
-   def isEmpty: Bool = count === UInt(0)
+   //def clear(): Unit = count := 0.U
+   def isEmpty: Bool = count === 0.U
 
-   private val count = Reg(UInt(width = log2Up(nras+1)))
-   private val pos = Reg(UInt(width = log2Up(nras)))
+   private val count = Reg(UInt(log2Ceil(nras+1).W))
+   private val pos = Reg(UInt(log2Ceil(nras).W))
    private val stack = Reg(Vec(nras, UInt()))
 }
 
@@ -158,7 +159,7 @@ abstract class BoomBTB(implicit p: Parameters) extends BoomModule()(p) with HasB
       // req.valid is false if stalling (aka, we won't read and use BTB results, on cycle S1).
       // req.bits.addr is available on cycle S0.
       // resp is expected on cycle S2.
-      val req = Valid(new PCReq).flip
+      val req = Flipped(Valid(new PCReq))
 
       // resp is valid if there is a BTB hit.
       val resp = Valid(new BoomBTBResp)
@@ -168,15 +169,15 @@ abstract class BoomBTB(implicit p: Parameters) extends BoomModule()(p) with HasB
       //val s1_pc  = UInt(width = vaddrBits)
 
       // supress S1 (so next cycle S2 is not valid).
-      val flush = Bool(INPUT)
+      val flush = Input(Bool())
 
-      val btb_update = Valid(new BoomBTBUpdate).flip
-      val bim_update = Valid(new BimUpdate).flip
-      val ras_update = Valid(new RasUpdate).flip
+      val btb_update = Flipped(Valid(new BoomBTBUpdate))
+      val bim_update = Flipped(Valid(new BimUpdate))
+      val ras_update = Flipped(Valid(new RasUpdate))
 
       // HACK: prevent BTB updating/predicting during program load.
       // Easier to diff against spike which doesn't run debug mode.
-      val status_debug = Bool(INPUT)
+      val status_debug = Input(Bool())
    })
 
    override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)

--- a/src/main/scala/bpu/dense-btb.scala
+++ b/src/main/scala/bpu/dense-btb.scala
@@ -25,7 +25,8 @@
 
 package boom.bpu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import boom.common._
 import boom.exu._
@@ -57,16 +58,16 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
 
    class BTBSetData extends Bundle
    {
-      val tag      = UInt(width = tag_sz)
-      val offset   = UInt(width = offset_sz)
+      val tag      = UInt(tag_sz.W)
+      val offset   = UInt(offset_sz.W)
       val bpd_type = BpredType()
       val cfi_type = CfiType()
-      val cfi_idx  = UInt(width = log2Up(fetchWidth))
+      val cfi_idx  = UInt(log2Ceil(fetchWidth).W)
    }
 
    class BTBUpdateQueueEntry extends Bundle
    {
-      val level  = UInt(width = blevel_sz)
+      val level  = UInt(blevel_sz.W)
       val update = new BoomBTBUpdate()
    }
 
@@ -99,15 +100,15 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
    // logic below assumes number of ways to be 4 and only supports writing the dense branches biased toward the lower ways
    require(nWays == 4)
    private def getBankWriteData(next_way: UInt, btb_q_entry: BTBUpdateQueueEntry) = {
-      val wdata = Wire(init = Vec.fill(nWays){new BTBSetData().fromBits(0.U)})
-      val wmask = Wire(UInt(0, width = nWays))
+      val wdata = WireInit(VecInit(Seq.fill(nWays){(0.U).asTypeOf(new BTBSetData())}))
+      val wmask = WireInit(0.U(nWays.W))
 
       val level = btb_q_entry.level
       when (level === 0.U) {
          for (i <- 0 until nWays) {
             wdata(i).tag      := getTag(btb_q_entry.update.pc)
             wdata(i).offset   := btb_q_entry.update.target(offset_sz+lsb_sz-1,lsb_sz)
-            wdata(i).cfi_idx  := btb_q_entry.update.cfi_pc >> log2Up(coreInstBytes)
+            wdata(i).cfi_idx  := btb_q_entry.update.cfi_pc >> log2Ceil(coreInstBytes)
             wdata(i).bpd_type := btb_q_entry.update.bpd_type
             wdata(i).cfi_type := btb_q_entry.update.cfi_type
          }
@@ -117,7 +118,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
       when (level === 1.U) {
          wdata(1).tag      := getTag(btb_q_entry.update.pc)
          wdata(1).offset   := btb_q_entry.update.target(min(vaddrBits-1, tag_sz+2*offset_sz+lsb_sz-1), tag_sz+offset_sz+lsb_sz)
-         wdata(1).cfi_idx  := btb_q_entry.update.cfi_pc >> log2Up(coreInstBytes)
+         wdata(1).cfi_idx  := btb_q_entry.update.cfi_pc >> log2Ceil(coreInstBytes)
          wdata(1).bpd_type := btb_q_entry.update.bpd_type
          wdata(1).cfi_type := btb_q_entry.update.cfi_type
          wdata(0).tag      := btb_q_entry.update.target(tag_sz+offset_sz+lsb_sz-1, offset_sz+lsb_sz)
@@ -133,7 +134,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
             }
             wdata(2).tag      := getTag(btb_q_entry.update.pc)
             wdata(2).offset   := btb_q_entry.update.target(min(vaddrBits-1, 2*tag_sz + 3*offset_sz+lsb_sz-1), 2*(tag_sz+offset_sz)+lsb_sz)
-            wdata(2).cfi_idx  := btb_q_entry.update.cfi_pc >> log2Up(coreInstBytes)
+            wdata(2).cfi_idx  := btb_q_entry.update.cfi_pc >> log2Ceil(coreInstBytes)
             wdata(2).bpd_type := btb_q_entry.update.bpd_type
             wdata(2).cfi_type := btb_q_entry.update.cfi_type
             wmask             := 7.U
@@ -163,10 +164,11 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
    // wire declarations for collecting response
    val s1_valid     = Wire(Bool())
    val s1_resp_bits = Wire(new BoomBTBResp)
+   s1_resp_bits := DontCare //Overridden later
 
    // used to collect each hit; used in RAS
    val hits        = Wire(Vec(nWays, Bool()))
-   val blevels_vec = Wire(Vec(nWays, UInt(width = blevel_sz)))
+   val blevels_vec = Wire(Vec(nWays, UInt(blevel_sz.W)))
 
    // collect data out of the corresponding bank
    val data_out = Wire(Vec(nWays, new BTBSetData()))
@@ -190,26 +192,26 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
    btb_update_q.io.deq.ready := false.B
    for (b <- 0 until nBanks)
    {
-      val valids  = Reg(init = Vec(Seq.fill(nSets)(0.U(nWays.W))))
-      val blevels = Reg(init = Vec(Seq.fill(nSets)(0.U((nWays*blevel_sz).W))))
-      val data    = SeqMem(nSets, Vec(nWays, UInt(width=(new BTBSetData).getWidth.W)))
+      val valids  = RegInit(VecInit(Seq.fill(nSets)(0.U(nWays.W))))
+      val blevels = RegInit(VecInit(Seq.fill(nSets)(0.U((nWays*blevel_sz).W))))
+      val data    = SyncReadMem(nSets, Vec(nWays, UInt((new BTBSetData).getWidth.W)))
       data.suggestName("btb_data_array")
       valids.suggestName("valids_array")
 
       val bank_vals = valids(s1_idx)
       val ren       = getBank(io.req.bits.addr) === b.U
       val rout_bits = data.read(s0_idx, ren)
-      val rout      = Vec(rout_bits map { x => new BTBSetData().fromBits(x) })
+      val rout      = VecInit(rout_bits map { x => x.asTypeOf(new BTBSetData()) })
       val bank_hits = (bank_vals.toBools zip rout map {case(hit, data) => hit && data.tag === s1_req_tag})
 
       if (b == 0) {
          hits      := bank_hits
-         blevels_vec := Vec(blevels(s1_idx).grouped(blevel_sz))
+         blevels_vec := VecInit(blevels(s1_idx).grouped(blevel_sz))
          data_out  := rout
       } else {
          when (getBank(s1_pc) === b.U) {
             hits        := bank_hits
-            blevels_vec := Vec(blevels(s1_idx).grouped(blevel_sz))
+            blevels_vec := VecInit(blevels(s1_idx).grouped(blevel_sz))
             data_out  := rout
          }
       }
@@ -220,7 +222,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
       {
          btb_update_q.io.deq.ready := true.B
          val (wmask, wdata) = getBankWriteData(next_way, btb_update_q.io.deq.bits)
-         val wdata_bits = Vec(wdata map { x => x.asUInt })
+         val wdata_bits = VecInit(wdata map { x => x.asUInt })
          data.write(widx, wdata_bits, wmask.toBools)
 
          when (btb_update_q.io.deq.bits.level === 0.U) {
@@ -249,8 +251,8 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
 
    val sel_cfi_idx = PriorityEncoder(cfi_oh)
 
-   val data_sel = Wire(init = UInt(0, width = way_idx_sz))
-   val hits_oh  = Wire(init = Vec.fill(nWays){ false.B })
+   val data_sel = WireInit(0.U(way_idx_sz.W))
+   val hits_oh  = WireInit(VecInit(Seq.fill(nWays){ false.B }))
    for (i <- 0 until nWays) {
       when (data_out(i).cfi_idx === sel_cfi_idx && hits(i) && bim.io.resp.valid) {
          data_sel   := i.U
@@ -265,7 +267,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
    // TODO: Generalize the logic to read out; Currently, uses the same assumptions as in getBankWriteData
    val blevel = blevels_vec(data_sel)
    when (blevel === 0.U) {
-      s1_resp_bits.target   := Cat(s1_pc(vaddrBits-1,offset_sz+lsb_sz), data_out(data_sel).offset, UInt(0, lsb_sz))
+      s1_resp_bits.target   := Cat(s1_pc(vaddrBits-1,offset_sz+lsb_sz), data_out(data_sel).offset, 0.U(lsb_sz.W))
       s1_resp_bits.cfi_idx  := (if (fetchWidth > 1) data_out(data_sel).cfi_idx else 0.U)
       s1_resp_bits.bpd_type := data_out(data_sel).bpd_type
       s1_resp_bits.cfi_type := data_out(data_sel).cfi_type
@@ -280,7 +282,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
             data_out(1).offset((vaddrBits-1)-(tag_sz+offset_sz+lsb_sz), 0),
             data_out(0).tag,
             data_out(0).offset,
-            UInt(0,lsb_sz)
+            0.U(lsb_sz.W)
          )
       } else {
          Cat(
@@ -288,7 +290,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
             data_out(1).offset,
             data_out(0).tag,
             data_out(0).offset,
-            UInt(0,lsb_sz)
+            0.U(lsb_sz.W)
          )
       }
       s1_resp_bits.target := resp_target
@@ -306,7 +308,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
                data_out(1).offset,
                data_out(0).tag,
                data_out(0).offset,
-               UInt(0,lsb_sz)
+               0.U(lsb_sz.W)
             )
          } else {
             Cat(
@@ -316,7 +318,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
                data_out(1).offset,
                data_out(0).tag,
                data_out(0).offset,
-               UInt(0,lsb_sz)
+               0.U(lsb_sz.W)
             )
          }
          s1_resp_bits.target := resp_target

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -5,7 +5,7 @@
 
 package boom.common
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.subsystem.{SystemBusKey}
 import freechips.rocketchip.devices.tilelink.{BootROMParams}

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -14,7 +14,8 @@ package boom.common
 package constants
 {
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 import freechips.rocketchip.util.Str
@@ -43,16 +44,16 @@ trait BOOMDebugConstants
 
 trait BrPredConstants
 {
-   val NOT_TAKEN = Bool(false)
-   val TAKEN = Bool(true)
+   val NOT_TAKEN = false.B
+   val TAKEN = true.B
 }
 
 trait IQType
 {
    val IQT_SZ  = 2
-   val IQT_INT = UInt(0, IQT_SZ)
-   val IQT_MEM = UInt(1, IQT_SZ)
-   val IQT_FP  = UInt(2, IQT_SZ)
+   val IQT_INT = 0.U(IQT_SZ.W)
+   val IQT_MEM = 1.U(IQT_SZ.W)
+   val IQT_FP  = 2.U(IQT_SZ.W)
 }
 
 trait ScalarOpConstants
@@ -69,227 +70,229 @@ trait ScalarOpConstants
    // Control Signals
 
    // PC Select Signal
-   val PC_PLUS4 = UInt(0, 2)  // PC + 4
-   val PC_BRJMP = UInt(1, 2)  // brjmp_target
-   val PC_JALR  = UInt(2, 2)  // jump_reg_target
+   val PC_PLUS4 = 0.U(2.W)  // PC + 4
+   val PC_BRJMP = 1.U(2.W)  // brjmp_target
+   val PC_JALR  = 2.U(2.W)  // jump_reg_target
 
    // Branch Type
-   val BR_N   = UInt(0, 4)  // Next
-   val BR_NE  = UInt(1, 4)  // Branch on NotEqual
-   val BR_EQ  = UInt(2, 4)  // Branch on Equal
-   val BR_GE  = UInt(3, 4)  // Branch on Greater/Equal
-   val BR_GEU = UInt(4, 4)  // Branch on Greater/Equal Unsigned
-   val BR_LT  = UInt(5, 4)  // Branch on Less Than
-   val BR_LTU = UInt(6, 4)  // Branch on Less Than Unsigned
-   val BR_J   = UInt(7, 4)  // Jump
-   val BR_JR  = UInt(8, 4)  // Jump Register
+   val BR_N   = 0.U(4.W)  // Next
+   val BR_NE  = 1.U(4.W)  // Branch on NotEqual
+   val BR_EQ  = 2.U(4.W)  // Branch on Equal
+   val BR_GE  = 3.U(4.W)  // Branch on Greater/Equal
+   val BR_GEU = 4.U(4.W)  // Branch on Greater/Equal Unsigned
+   val BR_LT  = 5.U(4.W)  // Branch on Less Than
+   val BR_LTU = 6.U(4.W)  // Branch on Less Than Unsigned
+   val BR_J   = 7.U(4.W)  // Jump
+   val BR_JR  = 8.U(4.W)  // Jump Register
 
    // RS1 Operand Select Signal
-   val OP1_RS1 = UInt(0, 2) // Register Source #1
-   val OP1_ZERO= UInt(1, 2)
-   val OP1_PC  = UInt(2, 2)
+   val OP1_RS1 = 0.U(2.W) // Register Source #1
+   val OP1_ZERO= 1.U(2.W)
+   val OP1_PC  = 2.U(2.W)
    val OP1_X   = BitPat("b??")
 
    // RS2 Operand Select Signal
-   val OP2_RS2 = UInt(0, 3) // Register Source #2
-   val OP2_IMM = UInt(1, 3) // immediate
-   val OP2_ZERO= UInt(2, 3) // constant 0
-   val OP2_FOUR= UInt(3, 3) // constant 4 (for PC+4)
-   val OP2_IMMC= UInt(4, 3) // for CSR imm found in RS1
+   val OP2_RS2 = 0.U(3.W) // Register Source #2
+   val OP2_IMM = 1.U(3.W) // immediate
+   val OP2_ZERO= 2.U(3.W) // constant 0
+   val OP2_FOUR= 3.U(3.W) // constant 4 (for PC+4)
+   val OP2_IMMC= 4.U(3.W) // for CSR imm found in RS1
    val OP2_X   = BitPat("b???")
 
    // Register File Write Enable Signal
-   val REN_0   = Bool(false)
-   val REN_1   = Bool(true)
+   val REN_0   = false.B
+   val REN_1   = true.B
 
    // Is 32b Word or 64b Doubldword?
    val SZ_DW = 1
-   val DW_X   = Bool(true) // Bool(xLen==64)
-   val DW_32  = Bool(false)
-   val DW_64  = Bool(true)
-   val DW_XPR = Bool(true) // Bool(xLen==64)
+   val DW_X   = true.B // Bool(xLen==64)
+   val DW_32  = false.B
+   val DW_64  = true.B
+   val DW_XPR = true.B // Bool(xLen==64)
 
    // Memory Enable Signal
-   val MEN_0   = Bool(false)
-   val MEN_1   = Bool(true)
-   val MEN_X   = Bool(false)
+   val MEN_0   = false.B
+   val MEN_1   = true.B
+   val MEN_X   = false.B
 
    // Immediate Extend Select
-   val IS_I   = UInt(0, 3)  // I-Type  (LD,ALU)
-   val IS_S   = UInt(1, 3)  // S-Type  (ST)
-   val IS_B   = UInt(2, 3)  // SB-Type (BR)
-   val IS_U   = UInt(3, 3)  // U-Type  (LUI/AUIPC)
-   val IS_J   = UInt(4, 3)  // UJ-Type (J/JAL)
+   val IS_I   = 0.U(3.W)  // I-Type  (LD,ALU)
+   val IS_S   = 1.U(3.W)  // S-Type  (ST)
+   val IS_B   = 2.U(3.W)  // SB-Type (BR)
+   val IS_U   = 3.U(3.W)  // U-Type  (LUI/AUIPC)
+   val IS_J   = 4.U(3.W)  // UJ-Type (J/JAL)
    val IS_X   = BitPat("b???")
 
 
    // Decode Stage Control Signals
-   val RT_FIX   = UInt(0, 2)
-   val RT_FLT   = UInt(1, 2)
-   val RT_PAS   = UInt(3, 2) // pass-through (pop1 := lrs1, etc)
-   val RT_X     = UInt(2, 2) // not-a-register (but shouldn't get a busy-bit, etc.)
+   val RT_FIX   = 0.U(2.W)
+   val RT_FLT   = 1.U(2.W)
+   val RT_PAS   = 3.U(2.W) // pass-through (pop1 := lrs1, etc)
+   val RT_X     = 2.U(2.W) // not-a-register (but shouldn't get a busy-bit, etc.)
                              // TODO rename RT_NAR
 
    // Micro-op opcodes
    // TODO change micro-op opcodes into using enum
    val UOPC_SZ = 9
    val uopX    = BitPat.dontCare(UOPC_SZ)
-   val uopNOP  = UInt( 0, UOPC_SZ)
-   val uopLD   = UInt( 1, UOPC_SZ)
-   val uopSTA  = UInt( 2, UOPC_SZ)  // store address generation
-   val uopSTD  = UInt( 3, UOPC_SZ)  // store data generation
-   val uopLUI  = UInt( 4, UOPC_SZ)
+   val uopNOP  =  0.U(UOPC_SZ.W)
+   val uopLD   =  1.U(UOPC_SZ.W)
+   val uopSTA  =  2.U(UOPC_SZ.W)  // store address generation
+   val uopSTD  =  3.U(UOPC_SZ.W)  // store data generation
+   val uopLUI  =  4.U(UOPC_SZ.W)
 
-   val uopADDI = UInt( 5, UOPC_SZ)
-   val uopANDI = UInt( 6, UOPC_SZ)
-   val uopORI  = UInt( 7, UOPC_SZ)
-   val uopXORI = UInt( 8, UOPC_SZ)
-   val uopSLTI = UInt( 9, UOPC_SZ)
-   val uopSLTIU= UInt(10, UOPC_SZ)
-   val uopSLLI = UInt(11, UOPC_SZ)
-   val uopSRAI = UInt(12, UOPC_SZ)
-   val uopSRLI = UInt(13, UOPC_SZ)
+   val uopADDI =  5.U(UOPC_SZ.W)
+   val uopANDI =  6.U(UOPC_SZ.W)
+   val uopORI  =  7.U(UOPC_SZ.W)
+   val uopXORI =  8.U(UOPC_SZ.W)
+   val uopSLTI =  9.U(UOPC_SZ.W)
+   val uopSLTIU= 10.U(UOPC_SZ.W)
+   val uopSLLI = 11.U(UOPC_SZ.W)
+   val uopSRAI = 12.U(UOPC_SZ.W)
+   val uopSRLI = 13.U(UOPC_SZ.W)
 
-   val uopSLL  = UInt(14, UOPC_SZ)
-   val uopADD  = UInt(15, UOPC_SZ)
-   val uopSUB  = UInt(16, UOPC_SZ)
-   val uopSLT  = UInt(17, UOPC_SZ)
-   val uopSLTU = UInt(18, UOPC_SZ)
-   val uopAND  = UInt(19, UOPC_SZ)
-   val uopOR   = UInt(20, UOPC_SZ)
-   val uopXOR  = UInt(21, UOPC_SZ)
-   val uopSRA  = UInt(22, UOPC_SZ)
-   val uopSRL  = UInt(23, UOPC_SZ)
+   val uopSLL  = 14.U(UOPC_SZ.W)
+   val uopADD  = 15.U(UOPC_SZ.W)
+   val uopSUB  = 16.U(UOPC_SZ.W)
+   val uopSLT  = 17.U(UOPC_SZ.W)
+   val uopSLTU = 18.U(UOPC_SZ.W)
+   val uopAND  = 19.U(UOPC_SZ.W)
+   val uopOR   = 20.U(UOPC_SZ.W)
+   val uopXOR  = 21.U(UOPC_SZ.W)
+   val uopSRA  = 22.U(UOPC_SZ.W)
+   val uopSRL  = 23.U(UOPC_SZ.W)
 
-   val uopBEQ  = UInt(24, UOPC_SZ)
-   val uopBNE  = UInt(25, UOPC_SZ)
-   val uopBGE  = UInt(26, UOPC_SZ)
-   val uopBGEU = UInt(27, UOPC_SZ)
-   val uopBLT  = UInt(28, UOPC_SZ)
-   val uopBLTU = UInt(29, UOPC_SZ)
-   val uopCSRRW= UInt(30, UOPC_SZ)
-   val uopCSRRS= UInt(31, UOPC_SZ)
-   val uopCSRRC= UInt(32, UOPC_SZ)
-   val uopCSRRWI=UInt(33, UOPC_SZ)
-   val uopCSRRSI=UInt(34, UOPC_SZ)
-   val uopCSRRCI=UInt(35, UOPC_SZ)
+   val uopBEQ  = 24.U(UOPC_SZ.W)
+   val uopBNE  = 25.U(UOPC_SZ.W)
+   val uopBGE  = 26.U(UOPC_SZ.W)
+   val uopBGEU = 27.U(UOPC_SZ.W)
+   val uopBLT  = 28.U(UOPC_SZ.W)
+   val uopBLTU = 29.U(UOPC_SZ.W)
+   val uopCSRRW= 30.U(UOPC_SZ.W)
+   val uopCSRRS= 31.U(UOPC_SZ.W)
+   val uopCSRRC= 32.U(UOPC_SZ.W)
+   val uopCSRRWI=33.U(UOPC_SZ.W)
+   val uopCSRRSI=34.U(UOPC_SZ.W)
+   val uopCSRRCI=35.U(UOPC_SZ.W)
 
-   val uopJ    = UInt(36, UOPC_SZ)
-   val uopJAL  = UInt(37, UOPC_SZ)
-   val uopJALR = UInt(38, UOPC_SZ)
-   val uopAUIPC= UInt(39, UOPC_SZ)
+   val uopJ    = 36.U(UOPC_SZ.W)
+   val uopJAL  = 37.U(UOPC_SZ.W)
+   val uopJALR = 38.U(UOPC_SZ.W)
+   val uopAUIPC= 39.U(UOPC_SZ.W)
 
-//   val uopSRET = UInt(40, UOPC_SZ)
-   val uopCFLSH= UInt(41, UOPC_SZ)
-   val uopFENCE= UInt(42, UOPC_SZ)
+// val uopSRET = 40.U(UOPC_SZ.W)
+   val uopCFLSH= 41.U(UOPC_SZ.W)
+   val uopFENCE= 42.U(UOPC_SZ.W)
 
-   val uopADDIW= UInt(43, UOPC_SZ)
-   val uopADDW = UInt(44, UOPC_SZ)
-   val uopSUBW = UInt(45, UOPC_SZ)
-   val uopSLLIW= UInt(46, UOPC_SZ)
-   val uopSLLW = UInt(47, UOPC_SZ)
-   val uopSRAIW= UInt(48, UOPC_SZ)
-   val uopSRAW = UInt(49, UOPC_SZ)
-   val uopSRLIW= UInt(50, UOPC_SZ)
-   val uopSRLW = UInt(51, UOPC_SZ)
-   val uopMUL  = UInt(52, UOPC_SZ)
-   val uopMULH = UInt(53, UOPC_SZ)
-   val uopMULHU= UInt(54, UOPC_SZ)
-   val uopMULHSU=UInt(55, UOPC_SZ)
-   val uopMULW = UInt(56, UOPC_SZ)
-   val uopDIV  = UInt(57, UOPC_SZ)
-   val uopDIVU = UInt(58, UOPC_SZ)
-   val uopREM  = UInt(59, UOPC_SZ)
-   val uopREMU = UInt(60, UOPC_SZ)
-   val uopDIVW = UInt(61, UOPC_SZ)
-   val uopDIVUW= UInt(62, UOPC_SZ)
-   val uopREMW = UInt(63, UOPC_SZ)
-   val uopREMUW= UInt(64, UOPC_SZ)
+   val uopADDIW= 43.U(UOPC_SZ.W)
+   val uopADDW = 44.U(UOPC_SZ.W)
+   val uopSUBW = 45.U(UOPC_SZ.W)
+   val uopSLLIW= 46.U(UOPC_SZ.W)
+   val uopSLLW = 47.U(UOPC_SZ.W)
+   val uopSRAIW= 48.U(UOPC_SZ.W)
+   val uopSRAW = 49.U(UOPC_SZ.W)
+   val uopSRLIW= 50.U(UOPC_SZ.W)
+   val uopSRLW = 51.U(UOPC_SZ.W)
+   val uopMUL  = 52.U(UOPC_SZ.W)
+   val uopMULH = 53.U(UOPC_SZ.W)
+   val uopMULHU= 54.U(UOPC_SZ.W)
+   val uopMULHSU=55.U(UOPC_SZ.W)
+   val uopMULW = 56.U(UOPC_SZ.W)
+   val uopDIV  = 57.U(UOPC_SZ.W)
+   val uopDIVU = 58.U(UOPC_SZ.W)
+   val uopREM  = 59.U(UOPC_SZ.W)
+   val uopREMU = 60.U(UOPC_SZ.W)
+   val uopDIVW = 61.U(UOPC_SZ.W)
+   val uopDIVUW= 62.U(UOPC_SZ.W)
+   val uopREMW = 63.U(UOPC_SZ.W)
+   val uopREMUW= 64.U(UOPC_SZ.W)
 
-   val uopFENCEI    = UInt(65, UOPC_SZ)
-   //               = UInt(66, UOPC_SZ)
-   val uopAMO_AG    = UInt(67, UOPC_SZ) // AMO-address gen (use normal STD for datagen)
+   val uopFENCEI    =  65.U(UOPC_SZ.W)
+   //               =  66.U(UOPC_SZ.W)
+   val uopAMO_AG    =  67.U(UOPC_SZ.W) // AMO-address gen (use normal STD for datagen)
 
-   val uopFMV_S_X   = UInt(68, UOPC_SZ)
-   val uopFMV_D_X   = UInt(69, UOPC_SZ)
-   val uopFMV_X_S   = UInt(70, UOPC_SZ)
-   val uopFMV_X_D   = UInt(71, UOPC_SZ)
+   val uopFMV_S_X   =  68.U(UOPC_SZ.W)
+   val uopFMV_D_X   =  69.U(UOPC_SZ.W)
+   val uopFMV_X_S   =  70.U(UOPC_SZ.W)
+   val uopFMV_X_D   =  71.U(UOPC_SZ.W)
 
-   val uopFSGNJ_S   = UInt(72, UOPC_SZ)
-   val uopFSGNJ_D   = UInt(73, UOPC_SZ)
+   val uopFSGNJ_S   =  72.U(UOPC_SZ.W)
+   val uopFSGNJ_D   =  73.U(UOPC_SZ.W)
 
-   val uopFCVT_S_D  = UInt(74, UOPC_SZ)
-   val uopFCVT_D_S  = UInt(75, UOPC_SZ)
+   val uopFCVT_S_D  =  74.U(UOPC_SZ.W)
+   val uopFCVT_D_S  =  75.U(UOPC_SZ.W)
 
-   val uopFCVT_S_X  = UInt(76, UOPC_SZ)
-   val uopFCVT_D_X  = UInt(77, UOPC_SZ)
+   val uopFCVT_S_X  =  76.U(UOPC_SZ.W)
+   val uopFCVT_D_X  =  77.U(UOPC_SZ.W)
 
-   val uopFCVT_X_S  = UInt(78, UOPC_SZ)
-   val uopFCVT_X_D  = UInt(79, UOPC_SZ)
+   val uopFCVT_X_S  =  78.U(UOPC_SZ.W)
+   val uopFCVT_X_D  =  79.U(UOPC_SZ.W)
 
-   val uopCMPR_S    = UInt(80, UOPC_SZ)
-   val uopCMPR_D    = UInt(81, UOPC_SZ)
+   val uopCMPR_S    =  80.U(UOPC_SZ.W)
+   val uopCMPR_D    =  81.U(UOPC_SZ.W)
 
-   val uopFCLASS_S  = UInt(82, UOPC_SZ)
-   val uopFCLASS_D  = UInt(83, UOPC_SZ)
+   val uopFCLASS_S  =  82.U(UOPC_SZ.W)
+   val uopFCLASS_D  =  83.U(UOPC_SZ.W)
 
-   val uopFMINMAX_S = UInt(84,UOPC_SZ)
-   val uopFMINMAX_D = UInt(85,UOPC_SZ)
+   val uopFMINMAX_S =  84.U(UOPC_SZ.W)
+   val uopFMINMAX_D =  85.U(UOPC_SZ.W)
 
-   //               = UInt(86, UOPC_SZ)
-   val uopFADD_S    = UInt(87,UOPC_SZ)
-   val uopFSUB_S    = UInt(88,UOPC_SZ)
-   val uopFMUL_S    = UInt(89,UOPC_SZ)
-   val uopFADD_D    = UInt(90,UOPC_SZ)
-   val uopFSUB_D    = UInt(91,UOPC_SZ)
-   val uopFMUL_D    = UInt(92,UOPC_SZ)
+   //               =  86.U(UOPC_SZ.W)
+   val uopFADD_S    =  87.U(UOPC_SZ.W)
+   val uopFSUB_S    =  88.U(UOPC_SZ.W)
+   val uopFMUL_S    =  89.U(UOPC_SZ.W)
+   val uopFADD_D    =  90.U(UOPC_SZ.W)
+   val uopFSUB_D    =  91.U(UOPC_SZ.W)
+   val uopFMUL_D    =  92.U(UOPC_SZ.W)
 
-   val uopFMADD_S   = UInt(93,UOPC_SZ)
-   val uopFMSUB_S   = UInt(94,UOPC_SZ)
-   val uopFNMADD_S  = UInt(95,UOPC_SZ)
-   val uopFNMSUB_S  = UInt(96,UOPC_SZ)
-   val uopFMADD_D   = UInt(97,UOPC_SZ)
-   val uopFMSUB_D   = UInt(98,UOPC_SZ)
-   val uopFNMADD_D  = UInt(99,UOPC_SZ)
-   val uopFNMSUB_D  = UInt(100,UOPC_SZ)
+   val uopFMADD_S   =  93.U(UOPC_SZ.W)
+   val uopFMSUB_S   =  94.U(UOPC_SZ.W)
+   val uopFNMADD_S  =  95.U(UOPC_SZ.W)
+   val uopFNMSUB_S  =  96.U(UOPC_SZ.W)
+   val uopFMADD_D   =  97.U(UOPC_SZ.W)
+   val uopFMSUB_D   =  98.U(UOPC_SZ.W)
+   val uopFNMADD_D  =  99.U(UOPC_SZ.W)
+   val uopFNMSUB_D  = 100.U(UOPC_SZ.W)
 
-   val uopFDIV_S    = UInt(101,UOPC_SZ)
-   val uopFDIV_D    = UInt(102,UOPC_SZ)
-   val uopFSQRT_S   = UInt(103,UOPC_SZ)
-   val uopFSQRT_D   = UInt(104,UOPC_SZ)
+   val uopFDIV_S    = 101.U(UOPC_SZ.W)
+   val uopFDIV_D    = 102.U(UOPC_SZ.W)
+   val uopFSQRT_S   = 103.U(UOPC_SZ.W)
+   val uopFSQRT_D   = 104.U(UOPC_SZ.W)
 
-   val uopSYSTEM    = UInt(105, UOPC_SZ) // pass uop down the CSR pipeline and let it handle it
-   val uopSFENCE    = UInt(106, UOPC_SZ)
+   val uopSYSTEM    = 105.U(UOPC_SZ.W) // pass uop down the CSR pipeline and let it handle it
+   val uopSFENCE    = 106.U(UOPC_SZ.W)
 
    // The Bubble Instruction (Machine generated NOP)
    // Insert (XOR x0,x0,x0) which is different from software compiler
    // generated NOPs which are (ADDI x0, x0, 0).
    // Reasoning for this is to let visualizers and stat-trackers differentiate
    // between software NOPs and machine-generated Bubbles in the pipeline.
-   val BUBBLE  = UInt(0x4033, 32)
+   val BUBBLE  = (0x4033).U(32.W)
 
 
    def NullMicroOp()(implicit p: Parameters): MicroOp =
    {
       val uop = Wire(new MicroOp()(p))
+      uop            := DontCare // Overridden in the following lines
       uop.uopc       := uopNOP // maybe not required, but helps on asserts that try to catch spurious behavior
-      uop.bypassable := Bool(false)
-      uop.fp_val     := Bool(false)
-      uop.is_store   := Bool(false)
-      uop.is_load    := Bool(false)
-      uop.pdst       := UInt(0)
+      uop.bypassable := false.B
+      uop.fp_val     := false.B
+      uop.is_store   := false.B
+      uop.is_load    := false.B
+      uop.pdst       := 0.U
       uop.dst_rtype  := RT_X
-      uop.valid      := Bool(false)
+      uop.valid      := false.B
       // TODO these unnecessary? used in regread stage?
-      uop.is_br_or_jmp := Bool(false)
+      uop.is_br_or_jmp := false.B
 
       val cs = Wire(new CtrlSignals())
+      cs             := DontCare // Overridden in the following lines
       cs.br_type     := BR_N
-      cs.rf_wen      := Bool(false)
+      cs.rf_wen      := false.B
       cs.csr_cmd     := freechips.rocketchip.rocket.CSR.N
-      cs.is_load     := Bool(false)
-      cs.is_sta      := Bool(false)
-      cs.is_std      := Bool(false)
+      cs.is_load     := false.B
+      cs.is_sta      := false.B
+      cs.is_std      := false.B
 
       uop.ctrl := cs
       uop
@@ -316,16 +319,16 @@ trait RISCVConstants
    // location of the fifth bit in the shamt (for checking for illegal ops for SRAIW,etc.)
    val SHAMT_5_BIT = 25
    val LONGEST_IMM_SZ = 20
-   val X0 = UInt(0)
-   val RA = UInt(1) // return address register
+   val X0 = 0.U
+   val RA = 1.U // return address register
 
    // memory consistency model
    // The C/C++ atomics MCM requires that two loads to the same address maintain program order.
    // The Cortex A9 does NOT enforce load/load ordering (which leads to buggy behavior).
    val MCM_ORDER_DEPENDENT_LOADS = false
 
-   val jal_opc = UInt(0x6f)
-   val jalr_opc = UInt(0x67)
+   val jal_opc = (0x6f).U
+   val jalr_opc = (0x67).U
    def GetUop(inst: UInt): UInt = inst(6,0)
    def GetRd (inst: UInt): UInt = inst(RD_MSB,RD_LSB)
    def GetRs1(inst: UInt): UInt = inst(RS1_MSB,RS1_LSB)
@@ -335,13 +338,13 @@ trait RISCVConstants
 
    def ComputeBranchTarget(pc: UInt, inst: UInt, xlen: Int): UInt =
    {
-      val b_imm32 = Cat(Fill(20,inst(31)), inst(7), inst(30,25), inst(11,8), UInt(0,1))
-      ((pc.asSInt + b_imm32.asSInt).asSInt & SInt(-2)).asUInt
+      val b_imm32 = Cat(Fill(20,inst(31)), inst(7), inst(30,25), inst(11,8), 0.U(1.W))
+      ((pc.asSInt + b_imm32.asSInt).asSInt & (-2).S).asUInt
    }
    def ComputeJALTarget(pc: UInt, inst: UInt, xlen: Int): UInt =
    {
-      val j_imm32 = Cat(Fill(12,inst(31)), inst(19,12), inst(20), inst(30,25), inst(24,21), UInt(0,1))
-      ((pc.asSInt + j_imm32.asSInt).asSInt & SInt(-2)).asUInt
+      val j_imm32 = Cat(Fill(12,inst(31)), inst(19,12), inst(20), inst(30,25), inst(24,21), 0.U(1.W))
+      ((pc.asSInt + j_imm32.asSInt).asSInt & (-2).S).asUInt
    }
 
    def GetCfiType(inst: UInt): UInt =

--- a/src/main/scala/common/microop.scala
+++ b/src/main/scala/common/microop.scala
@@ -9,7 +9,8 @@
 
 package boom.common
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import boom.bpu.BranchPredInfo
 import boom.exu.FUConstants
@@ -26,16 +27,16 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    // Used by fetch buffer and Decode stage.
    val valid            = Bool()
 
-   val uopc             = UInt(width = UOPC_SZ)       // micro-op code
-   val inst             = UInt(width = 32)
-   val pc               = UInt(width = coreMaxAddrBits) // TODO remove -- use FTQ to get PC. Change to debug_pc.
-   val iqtype           = UInt(width = IQT_SZ)        // which issue unit do we use?
-   val fu_code          = UInt(width = FUConstants.FUC_SZ) // which functional unit do we use?
+   val uopc             = UInt(UOPC_SZ.W)       // micro-op code
+   val inst             = UInt(32.W)
+   val pc               = UInt(coreMaxAddrBits.W) // TODO remove -- use FTQ to get PC. Change to debug_pc.
+   val iqtype           = UInt(IQT_SZ.W)        // which issue unit do we use?
+   val fu_code          = UInt(FUConstants.FUC_SZ.W) // which functional unit do we use?
    val ctrl             = new CtrlSignals
 
    // What is the next state of this uop in the issue window? useful
    // for the compacting queue.
-   val iw_state         = UInt(width = 2)
+   val iw_state         = UInt(2.W)
    // Has operand 1 or 2 been waken speculatively by a load?
    // Only integer operands are speculaively woken up,
    // so we can ignore p3.
@@ -48,8 +49,8 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val is_jal           = Bool()                      // is this a JAL (doesn't include JR)? used for branch unit
    val is_ret           = Bool()                      // is jalr with rd=x0, rs1=x1? (i.e., a return)
    val is_call          = Bool()                      //
-   val br_mask          = UInt(width = MAX_BR_COUNT)  // which branches are we being speculated under?
-   val br_tag           = UInt(width = BR_TAG_SZ)
+   val br_mask          = UInt(MAX_BR_COUNT.W)  // which branches are we being speculated under?
+   val br_tag           = UInt(BR_TAG_SZ.W)
 
    val br_prediction    = new BranchPredInfo
 
@@ -61,32 +62,32 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val stat_bpd_mispredicted   = Bool()                 // denominator: all committed branches
 
    // Index into FTQ to figure out our fetch PC.
-   val ftq_idx          = UInt(width = log2Ceil(ftqSz))
+   val ftq_idx          = UInt(log2Ceil(ftqSz).W)
    // Low-order bits of our own PC. Combine with ftq[ftq_idx] to get PC.
    // Aligned to a cache-line size, as that is the greater fetch granularity.
-   val pc_lob           = UInt(width = log2Ceil(icBlockBytes).W)
+   val pc_lob           = UInt(log2Ceil(icBlockBytes).W)
 
 
-   val imm_packed       = UInt(width = LONGEST_IMM_SZ) // densely pack the imm in decode...
-                                                       // then translate and sign-extend in execute
-   val csr_addr         = UInt(width = CSR_ADDR_SZ)    // only used for critical path reasons in Exe
-   val rob_idx          = UInt(width = ROB_ADDR_SZ)
-   val ldq_idx          = UInt(width = MEM_ADDR_SZ)
-   val stq_idx          = UInt(width = MEM_ADDR_SZ)
-   val pdst             = UInt(width = PREG_SZ)
-   val pop1             = UInt(width = PREG_SZ)
-   val pop2             = UInt(width = PREG_SZ)
-   val pop3             = UInt(width = PREG_SZ)
+   val imm_packed       = UInt(LONGEST_IMM_SZ.W) // densely pack the imm in decode...
+                                               // then translate and sign-extend in execute
+   val csr_addr         = UInt(CSR_ADDR_SZ.W)    // only used for critical path reasons in Exe
+   val rob_idx          = UInt(ROB_ADDR_SZ.W)
+   val ldq_idx          = UInt(MEM_ADDR_SZ.W)
+   val stq_idx          = UInt(MEM_ADDR_SZ.W)
+   val pdst             = UInt(PREG_SZ.W)
+   val pop1             = UInt(PREG_SZ.W)
+   val pop2             = UInt(PREG_SZ.W)
+   val pop3             = UInt(PREG_SZ.W)
 
    val prs1_busy        = Bool()
    val prs2_busy        = Bool()
    val prs3_busy        = Bool()
-   val stale_pdst       = UInt(width = PREG_SZ)
+   val stale_pdst       = UInt(PREG_SZ.W)
    val exception        = Bool()
-   val exc_cause        = UInt(width = xLen)          // TODO compress this down, xlen is insanity
+   val exc_cause        = UInt(xLen.W)          // TODO compress this down, xlen is insanity
    val bypassable       = Bool()                      // can we bypass ALU results? (doesn't include loads, csr, etc...)
-   val mem_cmd          = UInt(width = M_SZ)          // sync primitives/cache flushes
-   val mem_typ          = UInt(width = MT_SZ)         // memory mask type for loads/stores
+   val mem_cmd          = UInt(M_SZ.W)          // sync primitives/cache flushes
+   val mem_typ          = UInt(MT_SZ.W)         // memory mask type for loads/stores
    val is_fence         = Bool()
    val is_fencei        = Bool()
    val is_store         = Bool()                      // anything that goes into the STQ, including fences and AMOs
@@ -98,14 +99,14 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val flush_on_commit  = Bool()                      // some instructions need to flush the pipeline behind them
 
    // logical specifiers (only used in Decode->Rename), except rollback (ldst)
-   val ldst             = UInt(width=LREG_SZ)
-   val lrs1             = UInt(width=LREG_SZ)
-   val lrs2             = UInt(width=LREG_SZ)
-   val lrs3             = UInt(width=LREG_SZ)
+   val ldst             = UInt(LREG_SZ.W)
+   val lrs1             = UInt(LREG_SZ.W)
+   val lrs2             = UInt(LREG_SZ.W)
+   val lrs3             = UInt(LREG_SZ.W)
    val ldst_val         = Bool()              // is there a destination? invalid for stores, rd==x0, etc.
-   val dst_rtype        = UInt(width=2)
-   val lrs1_rtype       = UInt(width=2)
-   val lrs2_rtype       = UInt(width=2)
+   val dst_rtype        = UInt(2.W)
+   val lrs1_rtype       = UInt(2.W)
+   val lrs2_rtype       = UInt(2.W)
    val frs3_en          = Bool()
 
    // floating point information
@@ -120,7 +121,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val xcpt_ma_if       = Bool()             // Misaligned fetch (jal/brjumping to misaligned addr).
 
    // purely debug information
-   val debug_wdata      = UInt(width=xLen)
+   val debug_wdata      = UInt(xLen.W)
    val debug_events     = new DebugStageEvents
 
    def fu_code_is(_fu: UInt) = fu_code === _fu
@@ -134,14 +135,14 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
 // TODO REFACTOR this, as this should no longer be true, as bypass occurs in stage before branch resolution
 class CtrlSignals extends Bundle()
 {
-   val br_type     = UInt(width = BR_N.getWidth)
-   val op1_sel     = UInt(width = OP1_X.getWidth)
-   val op2_sel     = UInt(width = OP2_X.getWidth)
-   val imm_sel     = UInt(width = IS_X.getWidth)
-   val op_fcn      = UInt(width = freechips.rocketchip.rocket.ALU.SZ_ALU_FN)
+   val br_type     = UInt(BR_N.getWidth.W)
+   val op1_sel     = UInt(OP1_X.getWidth.W)
+   val op2_sel     = UInt(OP2_X.getWidth.W)
+   val imm_sel     = UInt(IS_X.getWidth.W)
+   val op_fcn      = UInt(freechips.rocketchip.rocket.ALU.SZ_ALU_FN.W)
    val fcn_dw      = Bool()
    val rf_wen      = Bool()
-   val csr_cmd     = UInt(width = freechips.rocketchip.rocket.CSR.SZ)
+   val csr_cmd     = UInt(freechips.rocketchip.rocket.CSR.SZ.W)
    val is_load     = Bool()   // will invoke TLB address lookup
    val is_sta      = Bool()   // will invoke TLB address lookup
    val is_std      = Bool()
@@ -150,14 +151,14 @@ class CtrlSignals extends Bundle()
 class DebugStageEvents extends Bundle()
 {
    // Track the sequence number of each instruction fetched.
-   val fetch_seq        = UInt(width = 32)
+   val fetch_seq        = UInt(32.W)
 }
 
 // What type of Control-Flow Instruction is it?
 object CfiType
 {
    def SZ = 3
-   def apply() = UInt(width = SZ)
+   def apply() = UInt(SZ.W)
    def none = 0.U
    def branch = 1.U
    def jal = 2.U
@@ -167,6 +168,6 @@ object CfiType
 class MicroOpWithData(data_sz: Int)(implicit p: Parameters) extends BoomBundle()(p)
   with HasBoomUOP
 {
-   val data = UInt(width = data_sz)
+   val data = UInt(data_sz.W)
    override def cloneType = new MicroOpWithData(data_sz)(p).asInstanceOf[this.type]
 }

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -4,7 +4,8 @@
 //------------------------------------------------------------------------------
 package boom.common
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.config.{Parameters, Field}
@@ -230,19 +231,19 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    //************************************
    // Implicitly calculated constants
    val NUM_ROB_ROWS      = NUM_ROB_ENTRIES/decodeWidth
-   val ROB_ADDR_SZ       = log2Up(NUM_ROB_ENTRIES)
+   val ROB_ADDR_SZ       = log2Ceil(NUM_ROB_ENTRIES)
    // the f-registers are mapped into the space above the x-registers
    val LOGICAL_REG_COUNT = if (usingFPU) 64 else 32
-   val LREG_SZ           = log2Up(LOGICAL_REG_COUNT)
-   val IPREG_SZ          = log2Up(numIntPhysRegs)
-   val FPREG_SZ          = log2Up(numFpPhysRegs)
+   val LREG_SZ           = log2Ceil(LOGICAL_REG_COUNT)
+   val IPREG_SZ          = log2Ceil(numIntPhysRegs)
+   val FPREG_SZ          = log2Ceil(numFpPhysRegs)
    val PREG_SZ          = IPREG_SZ max FPREG_SZ
-   val MEM_ADDR_SZ       = log2Up(NUM_LSU_ENTRIES)
+   val MEM_ADDR_SZ       = log2Ceil(NUM_LSU_ENTRIES)
    val MAX_ST_COUNT      = (1 << MEM_ADDR_SZ)
    val MAX_LD_COUNT      = (1 << MEM_ADDR_SZ)
-   val BR_TAG_SZ         = log2Up(MAX_BR_COUNT)
+   val BR_TAG_SZ         = log2Ceil(MAX_BR_COUNT)
    val NUM_BROB_ENTRIES  = NUM_ROB_ROWS //TODO explore smaller BROBs
-   val BROB_ADDR_SZ      = log2Up(NUM_BROB_ENTRIES)
+   val BROB_ADDR_SZ      = log2Ceil(NUM_BROB_ENTRIES)
 
    require (numIntPhysRegs >= (32 + decodeWidth))
    require (numFpPhysRegs >= (32 + decodeWidth))

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -3,7 +3,7 @@
 
 package boom.common
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
@@ -128,8 +128,8 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   core.io.release.valid := tl_c.fire()
   core.io.release.bits.address := tl_c.bits.address
 
-  val uncorrectable = RegInit(Bool(false))
-  val halt_and_catch_fire = outer.boomParams.hcfOnUncorrectable.option(IO(Bool(OUTPUT)))
+  val uncorrectable = RegInit(false.B)
+  val halt_and_catch_fire = outer.boomParams.hcfOnUncorrectable.option(IO(Output(Bool())))
 
   outer.dtim_adapter.foreach { lm => dcachePorts += lm.module.io.dmem }
 
@@ -150,6 +150,9 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
   //fpuOpt foreach { fpu => core.io.fpu <> fpu.io } RocketFpu - not needed in boom
   core.io.ptw <> ptw.io.dpath
+  core.io.rocc := DontCare
+  core.io.fpu := DontCare
+  core.io.reset_vector := DontCare
   //roccCore.cmd <> core.io.rocc.cmd
   //roccCore.exception := core.io.rocc.exception
   //core.io.rocc.resp <> roccCore.resp

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -28,9 +28,10 @@
 
 package boom.exu
 
-import Chisel._
-import chisel3.core.DontCare
+import chisel3._
+import chisel3.util._
 import chisel3.experimental.dontTouch
+
 import freechips.rocketchip.config.Parameters
 
 import freechips.rocketchip.rocket.Instructions._
@@ -48,16 +49,16 @@ trait HasBoomCoreIO extends freechips.rocketchip.tile.HasTileParameters {
    implicit val p: Parameters
    val io = new freechips.rocketchip.tile.CoreBundle()(p)
       with freechips.rocketchip.tile.HasExternallyDrivenTileConstants {
-         val interrupts = new freechips.rocketchip.tile.CoreInterrupts().asInput
+         val interrupts = Input(new freechips.rocketchip.tile.CoreInterrupts())
          val ifu = new boom.ifu.BoomFrontendIO
          val dmem = new freechips.rocketchip.rocket.HellaCacheIO
-         val ptw = new freechips.rocketchip.rocket.DatapathPTWIO().flip
-         val fpu = new freechips.rocketchip.tile.FPUCoreIO().flip
-         val rocc = new freechips.rocketchip.tile.RoCCCoreIO().flip
+         val ptw = Flipped(new freechips.rocketchip.rocket.DatapathPTWIO())
+         val fpu = Flipped(new freechips.rocketchip.tile.FPUCoreIO())
+         val rocc = Flipped(new freechips.rocketchip.tile.RoCCCoreIO())
          val ptw_tlb = new freechips.rocketchip.rocket.TLBPTWIO()
-         val trace = Vec(coreParams.retireWidth,
-            new freechips.rocketchip.rocket.TracedInstruction).asOutput
-         val release = Valid(new boom.lsu.ReleaseInfo).flip
+         val trace = Output(Vec(coreParams.retireWidth,
+            new freechips.rocketchip.rocket.TracedInstruction))
+         val release = Flipped(Valid(new boom.lsu.ReleaseInfo))
    }
 }
 
@@ -144,7 +145,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    dc_shim.io.core <> exe_units.memory_unit.io.dmem
 
    // Load/Store Unit & ExeUnits
-   exe_units.memory_unit.io.lsu_io := lsu.io
+   exe_units.memory_unit.io.lsu_io <> lsu.io
    val sxt_ldMiss = Wire(Bool())
 
 
@@ -213,9 +214,9 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //****************************************
    // Time Stamp Counter & Retired Instruction Counter
    // (only used for printf and vcd dumps - the actual counters are in the CSRFile)
-   val debug_tsc_reg  = Reg(init = UInt(0, xLen))
-   val debug_irt_reg  = Reg(init = UInt(0, xLen))
-   debug_tsc_reg  := debug_tsc_reg + Mux(Bool(O3PIPEVIEW_PRINTF), UInt(O3_CYCLE_TIME), UInt(1))
+   val debug_tsc_reg  = RegInit(0.U(xLen.W))
+   val debug_irt_reg  = RegInit(0.U(xLen.W))
+   debug_tsc_reg  := debug_tsc_reg + Mux(O3PIPEVIEW_PRINTF.B, O3_CYCLE_TIME.U, 1.U)
    debug_irt_reg  := debug_irt_reg + PopCount(rob.io.commit.valids.asUInt)
    dontTouch(debug_tsc_reg)
    dontTouch(debug_irt_reg)
@@ -331,7 +332,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // use this to mask out insts coming from FetchBuffer that have been finished
    // for example, back pressure may cause us to only issue some instructions from FetchBuffer
    // but on the next cycle, we only want to retry a subset
-   val dec_finished_mask = Reg(init = UInt(0, decodeWidth))
+   val dec_finished_mask = RegInit(0.U(decodeWidth.W))
 
    //-------------------------------------------------------------
    // Pull out instructions and send to the Decoders
@@ -343,7 +344,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // Decoders
 
    // allow early instructions to stall later instructions
-   var dec_stall_next_inst = Bool(false)
+   var dec_stall_next_inst = false.B
    var dec_last_inst_was_stalled = false.B
 
    // stall fetch/dcode because we ran out of branch tags
@@ -354,11 +355,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       dec_valids(w)                      := io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid && !dec_finished_mask(w)
       decode_units(w).io.enq.uop         := dec_fbundle.uops(w)
       decode_units(w).io.status          := csr.io.status
-      decode_units(w).io.csr_decode      := csr.io.decode(w)
+      decode_units(w).io.csr_decode      <> csr.io.decode(w)
       decode_units(w).io.interrupt       := csr.io.interrupt
       decode_units(w).io.interrupt_cause := csr.io.interrupt_cause
 
-      val prev_insts_in_bundle_valid = Range(0,w).map{i => dec_valids(i)}.foldLeft(Bool(false))(_|_)
+      val prev_insts_in_bundle_valid = Range(0,w).map{i => dec_valids(i)}.foldLeft(false.B)(_|_)
 
       // stall this instruction?
       // TODO tailor this to only care if a given instruction uses a resource?
@@ -390,7 +391,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    when (dec_rdy || io.ifu.clear_fetchbuffer)
    {
-      dec_finished_mask := Bits(0)
+      dec_finished_mask := 0.U
    }
    .otherwise
    {
@@ -444,18 +445,25 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       if (decodeWidth == 1)
          dec_uops(w).rob_idx := rob.io.curr_rob_tail
       else
-         dec_uops(w).rob_idx := Cat(rob.io.curr_rob_tail, UInt(w, log2Up(decodeWidth)))
+         dec_uops(w).rob_idx := Cat(rob.io.curr_rob_tail, w.U(log2Ceil(decodeWidth).W))
    }
 
    val dec_has_br_or_jalr_in_packet =
       (dec_valids zip dec_uops map {case(v,u) => v && u.is_br_or_jmp && !u.is_jal}).reduce(_|_)
-
 
    //-------------------------------------------------------------
    //-------------------------------------------------------------
    // **** Register Rename Stage ****
    //-------------------------------------------------------------
    //-------------------------------------------------------------
+
+   // ********************************************************
+   // Clear fp_pipeline before use
+   if (usingFPU){
+     fp_pipeline.io.ll_wport := DontCare
+     fp_pipeline.io.wb_valids := DontCare
+     fp_pipeline.io.wb_pdsts := DontCare
+   }
 
    // TODO for now, assume worst-case all instructions will dispatch towards one issue unit.
    var dis_readys = issue_units.map(_.io.dis_readys.asUInt).reduce(_&_)
@@ -477,6 +485,9 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // loop through each issue-port (exe_units are statically connected to an issue-port)
    for (i <- 0 until exe_units.length)
    {
+      // Overridden in the following section
+      int_wakeups(wu_idx).bits := DontCare
+
       if (exe_units(i).is_mem_unit)
       {
          // If Memory, it's the shared long-latency port.
@@ -566,12 +577,12 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       iu <- issue_units
       w <- 0 until DISPATCH_WIDTH
    }{
-      iu.io.dis_valids(w) := dis_valids(w) && dis_uops(w).iqtype === UInt(iu.iqType)
+      iu.io.dis_valids(w) := dis_valids(w) && dis_uops(w).iqtype === (iu.iqType).U
       iu.io.dis_uops(w) := dis_uops(w)
 
       when (dis_uops(w).uopc === uopSTA && dis_uops(w).lrs2_rtype === RT_FLT) {
          iu.io.dis_uops(w).lrs2_rtype := RT_X
-         iu.io.dis_uops(w).prs2_busy := Bool(false)
+         iu.io.dis_uops(w).prs2_busy := false.B
       }
    }
    if (usingFPU) {
@@ -619,7 +630,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          // Supress just-issued divides from issuing back-to-back, since it's an iterative divider.
          // But it takes a cycle to get to the Exe stage, so it can't tell us it is busy yet.
          val idiv_issued = iss_valids(w) && iss_uops(w).fu_code_is(FU_DIV)
-         fu_types = fu_types & RegNext(~Mux(idiv_issued, FU_DIV, Bits(0)))
+         fu_types = fu_types & RegNext(~Mux(idiv_issued, FU_DIV, 0.U))
       }
       require (!exe_units(w).supportedFuncUnits.fdiv)
 
@@ -664,7 +675,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    val mem_unit = exe_units.memory_unit
    require (mem_unit.num_rf_write_ports == 1)
    val mem_resp = mem_unit.io.resp(0)
-
+   mem_unit.io.resp(0).ready := DontCare
 
    when (RegNext(!sxt_ldMiss) && RegNext(RegNext(lsu.io.mem_ldSpecWakeup.valid)) &&
       !(RegNext(rob.io.flush.valid || (br_unit.brinfo.valid && br_unit.brinfo.mispredict))) &&
@@ -723,9 +734,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    val csr_rw_cmd = csr_exe_unit.io.resp(0).bits.uop.ctrl.csr_cmd
    val wb_wdata = csr_exe_unit.io.resp(0).bits.data
 
-   csr.io.rw.addr  := csr_exe_unit.io.resp(0).bits.uop.csr_addr
-   csr.io.rw.cmd   := freechips.rocketchip.rocket.CSR.maskCmd(csr_exe_unit.io.resp(0).valid, csr_rw_cmd)
-   csr.io.rw.wdata := wb_wdata
+   csr.io.rw.addr        := csr_exe_unit.io.resp(0).bits.uop.csr_addr
+   csr.io.rw.cmd         := freechips.rocketchip.rocket.CSR.maskCmd(csr_exe_unit.io.resp(0).valid, csr_rw_cmd)
+   csr.io.rw.wdata       := wb_wdata
+   csr.io.inst           := DontCare
+   csr.io.rocc_interrupt := DontCare // We don't support RoCC interrupts
 
    // Extra I/O
    csr.io.retire    := PopCount(rob.io.commit.valids.asUInt)
@@ -789,6 +802,12 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       exe_units(w).io.req <> iregister_read.io.exe_reqs(w)
       exe_units(w).io.brinfo := br_unit.brinfo
       exe_units(w).io.com_exception := rob.io.flush.valid
+      exe_units(w).io.status := DontCare
+      exe_units(w).io.get_ftq_pc := DontCare
+      if (!exe_units(w).is_mem_unit){
+          exe_units(w).io.dmem := DontCare
+          exe_units(w).io.lsu_io := DontCare
+      }
 
       if (exe_units(w).isBypassable)
       {
@@ -807,10 +826,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    // don't send IntToFP moves to integer execution units.
    when (iregister_read.io.exe_reqs(ifpu_idx).bits.uop.fu_code === FUConstants.FU_I2F) {
-      exe_units(ifpu_idx).io.req.valid := Bool(false)
+      exe_units(ifpu_idx).io.req.valid := false.B
    }
    if (usingFPU) {
-      fp_pipeline.io.fromint := iregister_read.io.exe_reqs(ifpu_idx)
+      fp_pipeline.io.fromint <> iregister_read.io.exe_reqs(ifpu_idx)
       fp_pipeline.io.fromint.valid :=
          iregister_read.io.exe_reqs(ifpu_idx).valid &&
          iregister_read.io.exe_reqs(ifpu_idx).bits.uop.fu_code === FUConstants.FU_I2F
@@ -913,7 +932,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                fp_pipeline.io.ll_wport.valid     := wbIsValid(RT_FLT)
                fp_pipeline.io.ll_wport.bits.uop  := wbresp.bits.uop
                fp_pipeline.io.ll_wport.bits.data := wbdata
-               fp_pipeline.io.ll_wport.bits.fflags.valid := Bool(false)
+               fp_pipeline.io.ll_wport.bits.fflags.valid := false.B
                assert (fp_pipeline.io.ll_wport.ready, "[core] LL port should always be ready.")
             }
          }
@@ -1226,7 +1245,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
       printf("--- Cyc=%d , ----------------- Ret: %d ----------------------------------"
          , debug_tsc_reg
-         , debug_irt_reg & UInt(0xffffff))
+         , debug_irt_reg & (0xffffff).U)
 
       for (w <- 0 until decodeWidth)
       {
@@ -1297,10 +1316,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       if (DEBUG_PRINTF_ROB)
       {
          printf("\n) ctate: (%c: %c %c %c %c %c %c) BMsk:%x Mode:%c\n"
-         , Mux(rob.io.debug.state === UInt(0), Str("R"),
-           Mux(rob.io.debug.state === UInt(1), Str("N"),
-           Mux(rob.io.debug.state === UInt(2), Str("B"),
-           Mux(rob.io.debug.state === UInt(3), Str("W"),
+         , Mux(rob.io.debug.state === 0.U, Str("R"),
+           Mux(rob.io.debug.state === 1.U, Str("N"),
+           Mux(rob.io.debug.state === 2.U, Str("B"),
+           Mux(rob.io.debug.state === 3.U, Str("W"),
                                                Str(" ")))))
          , Mux(rob.io.ready,Str("_"), Str("!"))
          , Mux(lsu.io.laq_full, Str("L"), Str("_"))
@@ -1309,9 +1328,9 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          , Mux(branch_mask_full.reduce(_|_), Str("B"), Str(" "))
          , Mux(dc_shim.io.core.req.ready, Str("R"), Str("B"))
          , dec_brmask_logic.io.debug.branch_mask
-         , Mux(csr.io.status.prv === Bits(0x3), Str("M"),
-           Mux(csr.io.status.prv === Bits(0x0), Str("U"),
-           Mux(csr.io.status.prv === Bits(0x1), Str("S"),  //2 is H
+         , Mux(csr.io.status.prv === (0x3).U, Str("M"),
+           Mux(csr.io.status.prv === (0x0).U, Str("U"),
+           Mux(csr.io.status.prv === (0x1).U, Str("S"),  //2 is H
                                                  Str("?"))))
          )
       }
@@ -1344,7 +1363,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
       // Rename Map Tables / ISA Register File
       val xpr_to_string =
-              Vec(Str(" x0"), Str(" ra"), Str(" sp"), Str(" gp"),
+              VecInit(Str(" x0"), Str(" ra"), Str(" sp"), Str(" gp"),
                    Str(" tp"), Str(" t0"), Str(" t1"), Str(" t2"),
                    Str(" s0"), Str(" s1"), Str(" a0"), Str(" a1"),
                    Str(" a2"), Str(" a3"), Str(" a4"), Str(" a5"),
@@ -1354,7 +1373,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                    Str(" t3"), Str(" t4"), Str(" t5"), Str(" t6"))
 
       val fpr_to_string =
-              Vec( Str("ft0"), Str("ft1"), Str("ft2"), Str("ft3"),
+              VecInit( Str("ft0"), Str("ft1"), Str("ft2"), Str("ft3"),
                    Str("ft4"), Str("ft5"), Str("ft6"), Str("ft7"),
                    Str("fs0"), Str("fs1"), Str("fa0"), Str("fa1"),
                    Str("fa2"), Str("fa3"), Str("fa4"), Str("fa5"),
@@ -1373,14 +1392,14 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    if (COMMIT_LOG_PRINTF)
    {
-      var new_commit_cnt = UInt(0)
+      var new_commit_cnt = 0.U
       for (w <- 0 until COMMIT_WIDTH)
       {
          val priv = csr.io.status.prv
 
          when (rob.io.commit.valids(w))
          {
-            when (rob.io.commit.uops(w).dst_rtype === RT_FIX && rob.io.commit.uops(w).ldst =/= UInt(0))
+            when (rob.io.commit.uops(w).dst_rtype === RT_FIX && rob.io.commit.uops(w).ldst =/= 0.U)
             {
                printf("%d 0x%x (0x%x) x%d 0x%x\n",
                   priv, Sext(rob.io.commit.uops(w).pc(vaddrBits,0), xLen), rob.io.commit.uops(w).inst,
@@ -1410,7 +1429,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       println("   O3Pipeview Visualization Enabled\n")
 
       // did we already print out the instruction sitting at the front of the fetchbuffer/decode stage?
-      val dec_printed_mask = Reg(init = Bits(0, decodeWidth))
+      val dec_printed_mask = RegInit(0.U(decodeWidth.W))
 
       for (w <- 0 until decodeWidth)
       {

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -5,7 +5,8 @@
 
 package boom.exu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 import freechips.rocketchip.rocket.Instructions._
@@ -45,22 +46,22 @@ class CtrlSigs extends Bundle
    val legal           = Bool()
    val fp_val          = Bool()
    val fp_single       = Bool()
-   val uopc            = UInt(width = UOPC_SZ)
-   val iqtype          = UInt(width = IQT_SZ)
-   val fu_code         = UInt(width = FUC_SZ)
-   val dst_type        = UInt(width=2)
-   val rs1_type        = UInt(width=2)
-   val rs2_type        = UInt(width=2)
+   val uopc            = UInt(UOPC_SZ.W)
+   val iqtype          = UInt(IQT_SZ.W)
+   val fu_code         = UInt(FUC_SZ.W)
+   val dst_type        = UInt(2.W)
+   val rs1_type        = UInt(2.W)
+   val rs2_type        = UInt(2.W)
    val frs3_en         = Bool()
-   val imm_sel         = UInt(width = IS_X.getWidth)
+   val imm_sel         = UInt(IS_X.getWidth.W)
    val is_load         = Bool()
    val is_store        = Bool()
    val is_amo          = Bool()
    val is_fence        = Bool()
    val is_fencei       = Bool()
-   val mem_cmd         = UInt(width = freechips.rocketchip.rocket.M_SZ)
-   val mem_typ         = UInt(width = freechips.rocketchip.rocket.MT_SZ)
-   val wakeup_delay    = UInt(width = 2)
+   val mem_cmd         = UInt(freechips.rocketchip.rocket.M_SZ.W)
+   val mem_typ         = UInt(freechips.rocketchip.rocket.MT_SZ.W)
+   val wakeup_delay    = UInt(2.W)
    val bypassable      = Bool()
    val br_or_jmp       = Bool()
    val is_jal          = Bool()
@@ -68,7 +69,7 @@ class CtrlSigs extends Bundle
    val is_sys_pc2epc   = Bool()
    val inst_unique     = Bool()
    val flush_on_commit = Bool()
-   val csr_cmd         = UInt(width = freechips.rocketchip.rocket.CSR.SZ)
+   val csr_cmd         = UInt(freechips.rocketchip.rocket.CSR.SZ.W)
    val rocc            = Bool()
 
    def decode(inst: UInt, table: Iterable[(BitPat, List[BitPat])]) = {
@@ -99,124 +100,124 @@ object XDecode extends DecodeConstants
             //     |  |  |  |         |        |        regtype |       |       |  |     |  |  |  |  |  cmd    msk    |        |  |  |  |  |  |  flush on commit
             //     |  |  |  |         |        |        |       |       |       |  |     |  |  |  |  |  |      |      |        |  |  |  |  |  |  |  csr cmd
    val table: Array[(BitPat, List[BitPat])] = Array(//  |       |       |       |  |     |  |  |  |  |  |      |      |        |  |  |  |  |  |  |  |
-   LD      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_D , UInt(3), N, N, N, N, N, N, N, CSR.N),
-   LW      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_W , UInt(3), N, N, N, N, N, N, N, CSR.N),
-   LWU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_WU, UInt(3), N, N, N, N, N, N, N, CSR.N),
-   LH      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_H , UInt(3), N, N, N, N, N, N, N, CSR.N),
-   LHU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_HU, UInt(3), N, N, N, N, N, N, N, CSR.N),
-   LB      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_B , UInt(3), N, N, N, N, N, N, N, CSR.N),
-   LBU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_BU, UInt(3), N, N, N, N, N, N, N, CSR.N),
+   LD      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_D , 3.U, N, N, N, N, N, N, N, CSR.N),
+   LW      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_W , 3.U, N, N, N, N, N, N, N, CSR.N),
+   LWU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_WU, 3.U, N, N, N, N, N, N, N, CSR.N),
+   LH      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_H , 3.U, N, N, N, N, N, N, N, CSR.N),
+   LHU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_HU, 3.U, N, N, N, N, N, N, N, CSR.N),
+   LB      -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_B , 3.U, N, N, N, N, N, N, N, CSR.N),
+   LBU     -> List(Y, N, X, uopLD   , IQT_MEM, FU_MEM , RT_FIX, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_BU, 3.U, N, N, N, N, N, N, N, CSR.N),
 
-   SD      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_D , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   SW      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_W , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   SH      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_H , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   SB      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_B , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   SD      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_D , 0.U, N, N, N, N, N, N, N, CSR.N),
+   SW      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_W , 0.U, N, N, N, N, N, N, N, CSR.N),
+   SH      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_H , 0.U, N, N, N, N, N, N, N, CSR.N),
+   SB      -> List(Y, N, X, uopSTA  , IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_S, N, Y, N, N, N, M_XWR, MT_B , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   LUI     -> List(Y, N, X, uopLUI  , IQT_INT, FU_ALU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
+   LUI     -> List(Y, N, X, uopLUI  , IQT_INT, FU_ALU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
 
-   ADDI    -> List(Y, N, X, uopADDI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   ANDI    -> List(Y, N, X, uopANDI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   ORI     -> List(Y, N, X, uopORI  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   XORI    -> List(Y, N, X, uopXORI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLTI    -> List(Y, N, X, uopSLTI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLTIU   -> List(Y, N, X, uopSLTIU, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLLI    -> List(Y, N, X, uopSLLI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRAI    -> List(Y, N, X, uopSRAI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRLI    -> List(Y, N, X, uopSRLI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
+   ADDI    -> List(Y, N, X, uopADDI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   ANDI    -> List(Y, N, X, uopANDI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   ORI     -> List(Y, N, X, uopORI  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   XORI    -> List(Y, N, X, uopXORI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLTI    -> List(Y, N, X, uopSLTI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLTIU   -> List(Y, N, X, uopSLTIU, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLLI    -> List(Y, N, X, uopSLLI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRAI    -> List(Y, N, X, uopSRAI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRLI    -> List(Y, N, X, uopSRLI , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
 
-   ADDIW   -> List(Y, N, X, uopADDIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLLIW   -> List(Y, N, X, uopSLLIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRAIW   -> List(Y, N, X, uopSRAIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRLIW   -> List(Y, N, X, uopSRLIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
+   ADDIW   -> List(Y, N, X, uopADDIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLLIW   -> List(Y, N, X, uopSLLIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRAIW   -> List(Y, N, X, uopSRAIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRLIW   -> List(Y, N, X, uopSRLIW, IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
 
-   SLL     -> List(Y, N, X, uopSLL  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   ADD     -> List(Y, N, X, uopADD  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SUB     -> List(Y, N, X, uopSUB  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLT     -> List(Y, N, X, uopSLT  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLTU    -> List(Y, N, X, uopSLTU , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   AND     -> List(Y, N, X, uopAND  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   OR      -> List(Y, N, X, uopOR   , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   XOR     -> List(Y, N, X, uopXOR  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRA     -> List(Y, N, X, uopSRA  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRL     -> List(Y, N, X, uopSRL  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
+   SLL     -> List(Y, N, X, uopSLL  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   ADD     -> List(Y, N, X, uopADD  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SUB     -> List(Y, N, X, uopSUB  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLT     -> List(Y, N, X, uopSLT  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLTU    -> List(Y, N, X, uopSLTU , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   AND     -> List(Y, N, X, uopAND  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   OR      -> List(Y, N, X, uopOR   , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   XOR     -> List(Y, N, X, uopXOR  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRA     -> List(Y, N, X, uopSRA  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRL     -> List(Y, N, X, uopSRL  , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
 
-   ADDW    -> List(Y, N, X, uopADDW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SUBW    -> List(Y, N, X, uopSUBW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SLLW    -> List(Y, N, X, uopSLLW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRAW    -> List(Y, N, X, uopSRAW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
-   SRLW    -> List(Y, N, X, uopSRLW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(1), Y, N, N, N, N, N, N, CSR.N),
+   ADDW    -> List(Y, N, X, uopADDW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SUBW    -> List(Y, N, X, uopSUBW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SLLW    -> List(Y, N, X, uopSLLW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRAW    -> List(Y, N, X, uopSRAW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
+   SRLW    -> List(Y, N, X, uopSRLW , IQT_INT, FU_ALU , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 1.U, Y, N, N, N, N, N, N, CSR.N),
 
-   MUL     -> List(Y, N, X, uopMUL  , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   MULH    -> List(Y, N, X, uopMULH , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   MULHU   -> List(Y, N, X, uopMULHU, IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   MULHSU  -> List(Y, N, X, uopMULHSU,IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   MULW    -> List(Y, N, X, uopMULW , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   MUL     -> List(Y, N, X, uopMUL  , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   MULH    -> List(Y, N, X, uopMULH , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   MULHU   -> List(Y, N, X, uopMULHU, IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   MULHSU  -> List(Y, N, X, uopMULHSU,IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   MULW    -> List(Y, N, X, uopMULW , IQT_INT, FU_MUL , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   DIV     -> List(Y, N, X, uopDIV  , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   DIVU    -> List(Y, N, X, uopDIVU , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   REM     -> List(Y, N, X, uopREM  , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   REMU    -> List(Y, N, X, uopREMU , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   DIVW    -> List(Y, N, X, uopDIVW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   DIVUW   -> List(Y, N, X, uopDIVUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   REMW    -> List(Y, N, X, uopREMW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   REMUW   -> List(Y, N, X, uopREMUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   DIV     -> List(Y, N, X, uopDIV  , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   DIVU    -> List(Y, N, X, uopDIVU , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   REM     -> List(Y, N, X, uopREM  , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   REMU    -> List(Y, N, X, uopREMU , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   DIVW    -> List(Y, N, X, uopDIVW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   DIVUW   -> List(Y, N, X, uopDIVUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   REMW    -> List(Y, N, X, uopREMW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   REMUW   -> List(Y, N, X, uopREMUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   AUIPC   -> List(Y, N, X, uopAUIPC, IQT_INT, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MT_X , UInt(1), N, N, N, N, N, N, N, CSR.N), // use BRU for the PC read
-   JAL     -> List(Y, N, X, uopJAL  , IQT_INT, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_J, N, N, N, N, N, M_X  , MT_X , UInt(1), N, Y, Y, N, N, N, N, CSR.N),
-   JALR    -> List(Y, N, X, uopJALR , IQT_INT, FU_BRU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(1), N, Y, N, Y, N, N, N, CSR.N),
-   BEQ     -> List(Y, N, X, uopBEQ  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , UInt(0), N, Y, N, Y, N, N, N, CSR.N),
-   BNE     -> List(Y, N, X, uopBNE  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , UInt(0), N, Y, N, Y, N, N, N, CSR.N),
-   BGE     -> List(Y, N, X, uopBGE  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , UInt(0), N, Y, N, Y, N, N, N, CSR.N),
-   BGEU    -> List(Y, N, X, uopBGEU , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , UInt(0), N, Y, N, Y, N, N, N, CSR.N),
-   BLT     -> List(Y, N, X, uopBLT  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , UInt(0), N, Y, N, Y, N, N, N, CSR.N),
-   BLTU    -> List(Y, N, X, uopBLTU , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , UInt(0), N, Y, N, Y, N, N, N, CSR.N),
+   AUIPC   -> List(Y, N, X, uopAUIPC, IQT_INT, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , MT_X , 1.U, N, N, N, N, N, N, N, CSR.N), // use BRU for the PC read
+   JAL     -> List(Y, N, X, uopJAL  , IQT_INT, FU_BRU , RT_FIX, RT_X  , RT_X  , N, IS_J, N, N, N, N, N, M_X  , MT_X , 1.U, N, Y, Y, N, N, N, N, CSR.N),
+   JALR    -> List(Y, N, X, uopJALR , IQT_INT, FU_BRU , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 1.U, N, Y, N, Y, N, N, N, CSR.N),
+   BEQ     -> List(Y, N, X, uopBEQ  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , 0.U, N, Y, N, Y, N, N, N, CSR.N),
+   BNE     -> List(Y, N, X, uopBNE  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , 0.U, N, Y, N, Y, N, N, N, CSR.N),
+   BGE     -> List(Y, N, X, uopBGE  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , 0.U, N, Y, N, Y, N, N, N, CSR.N),
+   BGEU    -> List(Y, N, X, uopBGEU , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , 0.U, N, Y, N, Y, N, N, N, CSR.N),
+   BLT     -> List(Y, N, X, uopBLT  , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , 0.U, N, Y, N, Y, N, N, N, CSR.N),
+   BLTU    -> List(Y, N, X, uopBLTU , IQT_INT, FU_BRU , RT_X  , RT_FIX, RT_FIX, N, IS_B, N, N, N, N, N, M_X  , MT_X , 0.U, N, Y, N, Y, N, N, N, CSR.N),
 
    // I-type, the immediate12 holds the CSR register.
-   CSRRW   -> List(Y, N, X, uopCSRRW, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.W),
-   CSRRS   -> List(Y, N, X, uopCSRRS, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.S),
-   CSRRC   -> List(Y, N, X, uopCSRRC, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.C),
+   CSRRW   -> List(Y, N, X, uopCSRRW, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.W),
+   CSRRS   -> List(Y, N, X, uopCSRRS, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.S),
+   CSRRC   -> List(Y, N, X, uopCSRRC, IQT_INT, FU_CSR , RT_FIX, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.C),
 
-   CSRRWI  -> List(Y, N, X, uopCSRRWI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.W),
-   CSRRSI  -> List(Y, N, X, uopCSRRSI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.S),
-   CSRRCI  -> List(Y, N, X, uopCSRRCI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.C),
+   CSRRWI  -> List(Y, N, X, uopCSRRWI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.W),
+   CSRRSI  -> List(Y, N, X, uopCSRRSI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.S),
+   CSRRCI  -> List(Y, N, X, uopCSRRCI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.C),
 
-   SFENCE_VMA->List(Y,N, X, uopSFENCE,IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_SFENCE,MT_X,UInt(0), N, N, N, N, N, Y, Y, CSR.N),
-   SCALL   -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, Y, Y, N, CSR.I),
-   SBREAK  -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, Y, Y, N, CSR.I),
-   SRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, N, CSR.I),
-   MRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, N, CSR.I),
-   DRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, N, CSR.I),
+   SFENCE_VMA->List(Y,N, X, uopSFENCE,IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_SFENCE,MT_X,0.U, N, N, N, N, N, Y, Y, CSR.N),
+   SCALL   -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, Y, Y, N, CSR.I),
+   SBREAK  -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, Y, Y, N, CSR.I),
+   SRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, N, CSR.I),
+   MRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, N, CSR.I),
+   DRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, N, CSR.I),
 
-   WFI     -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.I),
+   WFI     -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.I),
 
-   FENCE_I -> List(Y, N, X, uopNOP  , IQT_INT, FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, Y, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.N),
-   FENCE   -> List(Y, N, X, uopFENCE, IQT_INT, FU_MEM , RT_X  , RT_X  , RT_X  , N, IS_X, N, Y, N, Y, N, M_X  , MT_X , UInt(0), N, N, N, N, N, Y, Y, CSR.N), // TODO PERF make fence higher performance
+   FENCE_I -> List(Y, N, X, uopNOP  , IQT_INT, FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, Y, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.N),
+   FENCE   -> List(Y, N, X, uopFENCE, IQT_INT, FU_MEM , RT_X  , RT_X  , RT_X  , N, IS_X, N, Y, N, Y, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.N), // TODO PERF make fence higher performance
                                                                                                                                                     // currently serializes pipeline
    // A-type
-   AMOADD_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N), // TODO make AMOs higherperformance
-   AMOXOR_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOSWAP_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOAND_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOOR_W -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMIN_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMINU_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMAX_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMAXU_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
+   AMOADD_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N), // TODO make AMOs higherperformance
+   AMOXOR_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOSWAP_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOAND_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOOR_W -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMIN_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMINU_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMAX_W-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMAXU_W->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N),
 
-   AMOADD_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOXOR_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOSWAP_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOAND_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOOR_D -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMIN_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMINU_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMAX_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
-   AMOMAXU_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N),
+   AMOADD_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_ADD, MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOXOR_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_XOR, MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOSWAP_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_SWAP,MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOAND_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_AND, MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOOR_D -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_OR,  MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMIN_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MIN, MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMINU_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MINU,MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMAX_D-> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAX, MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
+   AMOMAXU_D->List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XA_MAXU,MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N),
 
-   LR_W    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N), // TODO optimize LR, SC
-   LR_D    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N), // note LR generates 2 micro-ops,
-   SC_W    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MT_W,UInt(0),N, N, N, N, N, Y, Y, CSR.N), // one which isn't needed
-   SC_D    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MT_D,UInt(0),N, N, N, N, N, Y, Y, CSR.N)
+   LR_W    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N), // TODO optimize LR, SC
+   LR_D    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XLR   , MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N), // note LR generates 2 micro-ops,
+   SC_W    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MT_W,0.U,N, N, N, N, N, Y, Y, CSR.N), // one which isn't needed
+   SC_D    -> List(Y, N, X, uopAMO_AG, IQT_MEM, FU_MEM, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, Y, Y, N, N, M_XSC   , MT_D,0.U,N, N, N, N, N, Y, Y, CSR.N)
    )
 // scalastyle:on
 }
@@ -235,81 +236,81 @@ object FDecode extends DecodeConstants
              //    |  |  |  |           iq_type  func    dst     |       |       |  |     |  |  |  |  |  mem    mem    |        |  |  |  |  |  is unique? (clear pipeline for it)
              //    |  |  |  |           |        unit    regtype |       |       |  |     |  |  |  |  |  cmd    msk    |        |  |  |  |  |  |  flush on commit
              //    |  |  |  |           |        |       |       |       |       |  |     |  |  |  |  |  |      |      |        |  |  |  |  |  |  |  csr cmd
-   FLW     -> List(Y, Y, Y, uopLD     , IQT_MEM, FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_W , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FLD     -> List(Y, Y, N, uopLD     , IQT_MEM, FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_D , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSW     -> List(Y, Y, Y, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MT_W , UInt(0), N, N, N, N, N, N, N, CSR.N), // sort of a lie; broken into two micro-ops
-   FSD     -> List(Y, Y, N, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MT_D , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FLW     -> List(Y, Y, Y, uopLD     , IQT_MEM, FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_W , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FLD     -> List(Y, Y, N, uopLD     , IQT_MEM, FU_MEM, RT_FLT, RT_FIX, RT_X  , N, IS_I, Y, N, N, N, N, M_XRD, MT_D , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSW     -> List(Y, Y, Y, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MT_W , 0.U, N, N, N, N, N, N, N, CSR.N), // sort of a lie; broken into two micro-ops
+   FSD     -> List(Y, Y, N, uopSTA    , IQT_MEM, FU_MEM, RT_X  , RT_FIX, RT_FLT, N, IS_S, N, Y, N, N, N, M_XWR, MT_D , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCLASS_D-> List(Y, Y, N, uopFCLASS_D,IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FCLASS_S-> List(Y, Y, Y, uopFCLASS_S,IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCLASS_D-> List(Y, Y, N, uopFCLASS_D,IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMV_D_X -> List(Y, Y, N, uopFMV_D_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMV_X_D -> List(Y, Y, N, uopFMV_X_D, IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FMV_S_X -> List(Y, Y, Y, uopFMV_S_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMV_D_X -> List(Y, Y, N, uopFMV_D_X, IQT_INT, FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMV_X_S -> List(Y, Y, Y, uopFMV_X_S, IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMV_X_D -> List(Y, Y, N, uopFMV_X_D, IQT_FP , FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FSGNJ_S -> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSGNJ_D -> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSGNJX_S-> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSGNJX_D-> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSGNJN_S-> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSGNJN_D-> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FSGNJ_S -> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSGNJ_D -> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSGNJX_S-> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSGNJX_D-> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSGNJN_S-> List(Y, Y, Y, uopFSGNJ_S, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSGNJN_D-> List(Y, Y, N, uopFSGNJ_D, IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
    // FP to FP
-   FCVT_S_D-> List(Y, Y, Y, uopFCVT_S_D,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_D_S-> List(Y, Y, N, uopFCVT_D_S,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FCVT_S_D-> List(Y, Y, Y, uopFCVT_S_D,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_D_S-> List(Y, Y, N, uopFCVT_D_S,IQT_FP , FU_FPU, RT_FLT, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
    // Int to FP
-   FCVT_S_W-> List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_S_WU->List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_S_L-> List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_S_LU->List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FCVT_S_W-> List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_S_WU->List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_S_L-> List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_S_LU->List(Y, Y, Y, uopFCVT_S_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FCVT_D_W-> List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_D_WU->List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_D_L-> List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_D_LU->List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FCVT_D_W-> List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_D_WU->List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_D_L-> List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_D_LU->List(Y, Y, N, uopFCVT_D_X, IQT_INT,FU_I2F, RT_FLT, RT_FIX, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
    // FP to Int
-   FCVT_W_S-> List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_WU_S->List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_L_S-> List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_LU_S->List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FCVT_W_S-> List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_WU_S->List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_L_S-> List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_LU_S->List(Y, Y, Y, uopFCVT_X_S, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FCVT_W_D-> List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_WU_D->List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_L_D-> List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FCVT_LU_D->List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FCVT_W_D-> List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_WU_D->List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_L_D-> List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FCVT_LU_D->List(Y, Y, N, uopFCVT_X_D, IQT_FP, FU_F2I, RT_FIX, RT_FLT, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
    // "fp_single" is used for wb_data formatting (and debugging)
-   FEQ_S    ->List(Y, Y, Y, uopCMPR_S , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FLT_S    ->List(Y, Y, Y, uopCMPR_S , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FLE_S    ->List(Y, Y, Y, uopCMPR_S , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FEQ_S    ->List(Y, Y, Y, uopCMPR_S , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FLT_S    ->List(Y, Y, Y, uopCMPR_S , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FLE_S    ->List(Y, Y, Y, uopCMPR_S , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FEQ_D    ->List(Y, Y, N, uopCMPR_D , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FLT_D    ->List(Y, Y, N, uopCMPR_D , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FLE_D    ->List(Y, Y, N, uopCMPR_D , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FEQ_D    ->List(Y, Y, N, uopCMPR_D , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FLT_D    ->List(Y, Y, N, uopCMPR_D , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FLE_D    ->List(Y, Y, N, uopCMPR_D , IQT_FP,  FU_F2I, RT_FIX, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FMIN_S   ->List(Y, Y, Y,uopFMINMAX_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMAX_S   ->List(Y, Y, Y,uopFMINMAX_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMIN_D   ->List(Y, Y, N,uopFMINMAX_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMAX_D   ->List(Y, Y, N,uopFMINMAX_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FMIN_S   ->List(Y, Y, Y,uopFMINMAX_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMAX_S   ->List(Y, Y, Y,uopFMINMAX_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMIN_D   ->List(Y, Y, N,uopFMINMAX_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMAX_D   ->List(Y, Y, N,uopFMINMAX_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FADD_S   ->List(Y, Y, Y, uopFADD_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSUB_S   ->List(Y, Y, Y, uopFSUB_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMUL_S   ->List(Y, Y, Y, uopFMUL_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FADD_D   ->List(Y, Y, N, uopFADD_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSUB_D   ->List(Y, Y, N, uopFSUB_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMUL_D   ->List(Y, Y, N, uopFMUL_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
+   FADD_S   ->List(Y, Y, Y, uopFADD_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSUB_S   ->List(Y, Y, Y, uopFSUB_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMUL_S   ->List(Y, Y, Y, uopFMUL_S , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FADD_D   ->List(Y, Y, N, uopFADD_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSUB_D   ->List(Y, Y, N, uopFSUB_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMUL_D   ->List(Y, Y, N, uopFMUL_D , IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
 
-   FMADD_S  ->List(Y, Y, Y, uopFMADD_S, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMSUB_S  ->List(Y, Y, Y, uopFMSUB_S, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FNMADD_S ->List(Y, Y, Y, uopFNMADD_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FNMSUB_S ->List(Y, Y, Y, uopFNMSUB_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMADD_D  ->List(Y, Y, N, uopFMADD_D, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FMSUB_D  ->List(Y, Y, N, uopFMSUB_D, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FNMADD_D ->List(Y, Y, N, uopFNMADD_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FNMSUB_D ->List(Y, Y, N, uopFNMSUB_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N)
+   FMADD_S  ->List(Y, Y, Y, uopFMADD_S, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMSUB_S  ->List(Y, Y, Y, uopFMSUB_S, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FNMADD_S ->List(Y, Y, Y, uopFNMADD_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FNMSUB_S ->List(Y, Y, Y, uopFNMSUB_S,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMADD_D  ->List(Y, Y, N, uopFMADD_D, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FMSUB_D  ->List(Y, Y, N, uopFMSUB_D, IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FNMADD_D ->List(Y, Y, N, uopFNMADD_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FNMSUB_D ->List(Y, Y, N, uopFNMSUB_D,IQT_FP,  FU_FPU, RT_FLT, RT_FLT, RT_FLT, Y, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N)
    )
 
 // scalastyle:on
@@ -329,10 +330,10 @@ object FDivSqrtDecode extends DecodeConstants
              //     |  |  |  |           iq-type func    dst     |       |       |  |     |  |  |  |  |  mem    mem    |        |  |  |  |  |  is unique? (clear pipeline for it)
              //     |  |  |  |           |       unit    regtype |       |       |  |     |  |  |  |  |  cmd    msk    |        |  |  |  |  |  |  flush on commit
              //     |  |  |  |           |       |       |       |       |       |  |     |  |  |  |  |  |      |      |        |  |  |  |  |  |  |  csr cmd
-   FDIV_S    ->List(Y, Y, Y, uopFDIV_S , IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FDIV_D    ->List(Y, Y, N, uopFDIV_D , IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSQRT_S   ->List(Y, Y, Y, uopFSQRT_S, IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N),
-   FSQRT_D   ->List(Y, Y, N, uopFSQRT_D, IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , UInt(0), N, N, N, N, N, N, N, CSR.N)
+   FDIV_S    ->List(Y, Y, Y, uopFDIV_S , IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FDIV_D    ->List(Y, Y, N, uopFDIV_D , IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_FLT, N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSQRT_S   ->List(Y, Y, Y, uopFSQRT_S, IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N),
+   FSQRT_D   ->List(Y, Y, N, uopFSQRT_D, IQT_FP, FU_FDV, RT_FLT, RT_FLT, RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, N, N, CSR.N)
    )
 // scalastyle:on
 }
@@ -340,14 +341,14 @@ object FDivSqrtDecode extends DecodeConstants
 
 class DecodeUnitIo(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val enq = new Bundle { val uop = new MicroOp().asInput }
-   val deq = new Bundle { val uop = new MicroOp().asOutput }
+   val enq = new Bundle { val uop = Input(new MicroOp()) }
+   val deq = new Bundle { val uop = Output(new MicroOp()) }
 
    // from CSRFile
-   val status = new freechips.rocketchip.rocket.MStatus().asInput
+   val status = Input(new freechips.rocketchip.rocket.MStatus())
    val csr_decode = Flipped(new freechips.rocketchip.rocket.CSRDecodeIO)
-   val interrupt = Bool(INPUT)
-   val interrupt_cause = UInt(INPUT, xLen)
+   val interrupt = Input(Bool())
+   val interrupt_cause = Input(UInt(xLen.W))
 
    override def cloneType: this.type = new DecodeUnitIo()(p).asInstanceOf[this.type]
 }
@@ -394,10 +395,10 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    val (xcpt_valid, xcpt_cause) = checkExceptions(List(
       (io.interrupt,     io.interrupt_cause),
       (uop.replay_if,    MINI_EXCEPTION_REPLAY),
-      (uop.xcpt_pf_if,   UInt(Causes.fetch_page_fault)),
-      (uop.xcpt_ae_if,   UInt(Causes.fetch_access)),
-      (uop.xcpt_ma_if,   UInt(Causes.misaligned_fetch)),
-      (id_illegal_insn,  UInt(Causes.illegal_instruction))))
+      (uop.xcpt_pf_if,   (Causes.fetch_page_fault).U),
+      (uop.xcpt_ae_if,   (Causes.fetch_access).U),
+      (uop.xcpt_ma_if,   (Causes.misaligned_fetch).U),
+      (id_illegal_insn,  (Causes.illegal_instruction).U)))
 
    uop.exception := xcpt_valid
    uop.exc_cause := xcpt_cause
@@ -416,7 +417,7 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    uop.lrs2       := uop.inst(RS2_MSB,RS2_LSB)
    uop.lrs3       := uop.inst(RS3_MSB,RS3_LSB)
 
-   uop.ldst_val   := cs.dst_type =/= RT_X && !(uop.ldst === UInt(0) && uop.dst_rtype === RT_FIX)
+   uop.ldst_val   := cs.dst_type =/= RT_X && !(uop.ldst === 0.U && uop.dst_rtype === RT_FIX)
    uop.dst_rtype  := cs.dst_type
    uop.lrs1_rtype := cs.rs1_type
    uop.lrs2_rtype := cs.rs2_type
@@ -471,10 +472,10 @@ class BranchDecode extends Module
 {
    val io = IO(new Bundle
    {
-      val inst    = UInt(INPUT, 32)
-      val is_br   = Bool(OUTPUT)
-      val is_jal  = Bool(OUTPUT)
-      val is_jalr = Bool(OUTPUT)
+      val inst    = Input(UInt(32.W))
+      val is_br   = Output(Bool())
+      val is_jal  = Output(Bool())
+      val is_jalr = Output(Bool())
    })
 
    val bpd_csignals =
@@ -510,7 +511,7 @@ class BranchDecode extends Module
 
 class DebugBranchMaskGenerationLogicIO(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val branch_mask = UInt(width = MAX_BR_COUNT)
+   val branch_mask = UInt(MAX_BR_COUNT.W)
 }
 
 class BranchMaskGenerationLogic(val pl_width: Int)(implicit p: Parameters) extends BoomModule()(p)
@@ -518,50 +519,50 @@ class BranchMaskGenerationLogic(val pl_width: Int)(implicit p: Parameters) exten
    val io = IO(new Bundle
    {
       // guess if the uop is a branch (we'll catch this later)
-      val is_branch = Vec(pl_width, Bool()).asInput
+      val is_branch = Input(Vec(pl_width, Bool()))
       // lock in that it's actually a branch and will fire, so we update
       // the branch_masks.
-      val will_fire = Vec(pl_width, Bool()).asInput
+      val will_fire = Input(Vec(pl_width, Bool()))
 
       // give out tag immediately (needed in rename)
       // mask can come later in the cycle
-      val br_tag    = Vec(pl_width, UInt(width=BR_TAG_SZ)).asOutput
-      val br_mask   = Vec(pl_width, UInt(width=MAX_BR_COUNT)).asOutput
+      val br_tag    = Output(Vec(pl_width, UInt(BR_TAG_SZ.W)))
+      val br_mask   = Output(Vec(pl_width, UInt(MAX_BR_COUNT.W)))
 
        // tell decoders the branch mask has filled up, but on the granularity
        // of an individual micro-op (so some micro-ops can go through)
-      val is_full   = Vec(pl_width, Bool()).asOutput
+      val is_full   = Output(Vec(pl_width, Bool()))
 
-      val brinfo         = new BrResolutionInfo().asInput
-      val flush_pipeline = Bool(INPUT)
+      val brinfo         = Input(new BrResolutionInfo())
+      val flush_pipeline = Input(Bool())
 
-      val debug = new DebugBranchMaskGenerationLogicIO().asOutput
+      val debug = Output(new DebugBranchMaskGenerationLogicIO())
    })
 
-   val branch_mask = Reg(init = UInt(0, MAX_BR_COUNT))
+   val branch_mask = RegInit(0.U(MAX_BR_COUNT.W))
 
    //-------------------------------------------------------------
    // Give out the branch tag to each branch micro-op
 
    var allocate_mask = branch_mask
-   val tag_masks = Wire(Vec(pl_width, UInt(width=MAX_BR_COUNT)))
+   val tag_masks = Wire(Vec(pl_width, UInt(MAX_BR_COUNT.W)))
 
    for (w <- 0 until pl_width)
    {
       // TODO this is a loss of performance as we're blocking branches based on potentially fake branches
-      io.is_full(w) := (allocate_mask === ~(UInt(0,MAX_BR_COUNT))) && io.is_branch(w)
+      io.is_full(w) := (allocate_mask === ~(0.U(MAX_BR_COUNT.W))) && io.is_branch(w)
 
       // find br_tag and compute next br_mask
-      val new_br_tag = Wire(UInt(width = BR_TAG_SZ))
-      new_br_tag := UInt(0)
-      tag_masks(w) := UInt(0)
+      val new_br_tag = Wire(UInt(BR_TAG_SZ.W))
+      new_br_tag := 0.U
+      tag_masks(w) := 0.U
 
       for (i <- MAX_BR_COUNT-1 to 0 by -1)
       {
          when (~allocate_mask(i))
          {
-            new_br_tag := UInt(i)
-            tag_masks(w) := (UInt(1) << UInt(i))
+            new_br_tag := i.U
+            tag_masks(w) := (1.U << i.U)
          }
       }
 
@@ -585,7 +586,7 @@ class BranchMaskGenerationLogic(val pl_width: Int)(implicit p: Parameters) exten
 
    when (io.flush_pipeline)
    {
-      branch_mask := UInt(0)
+      branch_mask := 0.U
    }
    .elsewhen (io.brinfo.valid && io.brinfo.mispredict)
    {

--- a/src/main/scala/exu/execution_units.scala
+++ b/src/main/scala/exu/execution_units.scala
@@ -9,7 +9,7 @@
 
 package boom.exu
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config.Parameters
 import scala.collection.mutable.ArrayBuffer
 import boom.common._

--- a/src/main/scala/exu/fdiv.scala
+++ b/src/main/scala/exu/fdiv.scala
@@ -113,7 +113,7 @@ class FDivSqrtUnit(implicit p: Parameters)
       r_buffer_val := true.B
       r_buffer_req := io.req.bits
       r_buffer_req.uop.br_mask := GetNewBrMask(io.brinfo, io.req.bits.uop)
-      //r_buffer_fin := fdiv_decoder.io.sigs
+      r_buffer_fin <> fdiv_decoder.io.sigs
 
       r_buffer_fin.rm := io.fcsr_rm
       r_buffer_fin.typ := 0.U // unused for fdivsqrt

--- a/src/main/scala/exu/fppipeline.scala
+++ b/src/main/scala/exu/fppipeline.scala
@@ -85,13 +85,6 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
    require (exe_units.withFilter(_.uses_iss_unit).map(e =>
       e.num_rf_write_ports).sum -1 + num_ll_ports == num_wakeup_ports)
 
-   //*********************************
-   // dontcare unconnected signals
-   exe_units.map(_.io.lsu_io := DontCare)
-   exe_units.map(_.io.status := DontCare)
-   exe_units.map(_.io.dmem := DontCare)
-   exe_units.map(_.io.get_ftq_pc := DontCare)
-
    //*************************************************************
    // Issue window logic
 

--- a/src/main/scala/exu/fpu.scala
+++ b/src/main/scala/exu/fpu.scala
@@ -107,7 +107,6 @@ class UOPCodeFPUDecoder extends Module
    val decoder = rocket.DecodeLogic(io.uopc, default, insns)
 
    val s = io.sigs
-   io.sigs := DontCare //TODO: Overrides?
    val sigs = Seq(s.ldst, s.wen, s.ren1, s.ren2, s.ren3, s.swap12,
                   s.swap23, s.singleIn, s.singleOut, s.fromint, s.toint, s.fastpipe, s.fma,
                   s.div, s.sqrt, s.wflags)
@@ -176,7 +175,6 @@ class FPU(implicit p: Parameters) extends BoomModule()(p) with tile.HasFPUParame
 	def fuInput(minT: Option[tile.FType]): tile.FPInput = {
 		val req = Wire(new tile.FPInput)
 		val tag = !fp_ctrl.singleIn
-		req := DontCare
         req <> fp_ctrl
 		req.rm := fp_rm
 		req.in1 := unbox(io_req.rs1_data, tag, minT)

--- a/src/main/scala/exu/fpu.scala
+++ b/src/main/scala/exu/fpu.scala
@@ -103,7 +103,7 @@ class UOPCodeFPUDecoder extends Module
 //      case 32 => f_table
 //      case 64 => f_table ++ d_table
 //   }
-	val insns = f_table ++ d_table
+   val insns = f_table ++ d_table
    val decoder = rocket.DecodeLogic(io.uopc, default, insns)
 
    val s = io.sigs
@@ -172,22 +172,22 @@ class FPU(implicit p: Parameters) extends BoomModule()(p) with tile.HasFPUParame
    val fp_ctrl = fp_decoder.io.sigs
    val fp_rm = Mux(ImmGenRm(io_req.uop.imm_packed) === 7.U, io_req.fcsr_rm, ImmGenRm(io_req.uop.imm_packed))
 
-	def fuInput(minT: Option[tile.FType]): tile.FPInput = {
-		val req = Wire(new tile.FPInput)
-		val tag = !fp_ctrl.singleIn
+   def fuInput(minT: Option[tile.FType]): tile.FPInput = {
+        val req = Wire(new tile.FPInput)
+        val tag = !fp_ctrl.singleIn
         req <> fp_ctrl
-		req.rm := fp_rm
-		req.in1 := unbox(io_req.rs1_data, tag, minT)
-		req.in2 := unbox(io_req.rs2_data, tag, minT)
-		req.in3 := unbox(io_req.rs3_data, tag, minT)
+        req.rm := fp_rm
+        req.in1 := unbox(io_req.rs1_data, tag, minT)
+        req.in2 := unbox(io_req.rs2_data, tag, minT)
+        req.in3 := unbox(io_req.rs3_data, tag, minT)
         when (fp_ctrl.swap23) { req.in3 := req.in2 }
         req.typ := ImmGenTyp(io_req.uop.imm_packed)
 
         val fma_decoder = Module(new FMADecoder)
         fma_decoder.io.uopc := io_req.uop.uopc
-		req.fmaCmd := fma_decoder.io.cmd // ex_reg_inst(3,2) | (!fp_ctrl.ren3 && ex_reg_inst(27))
-    	req
-  	}
+        req.fmaCmd := fma_decoder.io.cmd // ex_reg_inst(3,2) | (!fp_ctrl.ren3 && ex_reg_inst(27))
+        req
+   }
 
 
    val dfma = Module(new tile.FPUFMAPipe(latency = fpu_latency, t = tile.FType.D))

--- a/src/main/scala/exu/fudecode.scala
+++ b/src/main/scala/exu/fudecode.scala
@@ -11,7 +11,8 @@
 
 package boom.exu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 import freechips.rocketchip.rocket.ALU._
@@ -21,17 +22,17 @@ import boom.common._
 
 class RRdCtrlSigs(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val br_type          = UInt(width = BR_N.getWidth)
+   val br_type          = UInt(BR_N.getWidth.W)
    val use_alupipe      = Bool()
    val use_muldivpipe   = Bool()
    val use_mempipe      = Bool()
-   val op_fcn      = Bits(width = SZ_ALU_FN)
+   val op_fcn      = Bits(SZ_ALU_FN.W)
    val fcn_dw      = Bool()
-   val op1_sel     = UInt(width = OP1_X.getWidth)
-   val op2_sel     = UInt(width = OP2_X.getWidth)
-   val imm_sel     = UInt(width = IS_X.getWidth)
+   val op1_sel     = UInt(OP1_X.getWidth.W)
+   val op2_sel     = UInt(OP2_X.getWidth.W)
+   val imm_sel     = UInt(IS_X.getWidth.W)
    val rf_wen      = Bool()
-   val csr_cmd     = Bits(width = CSR.SZ)
+   val csr_cmd     = Bits(CSR.SZ.W)
 
    def decode(uopc: UInt, table: Iterable[(BitPat, List[BitPat])]) =
    {
@@ -275,11 +276,11 @@ class RegisterReadDecode(supported_units: SupportedFuncUnits)(implicit p: Parame
 {
    val io = IO(new BoomBundle()(p)
    {
-      val iss_valid = Bool(INPUT)
-      val iss_uop   = new MicroOp().asInput
+      val iss_valid = Input(Bool())
+      val iss_uop   = Input(new MicroOp())
 
-      val rrd_valid = Bool(OUTPUT)
-      val rrd_uop   = new MicroOp().asOutput
+      val rrd_valid = Output(Bool())
+      val rrd_uop   = Output(new MicroOp())
    })
 
    // Issued Instruction

--- a/src/main/scala/exu/functional_unit.scala
+++ b/src/main/scala/exu/functional_unit.scala
@@ -644,13 +644,12 @@ class FPUUnit(implicit p: Parameters) extends PipelinedFunctionalUnit(
    data_width = 65)(p)
 {
    val fpu = Module(new FPU())
-   //fpu.io.req <> io.req
-   fpu.io.req.valid := io.req.valid
+   fpu.io.req.valid         := io.req.valid
+   fpu.io.req.bits.uop      := io.req.bits.uop 
    fpu.io.req.bits.rs1_data := io.req.bits.rs1_data
-   fpu.io.req.bits.rs2_data := io.req.bits.rs1_data
-   fpu.io.req.bits.rs3_data := io.req.bits.rs1_data
-   fpu.io.req.bits.fcsr_rm := io.fcsr_rm
-   fpu.io.req.bits.uop := DontCare
+   fpu.io.req.bits.rs2_data := io.req.bits.rs2_data
+   fpu.io.req.bits.rs3_data := io.req.bits.rs3_data
+   fpu.io.req.bits.fcsr_rm  := io.fcsr_rm
 
    io.resp.bits.data              := fpu.io.resp.bits.data
    io.resp.bits.fflags.valid      := fpu.io.resp.bits.fflags.valid
@@ -674,12 +673,14 @@ class IntToFPUnit(latency: Int)(implicit p: Parameters) extends PipelinedFunctio
    val req = Wire(new tile.FPInput)
    val tag = !fp_ctrl.singleIn
 
-   req := DontCare
    req <> fp_ctrl
+
    req.rm := fp_rm
    req.in1 := unbox(io_req.rs1_data, tag, None)
    req.in2 := unbox(io_req.rs2_data, tag, None)
+   req.in3 := DontCare
    req.typ := ImmGenTyp(io_req.uop.imm_packed)
+   req.fmaCmd := DontCare
 
    assert (!(io.req.valid && fp_ctrl.fromint && req.in1(64).toBool),
       "[func] IntToFP integer input has 65th high-order bit set!")

--- a/src/main/scala/exu/issue.scala
+++ b/src/main/scala/exu/issue.scala
@@ -31,7 +31,7 @@ trait IssueUnitConstants
    // invalid  : slot holds no valid uop.
    // s_valid_1: slot holds a valid uop.
    // s_valid_2: slot holds a store-like uop that may be broken into two micro-ops.
-   val s_invalid :: s_valid_1 :: s_valid_2 :: Nil = Enum(UInt(), 3)
+   val s_invalid :: s_valid_1 :: s_valid_2 :: Nil = Enum(3)
 }
 
 // What physical register is broadcasting its wakeup?
@@ -140,7 +140,7 @@ abstract class IssueUnit(
       {
          printf("  " + this.getType + "_issue_slot[%d](%c)(Req:%c):wen=%c P:(%c,%c,%c) OP:(%d,%d,%d) PDST:%d %c [[DASM(%x)]" +
                " 0x%x: %d] ri:%d bm=%d imm=0x%x\n"
-            , UInt(i, log2Up(num_issue_slots))
+            , i.U(log2Ceil(num_issue_slots).W)
             , Mux(issue_slots(i).valid, Str("V"), Str("-"))
             , Mux(issue_slots(i).request, Str("R"), Str("-"))
             , Mux(issue_slots(i).in_uop.valid, Str("W"),  Str(" "))

--- a/src/main/scala/exu/issue_slot.scala
+++ b/src/main/scala/exu/issue_slot.scala
@@ -81,7 +81,7 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters)
    val slot_p1_poisoned   = RegInit(false.B)
    val slot_p2_poisoned   = RegInit(false.B)
 
-   val slotUop = Reg(init = NullMicroOp)
+   val slotUop = RegInit(NullMicroOp)
 
    //-----------------------------------------------------------------------------
    // next slot state computation

--- a/src/main/scala/exu/registerread.scala
+++ b/src/main/scala/exu/registerread.scala
@@ -103,6 +103,9 @@ class RegisterRead(
    val rrd_rs1_data   = Wire(Vec(issue_width, Bits(regwidth.W)))
    val rrd_rs2_data   = Wire(Vec(issue_width, Bits(regwidth.W)))
    val rrd_rs3_data   = Wire(Vec(issue_width, Bits(regwidth.W)))
+   rrd_rs1_data := DontCare 
+   rrd_rs2_data := DontCare 
+   rrd_rs3_data := DontCare 
 
    var idx = 0 // index into flattened read_ports array
    for (w <- 0 until issue_width)
@@ -118,14 +121,10 @@ class RegisterRead(
       val rs2_addr = io.iss_uops(w).pop2
       val rs3_addr = io.iss_uops(w).pop3
 
-      // Set to DontCare then override
       if (num_read_ports > 0) io.rf_read_ports(idx+0).addr := rs1_addr
       if (num_read_ports > 1) io.rf_read_ports(idx+1).addr := rs2_addr
       if (num_read_ports > 2) io.rf_read_ports(idx+2).addr := rs3_addr
 
-      rrd_rs1_data(w) := DontCare
-      rrd_rs2_data(w) := DontCare
-      rrd_rs3_data(w) := DontCare
       if (num_read_ports > 0) rrd_rs1_data(w) := io.rf_read_ports(idx+0).data
       if (num_read_ports > 1) rrd_rs2_data(w) := io.rf_read_ports(idx+1).data
       if (num_read_ports > 2) rrd_rs3_data(w) := io.rf_read_ports(idx+2).data

--- a/src/main/scala/exu/registerread.scala
+++ b/src/main/scala/exu/registerread.scala
@@ -16,7 +16,8 @@
 
 package boom.exu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import boom.common._
 import boom.util._
@@ -29,19 +30,19 @@ class RegisterReadIO(
 )(implicit p: Parameters) extends  BoomBundle()(p)
 {
    // issued micro-ops
-   val iss_valids = Vec(issue_width, Bool()).asInput
-   val iss_uops   = Vec(issue_width, new MicroOp()).asInput
+   val iss_valids = Input(Vec(issue_width, Bool()))
+   val iss_uops   = Input(Vec(issue_width, new MicroOp()))
 
    // interface with register file's read ports
-   val rf_read_ports = Vec(num_total_read_ports, new RegisterFileReadPortIO(PREG_SZ, register_width)).flip
+   val rf_read_ports = Flipped(Vec(num_total_read_ports, new RegisterFileReadPortIO(PREG_SZ, register_width)))
 
-   val bypass = new BypassData(num_total_bypass_ports, register_width).asInput
+   val bypass = Input(new BypassData(num_total_bypass_ports, register_width))
 
    // send micro-ops to the execution pipelines
    val exe_reqs = Vec(issue_width, (new DecoupledIO(new FuncUnitReq(register_width))))
 
-   val kill   = Bool(INPUT)
-   val brinfo = new BrResolutionInfo().asInput
+   val kill   = Input(Bool())
+   val brinfo = Input(new BrResolutionInfo())
 
    override def cloneType =
       new RegisterReadIO(issue_width, num_total_read_ports, num_total_bypass_ports, register_width
@@ -66,11 +67,11 @@ class RegisterRead(
    val rrd_valids       = Wire(Vec(issue_width, Bool()))
    val rrd_uops         = Wire(Vec(issue_width, new MicroOp()))
 
-   val exe_reg_valids   = Reg(init = Vec.fill(issue_width) { Bool(false) })
+   val exe_reg_valids   = RegInit(VecInit(Seq.fill(issue_width) { false.B }))
    val exe_reg_uops     = Reg(Vec(issue_width, new MicroOp()))
-   val exe_reg_rs1_data = Reg(Vec(issue_width, Bits(width = register_width)))
-   val exe_reg_rs2_data = Reg(Vec(issue_width, Bits(width = register_width)))
-   val exe_reg_rs3_data = Reg(Vec(issue_width, Bits(width = register_width)))
+   val exe_reg_rs1_data = Reg(Vec(issue_width, Bits(register_width.W)))
+   val exe_reg_rs2_data = Reg(Vec(issue_width, Bits(register_width.W)))
+   val exe_reg_rs3_data = Reg(Vec(issue_width, Bits(register_width.W)))
 
 
    //-------------------------------------------------------------
@@ -99,9 +100,9 @@ class RegisterRead(
    require (num_total_read_ports == num_read_ports_array.reduce(_+_))
 
    val regwidth = if (usingFPU) 65 else 64
-   val rrd_rs1_data   = Wire(Vec(issue_width, Bits(width=regwidth)))
-   val rrd_rs2_data   = Wire(Vec(issue_width, Bits(width=regwidth)))
-   val rrd_rs3_data   = Wire(Vec(issue_width, Bits(width=regwidth)))
+   val rrd_rs1_data   = Wire(Vec(issue_width, Bits(regwidth.W)))
+   val rrd_rs2_data   = Wire(Vec(issue_width, Bits(regwidth.W)))
+   val rrd_rs3_data   = Wire(Vec(issue_width, Bits(regwidth.W)))
 
    var idx = 0 // index into flattened read_ports array
    for (w <- 0 until issue_width)
@@ -117,20 +118,24 @@ class RegisterRead(
       val rs2_addr = io.iss_uops(w).pop2
       val rs3_addr = io.iss_uops(w).pop3
 
+      // Set to DontCare then override
       if (num_read_ports > 0) io.rf_read_ports(idx+0).addr := rs1_addr
       if (num_read_ports > 1) io.rf_read_ports(idx+1).addr := rs2_addr
       if (num_read_ports > 2) io.rf_read_ports(idx+2).addr := rs3_addr
 
+      rrd_rs1_data(w) := DontCare
+      rrd_rs2_data(w) := DontCare
+      rrd_rs3_data(w) := DontCare
       if (num_read_ports > 0) rrd_rs1_data(w) := io.rf_read_ports(idx+0).data
       if (num_read_ports > 1) rrd_rs2_data(w) := io.rf_read_ports(idx+1).data
       if (num_read_ports > 2) rrd_rs3_data(w) := io.rf_read_ports(idx+2).data
 
-      val rrd_kill = Mux(io.kill, Bool(true),
+      val rrd_kill = Mux(io.kill, true.B,
                      Mux(io.brinfo.valid && io.brinfo.mispredict
                                        , maskMatch(rrd_uops(w).br_mask, io.brinfo.mask)
-                                       , Bool(false)))
+                                       , false.B))
 
-      exe_reg_valids(w) := Mux(rrd_kill, Bool(false), rrd_valids(w))
+      exe_reg_valids(w) := Mux(rrd_kill, false.B, rrd_valids(w))
       // TODO use only the valids signal, don't require us to set nullUop
       exe_reg_uops(w)   := Mux(rrd_kill, NullMicroOp, rrd_uops(w))
 
@@ -151,14 +156,14 @@ class RegisterRead(
    //       them!).
    //    - only bypass integer registers.
 
-   val bypassed_rs1_data = Wire(Vec(issue_width, Bits(width = register_width)))
-   val bypassed_rs2_data = Wire(Vec(issue_width, Bits(width = register_width)))
+   val bypassed_rs1_data = Wire(Vec(issue_width, Bits(register_width.W)))
+   val bypassed_rs2_data = Wire(Vec(issue_width, Bits(register_width.W)))
 
    for (w <- 0 until issue_width)
    {
       val num_read_ports = num_read_ports_array(w)
-      var rs1_cases = Array((Bool(false), Bits(0, register_width)))
-      var rs2_cases = Array((Bool(false), Bits(0, register_width)))
+      var rs1_cases = Array((false.B, 0.U(register_width.W)))
+      var rs2_cases = Array((false.B, 0.U(register_width.W)))
 
       val pop1       = rrd_uops(w).pop1
       val lrs1_rtype = rrd_uops(w).lrs1_rtype
@@ -169,9 +174,9 @@ class RegisterRead(
       {
          // can't use "io.bypass.valid(b) since it would create a combinational loop on branch kills"
          rs1_cases ++= Array((io.bypass.valid(b) && (pop1 === io.bypass.uop(b).pdst) && io.bypass.uop(b).ctrl.rf_wen
-            && io.bypass.uop(b).dst_rtype === RT_FIX && lrs1_rtype === RT_FIX && (pop1 =/= UInt(0)), io.bypass.data(b)))
+            && io.bypass.uop(b).dst_rtype === RT_FIX && lrs1_rtype === RT_FIX && (pop1 =/= 0.U), io.bypass.data(b)))
          rs2_cases ++= Array((io.bypass.valid(b) && (pop2 === io.bypass.uop(b).pdst) && io.bypass.uop(b).ctrl.rf_wen
-            && io.bypass.uop(b).dst_rtype === RT_FIX && lrs2_rtype === RT_FIX && (pop2 =/= UInt(0)), io.bypass.data(b)))
+            && io.bypass.uop(b).dst_rtype === RT_FIX && lrs2_rtype === RT_FIX && (pop2 =/= 0.U), io.bypass.data(b)))
       }
 
       if (num_read_ports > 0) bypassed_rs1_data(w) := MuxCase(rrd_rs1_data(w), rs1_cases)

--- a/src/main/scala/exu/rename-freelist.scala
+++ b/src/main/scala/exu/rename-freelist.scala
@@ -79,7 +79,7 @@ class RenameFreeListHelper(
    val io = IO(new FreeListIo(num_phys_registers, pl_width))
 
    // ** FREE LIST TABLE ** //
-   val free_list = RegInit((~(1.U(num_phys_registers.W))))
+   val free_list = RegInit(~(1.U(num_phys_registers.W)))
 
    // track all allocations that have occurred since branch passed by
    // can quickly reset pipeline on branch mispredict
@@ -212,7 +212,7 @@ class RenameFreeListHelper(
    // allowing for a single-cycle reset of the rename state on a pipeline flush.
    if (ENABLE_COMMIT_MAP_TABLE)
    {
-      val committed_free_list = RegInit((~1.U(num_phys_registers.W)))
+      val committed_free_list = RegInit(~(1.U(num_phys_registers.W)))
 
       val com_mask = Wire(Vec(pl_width,   Bits(num_phys_registers.W)))
       val stale_mask = Wire(Vec(pl_width, Bits(num_phys_registers.W)))

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -250,6 +250,7 @@ class Rob(
          override def cloneType: this.type = new DebugRobBundle().asInstanceOf[this.type]
       }
    val debug_entry = Wire(Vec(NUM_ROB_ENTRIES, new DebugRobBundle))
+   debug_entry := DontCare // override in statements below
 
 
    // **************************************************************************
@@ -486,9 +487,6 @@ class Rob(
       //--------------------------------------------------
       // Debug: handle passing out signals to printf in dpath
 
-      for (i <- 0 until num_rob_rows){
-          debug_entry(w + i*width) := DontCare // Set everything to DontCare first then override
-      }
       if (DEBUG_PRINTF_ROB)
       {
          for (i <- 0 until num_rob_rows)

--- a/src/main/scala/ifu/branchchecker.scala
+++ b/src/main/scala/ifu/branchchecker.scala
@@ -10,7 +10,8 @@
 
 package boom.ifu
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import boom.bpu._
 import boom.common._
@@ -32,33 +33,33 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    {
       val req           = Valid(new PCReq)
 
-      val valid         = Bool(INPUT)                      // are the inputs valid?
-      val inst_mask     = Vec(fetch_width, Bool()).asInput // valid instruction mask from I$
-      val is_br         = Vec(fetch_width, Bool()).asInput
-      val is_jal        = Vec(fetch_width, Bool()).asInput
-      val is_jr         = Vec(fetch_width, Bool()).asInput
-      val is_call       = Vec(fetch_width, Bool()).asInput
+      val valid         = Input(Bool())                      // are the inputs valid?
+      val inst_mask     = Input(Vec(fetch_width, Bool())) // valid instruction mask from I$
+      val is_br         = Input(Vec(fetch_width, Bool()))
+      val is_jal        = Input(Vec(fetch_width, Bool()))
+      val is_jr         = Input(Vec(fetch_width, Bool()))
+      val is_call       = Input(Vec(fetch_width, Bool()))
 
-      val br_targs      = Vec(fetch_width, UInt(width=vaddrBitsExtended)).asInput
-      val jal_targs     = Vec(fetch_width, UInt(width=vaddrBitsExtended)).asInput
+      val br_targs      = Input(Vec(fetch_width, UInt(vaddrBitsExtended.W)))
+      val jal_targs     = Input(Vec(fetch_width, UInt(vaddrBitsExtended.W)))
 
-      val fetch_pc      = UInt(INPUT, width=vaddrBitsExtended)
-      val aligned_pc    = UInt(INPUT, width=vaddrBitsExtended)
+      val fetch_pc      = Input(UInt(vaddrBitsExtended.W))
+      val aligned_pc    = Input(UInt(vaddrBitsExtended.W))
 
-      val btb_resp      = Valid(new BoomBTBResp).flip
-      val bpd_resp      = Valid(new BpdResp).flip
+      val btb_resp      = Flipped(Valid(new BoomBTBResp))
+      val bpd_resp      = Flipped(Valid(new BpdResp))
 
       val btb_update    = Valid(new BoomBTBUpdate)
       val ras_update    = Valid(new RasUpdate)
 
-      val req_cfi_idx   = UInt(OUTPUT, width = log2Up(fetchWidth)) // where is cfi we are predicting?
+      val req_cfi_idx   = Output(UInt(log2Ceil(fetchWidth).W)) // where is cfi we are predicting?
    })
 
    // Did the BTB mispredict the cfi type?
    // Did the BTB mispredict the cfi target?
    // Did the BTB predict a masked-off instruction?
-   val wrong_cfi = Wire(init = false.B)
-   val wrong_target = Wire(init = false.B)
+   val wrong_cfi = WireInit(false.B)
+   val wrong_target = WireInit(false.B)
 
    val btb_idx = io.btb_resp.bits.cfi_idx
    val btb_target = io.btb_resp.bits.target // TODO uncomment .sextTo(vaddrBitsExtended)
@@ -117,7 +118,7 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    io.req.valid := jal_wins || btb_was_wrong
    io.req.bits.addr := Mux(jal_wins, io.jal_targs(jal_idx), nextline_pc)
    // Help mask out instructions after predicted cfi.
-   io.req_cfi_idx := Mux(jal_wins, jal_idx, UInt(fetchWidth-1))
+   io.req_cfi_idx := Mux(jal_wins, jal_idx, (fetchWidth-1).U)
 
 
    //-------------------------------------------------------------
@@ -129,7 +130,7 @@ class BranchChecker(fetch_width: Int)(implicit p: Parameters) extends BoomModule
    io.btb_update.bits.pc := io.fetch_pc
    io.btb_update.bits.target := io.jal_targs(jal_idx)
    io.btb_update.bits.taken := true.B
-   io.btb_update.bits.cfi_pc := jal_idx << log2Up(coreInstBytes)
+   io.btb_update.bits.cfi_pc := jal_idx << log2Ceil(coreInstBytes)
    io.btb_update.bits.bpd_type := Mux(io.is_call(jal_idx), BpredType.call, BpredType.jump)
    io.btb_update.bits.cfi_type := CfiType.jal
 

--- a/src/main/scala/ifu/fetchbuffer.scala
+++ b/src/main/scala/ifu/fetchbuffer.scala
@@ -37,11 +37,11 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    require (num_entries > 1)
    private val num_elements = num_entries*fetchWidth
    private val ram = Mem(num_elements, new MicroOp())
-   private val write_ptr = RegInit(0.asUInt(width=log2Ceil(num_elements).W))
-   private val read_ptr = RegInit(0.asUInt(width=log2Ceil(num_elements).W))
+   private val write_ptr = RegInit(0.U(log2Ceil(num_elements).W))
+   private val read_ptr = RegInit(0.U(log2Ceil(num_elements).W))
 
    // How many uops are stored within the ram? If zero, bypass to the output flops.
-   private val count = RegInit(0.asUInt(width=log2Ceil(num_elements).W))
+   private val count = RegInit(0.U(log2Ceil(num_elements).W))
 
    //-------------------------------------------------------------
    // **** Enqueue Uops ****
@@ -93,8 +93,8 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
       else io.enq.bits.pc(msb, lsb)
    for (i <- 0 until fetchWidth)
    {
-      val selects_oh = Wire(UInt(width=fetchWidth.W))
-      selects_oh   := UIntToOH(i.asUInt(width=log2Ceil(fetchWidth).W) + first_index)
+      val selects_oh = Wire(UInt(fetchWidth.W))
+      selects_oh   := UIntToOH(i.U(log2Ceil(fetchWidth).W) + first_index)
 
       val invalid = first_index >= (fetchWidth - i).U // out-of-bounds
       compact_uops(i) := Mux1H(selects_oh, in_uops)
@@ -122,7 +122,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
 
    // If the ram is empty, bypass the first decodeWidth uops to the flops,
    // and only write the remaining uops into the ram.
-   val start_idx = Wire(UInt(width=(log2Ceil(fetchWidth)+1).W))
+   val start_idx = Wire(UInt((log2Ceil(fetchWidth)+1).W))
    start_idx := Mux(count === 0.U && io.deq.ready, decodeWidth.U, 0.U)
    for (i <- 0 until fetchWidth)
    {

--- a/src/main/scala/ifu/fetchmonitor.scala
+++ b/src/main/scala/ifu/fetchmonitor.scala
@@ -38,12 +38,12 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
    // Was the previous uop valid?
    var prev_valid  = WireInit(false.B)
    // What was the previous uop's PC?
-   var prev_pc = WireInit(0.asUInt(width=vaddrBitsExtended.W))
+   var prev_pc = WireInit(0.U(vaddrBitsExtended.W))
    var prev_cfitype = WireInit(CfiType.none)
    // What is the straight-line next PC for the previous uop?
-   var prev_npc = WireInit(0.asUInt(width=vaddrBitsExtended.W))
+   var prev_npc = WireInit(0.U(vaddrBitsExtended.W))
    // What is the target of the previous PC if a CFI.
-   var prev_target = WireInit(0.asUInt(width=vaddrBitsExtended.W))
+   var prev_target = WireInit(0.U(vaddrBitsExtended.W))
 
    for ((uop,i) <- io.uops.zipWithIndex)
    {
@@ -95,12 +95,12 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
    // Was the last uop from the previous decode group valid?
    var last_valid  = RegInit(false.B)
    // What was the previous decode group's last uop's PC?
-   var last_pc = RegInit(0.asUInt(width=vaddrBitsExtended.W))
+   var last_pc = RegInit(0.U(vaddrBitsExtended.W))
    var last_cfitype = RegInit(CfiType.none)
    // What is the straight-line next PC for the previous uop?
-   var last_npc = RegInit(0.asUInt(width=vaddrBitsExtended.W))
+   var last_npc = RegInit(0.U(vaddrBitsExtended.W))
    // What is the target of the previous PC if a CFI.
-   var last_target = RegInit(0.asUInt(width=vaddrBitsExtended.W))
+   var last_target = RegInit(0.U(vaddrBitsExtended.W))
 
    when (io.fire)
    {

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -32,10 +32,10 @@ case class FtqParameters(
 
 class FTQBundle(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val fetch_pc = UInt(width = vaddrBitsExtended.W) // TODO compress out high-order bits
-   val history = UInt(width = GLOBAL_HISTORY_LENGTH.W)
+   val fetch_pc = UInt(vaddrBitsExtended.W) // TODO compress out high-order bits
+   val history = UInt(GLOBAL_HISTORY_LENGTH.W)
    val bim_info = new BimStorage
-   val bpd_info = UInt(width = BPD_INFO_SIZE.W)
+   val bpd_info = UInt(BPD_INFO_SIZE.W)
 }
 
 // Initially, store a random branch entry for BIM (set cfi_type==branch).
@@ -49,7 +49,7 @@ class CfiMissInfo(implicit p: Parameters) extends BoomBundle()(p)
                               // Is DontCare if a misprediction occurred.
    val mispredicted = Bool()  // Was a branch or jump mispredicted in this fetch group?
    val taken = Bool()         // If a branch, was it taken?
-   val cfi_idx = UInt(width=log2Up(fetchWidth).W) // which instruction in fetch group?
+   val cfi_idx = UInt(log2Ceil(fetchWidth).W) // which instruction in fetch group?
    val cfi_type = CfiType()   // What kind of instruction is stored here?
 }
 
@@ -57,7 +57,7 @@ class CfiMissInfo(implicit p: Parameters) extends BoomBundle()(p)
 // And for JALRs, the PC of the next instruction.
 class GetPCFromFtqIO(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val ftq_idx  = Input(UInt(log2Up(ftqSz).W))
+   val ftq_idx  = Input(UInt(log2Ceil(ftqSz).W))
    val fetch_pc = Output(UInt(vaddrBitsExtended.W))
    // the next_pc may not be valid (stalled or still being fetched)
    val next_val = Output(Bool())
@@ -68,16 +68,16 @@ class GetPCFromFtqIO(implicit p: Parameters) extends BoomBundle()(p)
 class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomModule()(p)
    with HasBoomCoreParameters
 {
-   private val idx_sz = log2Up(num_entries)
+   private val idx_sz = log2Ceil(num_entries)
 
    val io = IO(new BoomBundle()(p)
    {
       // Enqueue one entry for every fetch cycle.
       val enq = Flipped(Decoupled(new FTQBundle()))
       // Pass to FetchBuffer (newly fetched instructions).
-      val enq_idx = Output(UInt(width=idx_sz.W))
+      val enq_idx = Output(UInt(idx_sz.W))
       // ROB tells us the youngest committed ftq_idx to remove from FTQ.
-      val deq = Flipped(Valid(UInt(width=idx_sz.W)))
+      val deq = Flipped(Valid(UInt(idx_sz.W)))
 
       // Give PC info to BranchUnit.
       val get_ftq_pc = new GetPCFromFtqIO()
@@ -91,8 +91,8 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
       val take_pc = Valid(new PCReq())
       // Tell the CSRFile what the fetch-pc at the FTQ's Commit Head is.
       // Still need the low-order bits of the PC from the ROB to know the true Commit PC.
-      val com_ftq_idx = Input(UInt(width=log2Up(ftqSz).W))
-      val com_fetch_pc = Output(UInt(width=vaddrBitsExtended.W))
+      val com_ftq_idx = Input(UInt(log2Ceil(ftqSz).W))
+      val com_fetch_pc = Output(UInt(vaddrBitsExtended.W))
 
       val bim_update = Valid(new BimUpdate)
       val bpd_update = Valid(new BpdUpdate)
@@ -109,7 +109,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    val full = ptr_match && maybe_full
 
    // What is the current commit point of the processor? Dequeue entries until deq_ptr matches commit_ptr.
-   val commit_ptr = RegInit(0.asUInt(log2Up(num_entries).W))
+   val commit_ptr = RegInit(0.asUInt(log2Ceil(num_entries).W))
 
    val ram = Mem(num_entries, new FTQBundle())
    val cfi_info = Reg(Vec(num_entries, new CfiMissInfo()))

--- a/src/main/scala/ifu/icache.scala
+++ b/src/main/scala/ifu/icache.scala
@@ -5,7 +5,6 @@ package boom.ifu
 
 import chisel3._
 import chisel3.util._
-//import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem.RocketTilesKey
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -1,6 +1,6 @@
 package boom.lsu
 
-import Chisel._
+import chisel3._
 
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule}
@@ -58,6 +58,6 @@ trait CanHaveBoomPTWModule extends HasBoomHellaCacheModule {
 
 class ReleaseInfo(implicit p: Parameters) extends boom.common.BoomBundle()(p)
 {
-   val address = UInt(width = corePAddrBits)
+   val address = UInt(corePAddrBits.W)
 }
 

--- a/src/main/scala/system/BoomSubsystem.scala
+++ b/src/main/scala/system/BoomSubsystem.scala
@@ -2,7 +2,7 @@
 
 package boom.system
 
-import Chisel._
+import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.devices.tilelink._
@@ -59,7 +59,7 @@ class BoomSubsystemModule[+L <: BoomSubsystem](_outer: L) extends BaseSubsystemM
   tile_inputs.zip(outer.hartIdList).foreach { case(wire, i) =>
     wire.clock := clock
     wire.reset := reset
-    wire.hartid := UInt(i)
+    wire.hartid := i.U
     wire.reset_vector := global_reset_vector
   }
 }

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -5,7 +5,7 @@
 
 package boom.system
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.devices.debug._
 import freechips.rocketchip.devices.tilelink._

--- a/src/main/scala/system/ExampleBoomSystem.scala
+++ b/src/main/scala/system/ExampleBoomSystem.scala
@@ -2,7 +2,7 @@
 
 package boom.system
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -4,7 +4,7 @@ package boom.system
 
 //TODO: Figure out how to switch to Chisel3
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.devices.debug.Debug
@@ -12,18 +12,19 @@ import freechips.rocketchip.devices.debug.Debug
 
 class TestHarness()(implicit p: Parameters) extends Module {
   val io = IO(new Bundle {
-    val success = Bool(OUTPUT)
+    val success = Output(Bool())
   })
   println("\n\nBuilding TestHarness for an ExampleBoomSystem.\n")
 
   val dut = Module(LazyModule(new ExampleBoomSystem).module)
-  dut.reset := reset | dut.debug.ndreset
+  dut.reset := reset.toBool | dut.debug.ndreset
 
   dut.dontTouchPorts()
   dut.tieOffInterrupts()
   dut.connectSimAXIMem()
   dut.connectSimAXIMMIO()
+  dut.l2_frontend_bus_axi4.foreach( q => q := DontCare ) // Overridden in next line
   dut.l2_frontend_bus_axi4.foreach(_.tieoff)
 
-  Debug.connectDebug(dut.debug, clock, reset, io.success)
+  Debug.connectDebug(dut.debug, clock, reset.toBool, io.success)
 }

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -2,6 +2,8 @@
 
 package boom.system
 
+//TODO: Figure out how to switch to Chisel3
+
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.LazyModule
@@ -9,9 +11,9 @@ import freechips.rocketchip.devices.debug.Debug
 
 
 class TestHarness()(implicit p: Parameters) extends Module {
-  val io = new Bundle {
+  val io = IO(new Bundle {
     val success = Bool(OUTPUT)
-  }
+  })
   println("\n\nBuilding TestHarness for an ExampleBoomSystem.\n")
 
   val dut = Module(LazyModule(new ExampleBoomSystem).module)
@@ -22,5 +24,6 @@ class TestHarness()(implicit p: Parameters) extends Module {
   dut.connectSimAXIMem()
   dut.connectSimAXIMMIO()
   dut.l2_frontend_bus_axi4.foreach(_.tieoff)
+
   Debug.connectDebug(dut.debug, clock, reset, io.success)
 }

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -2,8 +2,6 @@
 
 package boom.system
 
-//TODO: Figure out how to switch to Chisel3
-
 import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.LazyModule

--- a/src/main/scala/util/elastic-reg.scala
+++ b/src/main/scala/util/elastic-reg.scala
@@ -1,7 +1,7 @@
 package boom.util
 
-import Chisel._
-
+import chisel3._
+import chisel3.util._
 
 /** Implements the same interface as chisel3.util.Queue.
   * Effectively a two-entry Queue.
@@ -10,7 +10,7 @@ class ElasticReg[T <: Data](gen: T) extends Module {
    val entries = 2
    val io = IO(new QueueIO(gen, entries) {})
 
-   private val valid = RegInit(Vec.fill(entries) { false.B })
+   private val valid = RegInit(VecInit(Seq.fill(entries) { false.B }))
    private val elts = Reg(Vec(entries, gen))
 
    for (i <- 0 until entries) {
@@ -19,13 +19,13 @@ class ElasticReg[T <: Data](gen: T) extends Module {
       val wdata = if (i == entries-1) io.enq.bits else Mux(valid(i+1), elts(i+1), io.enq.bits)
       val wen =
          Mux(io.deq.ready,
-            paddedValid(i+1) || io.enq.fire() && (Bool(i == 0) || valid(i)),
+            paddedValid(i+1) || io.enq.fire() && ((i == 0).B || valid(i)),
             io.enq.fire() && paddedValid(i-1) && !valid(i))
       when (wen) { elts(i) := wdata }
 
       valid(i) :=
          Mux(io.deq.ready,
-            paddedValid(i+1) || io.enq.fire() && (Bool(i == 0) || valid(i)),
+            paddedValid(i+1) || io.enq.fire() && ((i == 0).B || valid(i)),
             io.enq.fire() && paddedValid(i-1) || valid(i))
    }
 

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -9,13 +9,13 @@
 
 package boom.util
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 import freechips.rocketchip.rocket.Instructions._
 import freechips.rocketchip.rocket._
 import boom.common.MicroOp
 import boom.exu.{BrResolutionInfo}
-
 
 // XOR fold an input that is full_length sized down to a compressed_length.
 object Fold
@@ -30,14 +30,14 @@ object Fold
       }
       else
       {
-         var res = UInt(0,clen)
+         var res = 0.U(clen.W)
          var remaining = input.asUInt
          for (i <- 0 to hlen-1 by clen)
          {
             val len = if (i + clen > hlen ) (hlen - i) else clen
             require(len > 0)
             res = res(clen-1,0) ^ remaining(len-1,0)
-            remaining = remaining >> UInt(len)
+            remaining = remaining >> len.U
          }
          res
       }
@@ -66,7 +66,7 @@ object GetNewUopAndBrMask
    def apply(uop: MicroOp, brinfo: BrResolutionInfo)
       (implicit p: freechips.rocketchip.config.Parameters): MicroOp =
    {
-      val newuop = Wire(init = uop)
+      val newuop = WireInit(uop)
       newuop.br_mask :=
          Mux(brinfo.valid,
             (uop.br_mask & ~brinfo.mask),
@@ -92,13 +92,13 @@ object GetNewBrMask
 //do two masks have at least 1 bit match?
 object maskMatch
 {
-   def apply(msk1: UInt, msk2: UInt): Bool = (msk1 & msk2) =/= UInt(0)
+   def apply(msk1: UInt, msk2: UInt): Bool = (msk1 & msk2) =/= 0.U
 }
 
 //clear one-bit in the Mask as specified by the idx
 object clearMaskBit
 {
-   def apply(msk: UInt, idx: UInt): UInt = (msk & ~(UInt(1) << idx))(msk.getWidth-1, 0)
+   def apply(msk: UInt, idx: UInt): UInt = (msk & ~(1.U << idx))(msk.getWidth-1, 0)
 }
 
 //shift a register over by one bit
@@ -120,7 +120,7 @@ object PerformCircularShiftRegister
    def apply(csr: UInt, new_bit: Bool, evict_bit: Bool, hlen: Int, clen: Int): UInt =
    {
       val carry = csr(clen-1)
-      val newval = Cat(csr, new_bit ^ carry) ^ (evict_bit << UInt(hlen % clen))
+      val newval = Cat(csr, new_bit ^ carry) ^ (evict_bit << (hlen % clen).U)
       newval
    }
 }
@@ -133,13 +133,13 @@ object WrapAdd
    {
       if (isPow2(n))
       {
-         (value + amt)(log2Up(n)-1,0)
+         (value + amt)(log2Ceil(n)-1,0)
       }
       else
       {
-         val sum = Cat(UInt(0,1), value) + Cat(UInt(0,1), amt)
-         Mux(sum >= UInt(n),
-            sum - UInt(n),
+         val sum = Cat(0.U(1.W), value) + Cat(0.U(1.W), amt)
+         Mux(sum >= n.U,
+            sum - n.U,
             sum)
       }
    }
@@ -153,15 +153,15 @@ object WrapSub
    {
       if (isPow2(n))
       {
-         (value - UInt(amt))(log2Up(n)-1,0)
+         (value - amt.U)(log2Ceil(n)-1,0)
       }
       else
       {
-         val v = Cat(UInt(0,1), value)
-         val b = Cat(UInt(0,1), UInt(amt))
-         Mux(value >= UInt(amt),
-            value - UInt(amt),
-            UInt(n) - (UInt(amt) - value))
+         val v = Cat(0.U(1.W), value)
+         val b = Cat(0.U(1.W), amt.U)
+         Mux(value >= amt.U,
+            value - amt.U,
+            n.U - amt.U - value)
       }
    }
 }
@@ -174,12 +174,12 @@ object WrapInc
    {
       if (isPow2(n))
       {
-         (value + UInt(1))(log2Up(n)-1,0)
+         (value + 1.U)(log2Ceil(n)-1,0)
       }
       else
       {
-         val wrap = (value === UInt(n-1))
-         Mux(wrap, UInt(0), value + UInt(1))
+         val wrap = (value === (n-1).U)
+         Mux(wrap, 0.U, value + 1.U)
       }
    }
 }
@@ -191,12 +191,12 @@ object WrapDec
    {
       if (isPow2(n))
       {
-         (value - UInt(1))(log2Up(n)-1,0)
+         (value - 1.U)(log2Ceil(n)-1,0)
       }
       else
       {
-         val wrap = (value === UInt(0))
-         Mux(wrap, UInt(n-1), value - UInt(1))
+         val wrap = (value === 0.U)
+         Mux(wrap, (n-1).U, value - 1.U)
       }
    }
 }
@@ -245,11 +245,11 @@ object ImmGen
       val sign = ip(LONGEST_IMM_SZ-1).asSInt
       val i30_20 = Mux(isel === IS_U, ip(18,8).asSInt, sign)
       val i19_12 = Mux(isel === IS_U || isel === IS_J, ip(7,0).asSInt, sign)
-      val i11    = Mux(isel === IS_U, SInt(0),
+      val i11    = Mux(isel === IS_U, 0.S,
                    Mux(isel === IS_J || isel === IS_B, ip(8).asSInt, sign))
-      val i10_5  = Mux(isel === IS_U, SInt(0), ip(18,14).asSInt)
-      val i4_1   = Mux(isel === IS_U, SInt(0), ip(13,9).asSInt)
-      val i0     = Mux(isel === IS_S || isel === IS_I, ip(8).asSInt, SInt(0))
+      val i10_5  = Mux(isel === IS_U, 0.S, ip(18,14).asSInt)
+      val i4_1   = Mux(isel === IS_U, 0.S, ip(13,9).asSInt)
+      val i0     = Mux(isel === IS_S || isel === IS_I, ip(8).asSInt, 0.S)
 
       return Cat(sign, i30_20, i19_12, i11, i10_5, i4_1, i0).asSInt
    }
@@ -267,7 +267,7 @@ object DebugIsJALR
 //      val is_jalr = rocket.DecodeLogic(inst, List(Bool(false)),
 //                                       Array(
 //                                       JALR -> Bool(true)))
-      inst(6,0) === UInt("b1100111")
+      inst(6,0) === "b1100111".U
    }
 }
 
@@ -292,10 +292,10 @@ object DebugGetBJImm
       //      ))
       //val is_br :: nothing :: Nil = csignals
 
-   val is_br = (inst(6,0) === UInt("b1100011"))
+   val is_br = (inst(6,0) === "b1100011".U)
 
-   val br_targ = Cat(Fill(12, inst(31)), Fill(8,inst(31)), inst(7), inst(30,25), inst(11,8), UInt(0,1))
-   val jal_targ= Cat(Fill(12, inst(31)), inst(19,12), inst(20), inst(30,25), inst(24,21), UInt(0,1))
+   val br_targ = Cat(Fill(12, inst(31)), Fill(8,inst(31)), inst(7), inst(30,25), inst(11,8), 0.U(1.W))
+   val jal_targ= Cat(Fill(12, inst(31)), inst(19,12), inst(20), inst(30,25), inst(24,21), 0.U(1.W))
 
    Mux(is_br, br_targ, jal_targ)
   }
@@ -307,9 +307,9 @@ object AgePriorityEncoder
    {
       val n = in.size
       require (isPow2(n))
-      val temp_vec = (0 until n).map(i => in(i) && UInt(i) >= head) ++ in
+      val temp_vec = (0 until n).map(i => in(i) && i.U >= head) ++ in
       val idx = PriorityEncoder(temp_vec)
-      idx(log2Up(n)-1, 0) //discard msb
+      idx(log2Ceil(n)-1, 0) //discard msb
    }
 }
 
@@ -322,31 +322,31 @@ class BranchKillableQueue[T <: boom.common.HasBoomUOP](gen: T, entries: Int)
 {
    val io = IO(new Bundle
    {
-      val enq     = Decoupled(gen).flip
+      val enq     = Flipped(Decoupled(gen))
       val deq     = Decoupled(gen)
 
-      val brinfo  = new BrResolutionInfo().asInput
-      val flush   = Bool(INPUT)
+      val brinfo  = Input(new BrResolutionInfo())
+      val flush   = Input(Bool())
 
-      val empty   = Bool(OUTPUT)
-      val count   = UInt(OUTPUT, log2Up(entries))
+      val empty   = Output(Bool())
+      val count   = Output(UInt(log2Ceil(entries).W))
    })
 
    private val ram     = Mem(entries, gen)
-   private val valids  = Reg(init = Vec.fill(entries) {Bool(false)})
-   private val brmasks = Reg(Vec(entries, UInt(width = MAX_BR_COUNT)))
+   private val valids  = RegInit(VecInit(Seq.fill(entries) {false.B}))
+   private val brmasks = Reg(Vec(entries, UInt(MAX_BR_COUNT.W)))
 
    private val enq_ptr = Counter(entries)
    private val deq_ptr = Counter(entries)
-   private val maybe_full = Reg(init=false.B)
+   private val maybe_full = RegInit(false.B)
 
    private val ptr_match = enq_ptr.value === deq_ptr.value
    io.empty := ptr_match && !maybe_full
    private val full = ptr_match && maybe_full
-   private val do_enq = Wire(init=io.enq.fire())
+   private val do_enq = WireInit(io.enq.fire())
 
-   private val deq_ram_valid = Wire(init= !(io.empty))
-   private val do_deq = Wire(init=io.deq.ready && deq_ram_valid)
+   private val deq_ram_valid = WireInit(!(io.empty))
+   private val do_deq = WireInit(io.deq.ready && deq_ram_valid)
 
    for (i <- 0 until entries)
    {


### PR DESCRIPTION
This is porting the BOOM codebase to use proper Chisel3 syntax.

Tested with run-asm-tests, run-bmark-tests on SmallBoomConfig and BoomConfig.

Note: RocketChip although using the "import Chisel._" Chisel2 import, is actually using Chisel3 compatibility mode. 