### PR TITLE
remove cloneType in favour of autoclonetype 

### DIFF
--- a/src/main/scala/bpu/2bc-table.scala
+++ b/src/main/scala/bpu/2bc-table.scala
@@ -46,7 +46,7 @@ import chisel3.util._
 import boom.util.SeqMem1rwTransformable
 
 
-class UpdateEntry(fetch_width: Int, index_sz: Int) extends Bundle
+class UpdateEntry(val fetch_width: Int, val index_sz: Int) extends Bundle
 {
    val index            = UInt(index_sz.W)
    val executed         = Vec(fetch_width, Bool())
@@ -57,17 +57,15 @@ class UpdateEntry(fetch_width: Int, index_sz: Int) extends Bundle
    // If takens(i), then we initialize entry to Weak-Taken. Otherwise, Weak-NotTaken.
    val do_initialize    = Bool()
 
-   override def cloneType: this.type = new UpdateEntry(fetch_width, index_sz).asInstanceOf[this.type]
 }
 
 
-class BrTableUpdate(fetch_width: Int, index_sz: Int) extends Bundle
+class BrTableUpdate(val fetch_width: Int, val index_sz: Int) extends Bundle
 {
    val index      = UInt(index_sz.W)
    val executed   = UInt(fetch_width.W) // which words in the fetch packet does the update correspond to?
    val new_value  = UInt(fetch_width.W)
 
-   override def cloneType: this.type = new BrTableUpdate(fetch_width, index_sz).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/bpu/base-only.scala
+++ b/src/main/scala/bpu/base-only.scala
@@ -74,6 +74,5 @@ class BaseOnlyBrPredictor(
 
    override def toString: String = "  Building no predictor (just using BIM as a base predictor)."
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/bpu/bim.scala
+++ b/src/main/scala/bpu/bim.scala
@@ -381,6 +381,5 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
       "\n   (" + size_kbits + " Kbits = " + size_kbits/8 + " kB) Bimodal Table (" +
       nSets + " entries across " + nBanks + " banks)"
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/bpu/brpredictor.scala
+++ b/src/main/scala/bpu/brpredictor.scala
@@ -266,7 +266,6 @@ abstract class BrPredictor(
 
    //************************************************
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 
 

--- a/src/main/scala/bpu/btb.scala
+++ b/src/main/scala/bpu/btb.scala
@@ -183,7 +183,6 @@ abstract class BoomBTB(implicit p: Parameters) extends BoomModule()(p) with HasB
       val status_debug = Input(Bool())
    })
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 
 object BoomBTB

--- a/src/main/scala/bpu/dense-btb.scala
+++ b/src/main/scala/bpu/dense-btb.scala
@@ -410,5 +410,4 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
       "\n   Offset Size   : " + offset_sz + "\n" +
       bim.toString
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }

--- a/src/main/scala/bpu/gshare.scala
+++ b/src/main/scala/bpu/gshare.scala
@@ -44,7 +44,7 @@ trait HasGShareParameters extends HasBoomCoreParameters
 }
 
 
-class GShareResp(fetch_width: Int, idx_sz: Int) extends Bundle
+class GShareResp(val fetch_width: Int, val idx_sz: Int) extends Bundle
 {
    val debug_index = UInt(idx_sz.W) // Can recompute index during update (but let's check for errors).
    val rowdata = UInt((fetch_width*2).W) // Store to prevent a re-read during an update.
@@ -62,7 +62,6 @@ class GShareResp(fetch_width: Int, idx_sz: Int) extends Bundle
       cntr
    }
 
-   override def cloneType: this.type = new GShareResp(fetch_width, idx_sz).asInstanceOf[this.type]
 }
 
 object GShareBrPredictor

