### PR TITLE
fix Generator.scala to emit correct set of tests to be run by BOOM without an FPU

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -57,7 +57,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
 
 class WithoutBoomFPU extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r => r.copy(core = r.core.copy(
-      usingFPU = false))
+      fpu = None))
    }
 })
 

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -126,7 +126,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    //************************************
    // Functional Units
    val usingFDivSqrt = boomParams.fpu.isDefined && boomParams.fpu.get.divSqrt
-   override val usingFPU      = boomParams.usingFPU
 
    val mulDivParams = boomParams.mulDiv.getOrElse(MulDivParams())
 

--- a/src/main/scala/exu/fppipeline.scala
+++ b/src/main/scala/exu/fppipeline.scala
@@ -51,6 +51,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
       val wb_pdsts         = Input(Vec(num_wakeup_ports, UInt(width=fp_preg_sz.W)))
 
       val debug_tsc_reg    = Input(UInt(width=xLen.W))
+      val debug_wb_wdata   = Output(Vec(num_wakeup_ports, UInt((fLen+1).W)))
    }
 
    //**********************************
@@ -299,6 +300,9 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
       }
    }
 
+   for ((wdata, wakeup) <- io.debug_wb_wdata zip io.wakeups) {
+      wdata := ieee(wakeup.bits.data)
+   }
 
    exe_units.map(_.io.fcsr_rm := io.fcsr_rm)
 

--- a/src/main/scala/exu/functional_unit.scala
+++ b/src/main/scala/exu/functional_unit.scala
@@ -585,7 +585,6 @@ class MemAddrCalcUnit(implicit p: Parameters)
       is_branch_unit = false)(p)
    with freechips.rocketchip.rocket.constants.MemoryOpConstants
    with freechips.rocketchip.rocket.constants.ScalarOpConstants
-   with freechips.rocketchip.tile.HasFPUParameters
 {
    // perform address calculation
    val sum = (io.req.bits.rs1_data.asSInt + io.req.bits.uop.imm_packed(19,8).asSInt).asUInt

--- a/src/main/scala/exu/rename.scala
+++ b/src/main/scala/exu/rename.scala
@@ -204,6 +204,7 @@ class RenameStage(
    {
       val imap = imaptable.io.values(w)
       val fmap = if (usingFPU) fmaptable.io.values(w) else Wire(new MapTableOutput(1))
+      if (!usingFPU) fmap := DontCare
 
       uop.pop1       := Mux(uop.lrs1_rtype === RT_FLT, fmap.prs1, imap.prs1)
       uop.pop2       := Mux(uop.lrs2_rtype === RT_FLT, fmap.prs2, imap.prs2)
@@ -303,6 +304,7 @@ class RenameStage(
    {
       val ibusy = ibusytable.io.values(w)
       val fbusy = if (usingFPU) fbusytable.io.values(w) else Wire(new BusyTableOutput)
+      if (!usingFPU) fbusy := DontCare
 
       uop.prs1_busy := Mux(uop.lrs1_rtype === RT_FLT, fbusy.prs1_busy, ibusy.prs1_busy)
       uop.prs2_busy := Mux(uop.lrs2_rtype === RT_FLT, fbusy.prs2_busy, ibusy.prs2_busy)

--- a/src/main/scala/system/Generator.scala
+++ b/src/main/scala/system/Generator.scala
@@ -69,12 +69,10 @@ object Generator extends GeneratorApp {
         if (cfg.fLen >= 64) {
           TestGeneration.addSuites(env.map(rv32ud))
         }
-      } else {
-        TestGeneration.addSuite(rv32udBenchmarks)
-        TestGeneration.addSuites(env.map(rv64uf))
-        if (cfg.fLen >= 64) {
+      } else if (cfg.fLen >= 64) {
           TestGeneration.addSuites(env.map(rv64ud))
-        }
+          TestGeneration.addSuites(env.map(rv64uf))
+          TestGeneration.addSuite(rv32udBenchmarks)
       }
     }
     if (coreParams.useAtomics) {


### PR DESCRIPTION
disabling fpu should show the correct set of supported extensions in dts