--- a/src/main/scala/bpu/tage-table.scala
+++ b/src/main/scala/bpu/tage-table.scala
@@ -269,6 +269,5 @@ class TageTable(
       tag_sz + "-bit tags, " +
       cntr_sz + "-bit counters"
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/bpu/tage-table.scala
+++ b/src/main/scala/bpu/tage-table.scala
@@ -19,11 +19,11 @@ import freechips.rocketchip.util.Str
 import boom.common._
 
 class TageTableIo(
-   fetch_width: Int,
-   index_sz: Int,
-   tag_sz: Int,
-   cntr_sz: Int,
-   ubit_sz: Int)
+   val fetch_width: Int,
+   val index_sz: Int,
+   val tag_sz: Int,
+   val cntr_sz: Int,
+   val ubit_sz: Int)
    extends Bundle
 {
    // bp1 - request a prediction (provide the index and tag).
@@ -63,19 +63,16 @@ class TageTableIo(
 
    val do_reset = Input(Bool())
 
-   override def cloneType: this.type = new TageTableIo(
-      fetch_width, index_sz, tag_sz, cntr_sz, ubit_sz).asInstanceOf[this.type]
 }
 
-class TageTableReq(index_sz: Int, tag_sz: Int) extends Bundle
+class TageTableReq(val index_sz: Int, val tag_sz: Int) extends Bundle
 {
    val index = UInt(index_sz.W)
    val tag = UInt(tag_sz.W)
 
-   override def cloneType: this.type = new TageTableReq(index_sz, tag_sz).asInstanceOf[this.type]
 }
 
-class TageTableResp(fetch_width: Int, tag_sz: Int, cntr_sz: Int, ubit_sz: Int) extends Bundle
+class TageTableResp(val fetch_width: Int, val tag_sz: Int, val cntr_sz: Int, val ubit_sz: Int) extends Bundle
 {
    val tag  = UInt(tag_sz.W)
    val cntr = UInt(cntr_sz.W)
@@ -84,20 +81,18 @@ class TageTableResp(fetch_width: Int, tag_sz: Int, cntr_sz: Int, ubit_sz: Int) e
 
    def predictsTaken = cntr(cntr_sz-1)
 
-   override def cloneType: this.type = new TageTableResp(fetch_width, tag_sz, cntr_sz, ubit_sz).asInstanceOf[this.type]
 }
 
-class TageTableEntry(fetch_width: Int, tag_sz: Int, cntr_sz: Int, ubit_sz: Int) extends Bundle
+class TageTableEntry(val fetch_width: Int, val tag_sz: Int, val cntr_sz: Int, val ubit_sz: Int) extends Bundle
 {
    val tag  = UInt(tag_sz.W)                 // Tag.
    val cntr = UInt(cntr_sz.W)                // Prediction counter.
    val cidx = UInt(log2Ceil(fetch_width).W)  // Control-flow instruction index.
    val ubit = UInt(ubit_sz.W)                // Usefulness counter.
 
-   override def cloneType: this.type = new TageTableEntry(fetch_width, tag_sz, cntr_sz, ubit_sz).asInstanceOf[this.type]
 }
 
-class TageTableWrite(fetch_width: Int, index_sz: Int, tag_sz: Int, cntr_sz: Int, ubit_sz: Int) extends Bundle
+class TageTableWrite(val fetch_width: Int, val index_sz: Int, val tag_sz: Int, val cntr_sz: Int, val ubit_sz: Int) extends Bundle
 {
    val index = UInt(index_sz.W)
    val old = new TageTableEntry(fetch_width, tag_sz, cntr_sz, ubit_sz)
@@ -110,8 +105,6 @@ class TageTableWrite(fetch_width: Int, index_sz: Int, tag_sz: Int, cntr_sz: Int,
    val mispredict = Bool()
    val taken = Bool()
 
-   override def cloneType: this.type = new TageTableWrite(fetch_width, index_sz, tag_sz, cntr_sz,
-                                                          ubit_sz).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/bpu/tage.scala
+++ b/src/main/scala/bpu/tage.scala
@@ -500,6 +500,5 @@ class TageBrPredictor(
       (size_in_bits/1024) + " Kbits) (max history length: " + history_lengths.max + " bits)\n" +
       tables.mkString("\n")
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/bpu/tage.scala
+++ b/src/main/scala/bpu/tage.scala
@@ -45,13 +45,13 @@ case class TageParameters(
    ubit_sz: Int = 1)
 
 class TageResp(
-   fetch_width: Int,
-   num_tables: Int,
-   max_history_length: Int,
-   max_index_sz: Int,
-   max_tag_sz: Int,
-   cntr_sz: Int,
-   ubit_sz: Int
+   val fetch_width: Int,
+   val num_tables: Int,
+   val max_history_length: Int,
+   val max_index_sz: Int,
+   val max_tag_sz: Int,
+   val cntr_sz: Int,
+   val ubit_sz: Int
    )
    extends Bundle
 {
@@ -75,15 +75,6 @@ class TageResp(
    val debug_indexes  = Vec(num_tables, UInt(max_index_sz.W))
    val debug_tags     = Vec(num_tables, UInt(max_tag_sz.W))
 
-   override def cloneType: this.type =
-      new TageResp(
-         fetch_width,
-         num_tables,
-         max_history_length,
-         max_index_sz,
-         max_tag_sz,
-         cntr_sz,
-         ubit_sz).asInstanceOf[this.type]
 }
 
 // provide information to the BpdResp bundle how many bits a TageResp needs

--- a/src/main/scala/common/microop.scala
+++ b/src/main/scala/common/microop.scala
@@ -168,9 +168,8 @@ object CfiType
    def jalr = 3.U
 }
 
-class MicroOpWithData(data_sz: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class MicroOpWithData(val data_sz: Int)(implicit p: Parameters) extends BoomBundle()(p)
   with HasBoomUOP
 {
    val data = UInt(data_sz.W)
-   override def cloneType = new MicroOpWithData(data_sz)(p).asInstanceOf[this.type]
 }

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1557,6 +1557,5 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    }
 
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -352,7 +352,6 @@ class DecodeUnitIo(implicit p: Parameters) extends BoomBundle()(p)
    val interrupt = Input(Bool())
    val interrupt_cause = Input(UInt(xLen.W))
 
-   override def cloneType: this.type = new DecodeUnitIo()(p).asInstanceOf[this.type]
 }
 
 // Takes in a single instruction, generates a MicroOp.

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -466,7 +466,6 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
 
    //-------------------------------------------------------------
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 
 
@@ -601,6 +600,5 @@ class BranchMaskGenerationLogic(val pl_width: Int)(implicit p: Parameters) exten
 
    io.debug.branch_mask := branch_mask
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/exu/execute.scala
+++ b/src/main/scala/exu/execute.scala
@@ -29,14 +29,13 @@ import boom.ifu.GetPCFromFtqIO
 import boom.util.{ImmGen, IsKilledByBranch, BranchKillableQueue}
 
 // TODO rename to something like MicroOpWithData
-class ExeUnitResp(data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class ExeUnitResp(val data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
   with HasBoomUOP
 {
    val data = Bits(data_width.W)
    val fflags = new ValidIO(new FFlagsResp) // write fflags to ROB
 
    var writesToIRF = true // does this response unit plug into the integer regfile?
-   override def cloneType: this.type = new ExeUnitResp(data_width).asInstanceOf[this.type]
 }
 
 class FFlagsResp(implicit p: Parameters) extends BoomBundle()(p)

--- a/src/main/scala/exu/fppipeline.scala
+++ b/src/main/scala/exu/fppipeline.scala
@@ -322,5 +322,4 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
       "\n   Num Wakeup Ports      : " + num_wakeup_ports +
       "\n   Num Bypass Ports      : " + exe_units.num_total_bypass_ports + "\n"
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }

--- a/src/main/scala/exu/functional_unit.scala
+++ b/src/main/scala/exu/functional_unit.scala
@@ -93,7 +93,7 @@ class GetPredictionInfo(implicit p: Parameters) extends BoomBundle()(p)
    val info = Input(new BranchPredInfo())
 }
 
-class FuncUnitReq(data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class FuncUnitReq(val data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
   with HasBoomUOP
 {
    val num_operands = 3
@@ -104,10 +104,9 @@ class FuncUnitReq(data_width: Int)(implicit p: Parameters) extends BoomBundle()(
 
    val kill = Bool() // kill everything
 
-   override def cloneType = new FuncUnitReq(data_width)(p).asInstanceOf[this.type]
 }
 
-class FuncUnitResp(data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class FuncUnitResp(val data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
   with HasBoomUOP
 {
    val data = UInt(data_width.W)
@@ -116,17 +115,15 @@ class FuncUnitResp(data_width: Int)(implicit p: Parameters) extends BoomBundle()
    val mxcpt = new ValidIO(UInt((freechips.rocketchip.rocket.Causes.all.max+2).W)) //only for maddr->LSU
    val sfence = Valid(new freechips.rocketchip.rocket.SFenceReq) // only for mcalc
 
-   override def cloneType = new FuncUnitResp(data_width)(p).asInstanceOf[this.type]
 }
 
-class BypassData(num_bypass_ports: Int, data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class BypassData(val num_bypass_ports: Int, val data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val valid = Vec(num_bypass_ports, Bool())
    val uop   = Vec(num_bypass_ports, new MicroOp())
    val data  = Vec(num_bypass_ports, UInt(data_width.W))
 
    def getNumPorts: Int = num_bypass_ports
-   override def cloneType: this.type = new BypassData(num_bypass_ports, data_width).asInstanceOf[this.type]
 }
 
 class BrResolutionInfo(implicit p: Parameters) extends BoomBundle()(p)

--- a/src/main/scala/exu/issue.scala
+++ b/src/main/scala/exu/issue.scala
@@ -175,7 +175,6 @@ abstract class IssueUnit(
       else if (iqType == IQT_FP.litValue) " fp"
       else "unknown"
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 
 class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters)

--- a/src/main/scala/exu/issue_slot.scala
+++ b/src/main/scala/exu/issue_slot.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.config.Parameters
 import boom.common._
 import boom.util._
 
-class IssueSlotIO(num_wakeup_ports: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class IssueSlotIO(val num_wakeup_ports: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val valid          = Output(Bool())
    val will_be_valid  = Output(Bool()) // TODO code review, do we need this signal so explicitely?
@@ -53,7 +53,6 @@ class IssueSlotIO(num_wakeup_ports: Int)(implicit p: Parameters) extends BoomBun
     Output(result)
   }
 
-   override def cloneType = new IssueSlotIO(num_wakeup_ports)(p).asInstanceOf[this.type]
 }
 
 class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters)

--- a/src/main/scala/exu/issue_slot.scala
+++ b/src/main/scala/exu/issue_slot.scala
@@ -318,6 +318,5 @@ class IssueSlot(num_slow_wakeup_ports: Int)(implicit p: Parameters)
    io.debug.p3 := slot_p3
    io.debug.state := slot_state
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/exu/regfile.scala
+++ b/src/main/scala/exu/regfile.scala
@@ -18,18 +18,16 @@ import freechips.rocketchip.config.Parameters
 import scala.collection.mutable.ArrayBuffer
 import boom.common._
 
-class RegisterFileReadPortIO(addr_width: Int, data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class RegisterFileReadPortIO(val addr_width: Int, val data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val addr = Input(UInt(addr_width.W))
    val data = Output(UInt(data_width.W))
-   override def cloneType = new RegisterFileReadPortIO(addr_width, data_width)(p).asInstanceOf[this.type]
 }
 
-class RegisterFileWritePort(addr_width: Int, data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class RegisterFileWritePort(val addr_width: Int, val data_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val addr = UInt(width = addr_width.W)
    val data = UInt(width = data_width.W)
-   override def cloneType = new RegisterFileWritePort(addr_width, data_width)(p).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/exu/registerread.scala
+++ b/src/main/scala/exu/registerread.scala
@@ -23,10 +23,10 @@ import boom.common._
 import boom.util._
 
 class RegisterReadIO(
-   issue_width: Int,
-   num_total_read_ports: Int,
-   num_total_bypass_ports: Int,
-   register_width: Int
+   val issue_width: Int,
+   val num_total_read_ports: Int,
+   val num_total_bypass_ports: Int,
+   val register_width: Int
 )(implicit p: Parameters) extends  BoomBundle()(p)
 {
    // issued micro-ops
@@ -44,9 +44,6 @@ class RegisterReadIO(
    val kill   = Input(Bool())
    val brinfo = Input(new BrResolutionInfo())
 
-   override def cloneType =
-      new RegisterReadIO(issue_width, num_total_read_ports, num_total_bypass_ports, register_width
-   )(p).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/exu/rename-freelist.scala
+++ b/src/main/scala/exu/rename-freelist.scala
@@ -60,11 +60,10 @@ class FreeListIo(
    val debug = Output(new DebugFreeListIO(num_phys_registers))
 }
 
-class DebugFreeListIO(num_phys_registers: Int) extends Bundle
+class DebugFreeListIO(val num_phys_registers: Int) extends Bundle
 {
    val freelist = Bits(num_phys_registers.W)
    val isprlist = Bits(num_phys_registers.W)
-   override def cloneType: this.type = new DebugFreeListIO(num_phys_registers).asInstanceOf[this.type]
 }
 
 // provide a fixed set of renamed destination registers

--- a/src/main/scala/exu/rename-maptable.scala
+++ b/src/main/scala/exu/rename-maptable.scala
@@ -19,7 +19,7 @@ import boom.common._
 import boom.util._
 
 
-class RenameMapTableElementIo(pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class RenameMapTableElementIo(val pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val element            = Output(UInt(PREG_SZ.W))
 
@@ -43,7 +43,6 @@ class RenameMapTableElementIo(pl_width: Int)(implicit p: Parameters) extends Boo
    val commit_pdst         = Input(UInt(PREG_SZ.W))
    val committed_element   = Output(UInt(PREG_SZ.W))
 
-   override def cloneType: this.type = new RenameMapTableElementIo(pl_width).asInstanceOf[this.type]
 }
 
 class RenameMapTableElement(pipeline_width: Int, always_zero: Boolean)(implicit p: Parameters) extends BoomModule()(p)
@@ -128,13 +127,12 @@ class RenameMapTableElement(pipeline_width: Int, always_zero: Boolean)(implicit 
 
 
 // Pass out the new physical register specifiers.
-class MapTableOutput(preg_sz: Int) extends Bundle
+class MapTableOutput(val preg_sz: Int) extends Bundle
 {
    val prs1              = UInt(preg_sz.W)
    val prs2              = UInt(preg_sz.W)
    val prs3              = UInt(preg_sz.W)
    val stale_pdst        = UInt(preg_sz.W)
-   override def cloneType: this.type = new MapTableOutput(preg_sz).asInstanceOf[this.type]
 }
 
 class RenameMapTable(

--- a/src/main/scala/exu/rename.scala
+++ b/src/main/scala/exu/rename.scala
@@ -354,6 +354,5 @@ class RenameStage(
    io.debug.fbusytable := (if (usingFPU) fbusytable.io.debug.busytable else 0.U)
 
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/exu/rename.scala
+++ b/src/main/scala/exu/rename.scala
@@ -73,7 +73,7 @@ class RenameStageIO(
 }
 
 
-class DebugRenameStageIO(int_num_pregs: Int, fp_num_pregs: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class DebugRenameStageIO(val int_num_pregs: Int, val fp_num_pregs: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    val ifreelist =  Bits(int_num_pregs.W)
    val iisprlist =  Bits(int_num_pregs.W)
@@ -81,7 +81,6 @@ class DebugRenameStageIO(int_num_pregs: Int, fp_num_pregs: Int)(implicit p: Para
    val ffreelist =  Bits(fp_num_pregs.W)
    val fisprlist =  Bits(fp_num_pregs.W)
    val fbusytable = UInt(fp_num_pregs.W)
-   override def cloneType: this.type = new DebugRenameStageIO(int_num_pregs, fp_num_pregs).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -246,7 +246,6 @@ class Rob(
          val busy = Bool()
          val uop = new MicroOp()
          val exception = Bool()
-         override def cloneType: this.type = new DebugRobBundle().asInstanceOf[this.type]
       }
    val debug_entry = Wire(Vec(NUM_ROB_ENTRIES, new DebugRobBundle))
    debug_entry := DontCare // override in statements below

--- a/src/main/scala/ifu/fetch.scala
+++ b/src/main/scala/ifu/fetch.scala
@@ -766,6 +766,5 @@ class FetchControlUnit(fetch_width: Int)(implicit p: Parameters) extends BoomMod
          )
    }
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/ifu/fetch.scala
+++ b/src/main/scala/ifu/fetch.scala
@@ -53,7 +53,6 @@ class FetchBundle(implicit p: Parameters) extends BoomBundle()(p)
 
    val debug_events  = Vec(fetchWidth, new DebugStageEvents)
 
-  override def cloneType: this.type = new FetchBundle().asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/ifu/fetchbuffer.scala
+++ b/src/main/scala/ifu/fetchbuffer.scala
@@ -232,6 +232,5 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
 
    assert (!(count === 0.U && write_ptr =/= read_ptr), "[fetchbuffer] pointers should match if count is zero.")
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/ifu/fetchmonitor.scala
+++ b/src/main/scala/ifu/fetchmonitor.scala
@@ -175,6 +175,5 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
 
 
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -350,6 +350,5 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    val debug_deq_ptr = deq_ptr.value
    dontTouch(debug_deq_ptr)
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -331,7 +331,6 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
     cover(cond, s"FRONTEND_$label", "Rocket;;" + desc)
 
-   override val compileOptions = chisel3.core.ExplicitCompileOptions.NotStrict.copy(explicitInvalidate = true)
 }
 
 /** Mix-ins for constructing tiles that have an ICache-based pipeline frontend */

--- a/src/main/scala/ifu/icache.scala
+++ b/src/main/scala/ifu/icache.scala
@@ -77,12 +77,11 @@ class ICache(
       minLatency = 1)})
 }
 
-class ICacheResp(outer: ICache) extends Bundle {
+class ICacheResp(val outer: ICache) extends Bundle {
   val data = UInt((outer.icacheParams.fetchBytes*8).W)
   val replay = Bool()
   val ae = Bool()
 
-  override def cloneType = new ICacheResp(outer).asInstanceOf[this.type]
 }
 
 class ICachePerfEvents extends Bundle {

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -55,7 +55,7 @@ import boom.common._
 import boom.exu.{BrResolutionInfo, Exception, FlushSignals, FuncUnitResp}
 import boom.util.{AgePriorityEncoder, IsKilledByBranch, GetNewBrMask, WrapInc}
 
-class LoadStoreUnitIO(pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
+class LoadStoreUnitIO(val pl_width: Int)(implicit p: Parameters) extends BoomBundle()(p)
 {
    // Decode Stage
    // Track which stores are "alive" in the pipeline
@@ -143,7 +143,6 @@ class LoadStoreUnitIO(pl_width: Int)(implicit p: Parameters) extends BoomBundle(
 
    val debug_tsc = Input(UInt(xLen.W))     // time stamp counter
 
-   override def cloneType: this.type = new LoadStoreUnitIO(pl_width)(p).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/util/elastic-sram.scala
+++ b/src/main/scala/util/elastic-sram.scala
@@ -10,12 +10,11 @@ package boom.util
 import chisel3._
 import chisel3.util._
 
-class ESramWritePort[T <: Data](idx_sz: Int, gen: T) extends Bundle
+class ESramWritePort[T <: Data](val idx_sz: Int, val gen: T) extends Bundle
 {
    val idx = UInt(idx_sz.W)
    val data = gen
 
-   override def cloneType = new ESramWritePort(idx_sz, gen).asInstanceOf[this.type]
 }
 
 /** Implements a decoupled SRAM which can be back-pressured on the read response side,


### PR DESCRIPTION
* remove cloneType in favour of autoclonetype 
* explicitly disabling strict chisel3 checking seems to be no longer required 