### PR TITLE
Cache both riscv-tools and verilator for faster CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,9 @@ version: 2
 
 # set of jobs to run
 jobs:
-    prepare-riscv-tools:
+    install-riscv-tools:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
@@ -17,24 +17,13 @@ jobs:
             - checkout
 
             - run:
-                name: Source environment variables
+                name: Create hash of RISC-V Tools based on RocketChip
                 command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
+                    ci/create-hash.sh rocket-chip
 
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version
-                    g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
+            - restore_cache:
+                keys:
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - run: 
                 name: Building RISC-V Tools
@@ -43,13 +32,44 @@ jobs:
                 no_output_timeout: 120m
 
             - save_cache:
-                key: riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                key: riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
                 paths:
                     - "/home/circleci/riscv-tools-install"
 
+    prepare-build-environment:
+        docker:
+            - image: riscvboom/riscvboom-images:0.0.4
+        environment:
+            JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
+            TERM: dumb
+            
+        steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of BoomTemplate
+                command: |
+                    ci/create-hash.sh
+
+            - restore_cache:
+                keys:
+                    - boom-template-with-verilator-v1-{{ checksum "../boom-template.hash" }}
+
+            - run: 
+                name: Building Verilator
+                command: |
+                    ci/prepare-for-build.sh
+                no_output_timeout: 120m
+
+            - save_cache:
+                key: boom-template-with-verilator-v1-{{ checksum "../boom-template.hash" }}
+                paths:
+                    - "/home/circleci/boom-template"
+
     prepare-boomconfig:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
@@ -58,29 +78,19 @@ jobs:
             # Checkout the code 
             - checkout
 
+            - run:
+                name: Create hash of RISC-V Tools and BoomTemplate
+                command: |
+                    ci/create-hash.sh rocket-chip
+                    ci/create-hash.sh
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version
-                    g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
+            - restore_cache:
+                keys:
+                    - boom-template-with-verilator-v1-{{ checksum "../boom-template.hash" }}
 
             - run: 
                 name: Building BoomConfig using Verilator
@@ -94,7 +104,7 @@ jobs:
                       
     prepare-smallboomconfig:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
@@ -103,29 +113,19 @@ jobs:
             # Checkout the code 
             - checkout
 
+            - run:
+                name: Create hash of RISC-V Tools and BoomTemplate
+                command: |
+                    ci/create-hash.sh rocket-chip
+                    ci/create-hash.sh
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version
-                    g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
+            - restore_cache:
+                keys:
+                    - boom-template-with-verilator-v1-{{ checksum "../boom-template.hash" }}
 
             - run: 
                 name: Building SmallBoomConfig using Verilator
@@ -139,7 +139,7 @@ jobs:
                       
     prepare-mediumboomconfig:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
@@ -147,30 +147,20 @@ jobs:
         steps:
             # Checkout the code 
             - checkout
+             
+            - run:
+                name: Create hash of RISC-V Tools and BoomTemplate
+                command: |
+                    ci/create-hash.sh rocket-chip
+                    ci/create-hash.sh
 
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version
-                    g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
+            - restore_cache:
+                keys:
+                    - boom-template-with-verilator-v1-{{ checksum "../boom-template.hash" }}
 
             - run: 
                 name: Building MediumBoomConfig using Verilator
@@ -184,7 +174,7 @@ jobs:
 
 #    prepare-megaboomconfig:
 #        docker:
-#            - image: circleci/openjdk:8-jdk
+#            - image: riscvboom/riscvboom-images:0.0.4
 #        environment:
 #            JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
 #            TERM: dumb
@@ -193,29 +183,19 @@ jobs:
 #            # Checkout the code 
 #            - checkout
 #
-#            - restore_cache:
-#                keys:
-#                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+#           - run:
+#               name: Create hash of RISC-V Tools and BoomTemplate
+#               command: |
+#                   ci/create-hash.sh rocket-chip
+#                   ci/create-hash.sh
 #
-#            - run:
-#                name: Source environment variables
-#                command: |
-#                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-#                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-#                    source /home/circleci/.bashrc
+#           - restore_cache:
+#               keys:
+#                   - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 #
-#            - run: 
-#                name: Install dependencies
-#                command: |
-#                    sudo apt-get update
-#                    gcc --version
-#                    g++ --version
-#                    sudo apt-get install autoconf automake autotools-dev curl
-#                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-#                    sudo apt-get install gawk build-essential bison flex 
-#                    sudo apt-get install texinfo gperf libtool patchutils
-#                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-#                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
+#           - restore_cache:
+#               keys:
+#                   - boom-template-with-verilator-v1-{{ checksum "../boom-template.hash" }}
 #
 #            - run: 
 #                name: Building MegaBoomConfig using Verilator
@@ -229,7 +209,7 @@ jobs:
 
     run-scala-checkstyle:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
@@ -238,28 +218,14 @@ jobs:
             # Checkout the code 
             - checkout
 
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - run:
                 name: Run Scala checkstyle
@@ -267,38 +233,27 @@ jobs:
 
     boomconfig-run-benchmark-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-boomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run BoomConfig benchmark tests
@@ -306,38 +261,27 @@ jobs:
 
     boomconfig-run-regression-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-boomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run BoomConfig regression tests
@@ -345,38 +289,27 @@ jobs:
 
     boomconfig-run-assembly-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-boomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run BoomConfig assembly tests
@@ -385,38 +318,27 @@ jobs:
 
     smallboomconfig-run-benchmark-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-smallboomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run SmallBoomConfig benchmark tests
@@ -424,38 +346,27 @@ jobs:
 
     smallboomconfig-run-regression-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-smallboomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run SmallBoomConfig regression tests
@@ -463,38 +374,27 @@ jobs:
 
     smallboomconfig-run-assembly-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-smallboomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run SmallBoomConfig assembly tests
@@ -503,38 +403,27 @@ jobs:
 
     mediumboomconfig-run-benchmark-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-mediumboomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run MediumBoomConfig benchmark tests
@@ -542,38 +431,27 @@ jobs:
 
     mediumboomconfig-run-regression-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-mediumboomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run MediumBoomConfig regression tests
@@ -581,38 +459,27 @@ jobs:
 
     mediumboomconfig-run-assembly-tests:
         docker:
-            - image: circleci/openjdk:8-jdk
+            - image: riscvboom/riscvboom-images:0.0.4
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
             TERM: dumb
 
         steps:
+            # Checkout the code 
+            - checkout
+
+            - run:
+                name: Create hash of RISC-V Tools based on RocketChip
+                command: |
+                    ci/create-hash.sh rocket-chip
+
             - restore_cache:
                 keys:
-                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - restore_cache:
                 keys:
                     - boom-template-mediumboomconfig-{{ .Branch }}-{{ .Revision }}
-
-            - run:
-                name: Source environment variables
-                command: |
-                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-                    source /home/circleci/.bashrc
-
-            - run: 
-                name: Install dependencies
-                command: |
-                    sudo apt-get update
-                    gcc --version g++ --version
-                    sudo apt-get install autoconf automake autotools-dev curl
-                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-                    sudo apt-get install gawk build-essential bison flex 
-                    sudo apt-get install texinfo gperf libtool patchutils
-                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 
             - run:
                 name: Run MediumBoomConfig assembly tests
@@ -621,38 +488,27 @@ jobs:
 
 #    megaboomconfig-run-benchmark-tests:
 #        docker:
-#            - image: circleci/openjdk:8-jdk
+#            - image: riscvboom/riscvboom-images:0.0.4
 #        environment:
 #            JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
 #            TERM: dumb
 #
 #        steps:
+#           # Checkout the code 
+#           - checkout
+#
+#            - run:
+#               name: Create hash of RISC-V Tools based on RocketChip
+#               command: |
+#                   ci/create-hash.sh rocket-chip
+#
 #            - restore_cache:
 #                keys:
-#                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+#                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 #
 #            - restore_cache:
 #                keys:
 #                    - boom-template-megaboomconfig-{{ .Branch }}-{{ .Revision }}
-#
-#            - run:
-#                name: Source environment variables
-#                command: |
-#                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-#                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-#                    source /home/circleci/.bashrc
-#
-#            - run: 
-#                name: Install dependencies
-#                command: |
-#                    sudo apt-get update
-#                    gcc --version g++ --version
-#                    sudo apt-get install autoconf automake autotools-dev curl
-#                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-#                    sudo apt-get install gawk build-essential bison flex 
-#                    sudo apt-get install texinfo gperf libtool patchutils
-#                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-#                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 #
 #            - run:
 #                name: Run MegaBoomConfig benchmark tests
@@ -660,38 +516,27 @@ jobs:
 #
 #    megaboomconfig-run-regression-tests:
 #        docker:
-#            - image: circleci/openjdk:8-jdk
+#            - image: riscvboom/riscvboom-images:0.0.4
 #        environment:
 #            JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
 #            TERM: dumb
 #
 #        steps:
+#           # Checkout the code 
+#           - checkout
+#
+#           - run:
+#               name: Create hash of RISC-V Tools based on RocketChip
+#               command: |
+#                   ci/create-hash.sh rocket-chip
+#
 #            - restore_cache:
 #                keys:
-#                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+#                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 #
 #            - restore_cache:
 #                keys:
 #                    - boom-template-megaboomconfig-{{ .Branch }}-{{ .Revision }}
-#
-#            - run:
-#                name: Source environment variables
-#                command: |
-#                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-#                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-#                    source /home/circleci/.bashrc
-#
-#            - run: 
-#                name: Install dependencies
-#                command: |
-#                    sudo apt-get update
-#                    gcc --version g++ --version
-#                    sudo apt-get install autoconf automake autotools-dev curl
-#                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-#                    sudo apt-get install gawk build-essential bison flex 
-#                    sudo apt-get install texinfo gperf libtool patchutils
-#                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-#                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 #
 #            - run:
 #                name: Run MegaBoomConfig regression tests
@@ -699,38 +544,27 @@ jobs:
 #
 #    megaboomconfig-run-assembly-tests:
 #        docker:
-#            - image: circleci/openjdk:8-jdk
+#            - image: riscvboom/riscvboom-images:0.0.4
 #        environment:
 #            JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
 #            TERM: dumb
 #
 #        steps:
+#           # Checkout the code 
+#           - checkout
+#
+#            - run:
+#               name: Create hash of RISC-V Tools based on RocketChip
+#               command: |
+#                   ci/create-hash.sh rocket-chip
+#
 #            - restore_cache:
 #                keys:
-#                    - riscv-tools-installed-{{ .Branch }}-{{ .Revision }}
+#                    - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 #
 #            - restore_cache:
 #                keys:
 #                    - boom-template-megaboomconfig-{{ .Branch }}-{{ .Revision }}
-#
-#            - run:
-#                name: Source environment variables
-#                command: |
-#                    echo 'export RISCV=$HOME/riscv-tools-install' >> $BASH_ENV
-#                    echo 'export PATH=$RISCV/bin:$PATH' >> $BASH_ENV
-#                    source /home/circleci/.bashrc
-#
-#            - run: 
-#                name: Install dependencies
-#                command: |
-#                    sudo apt-get update
-#                    gcc --version g++ --version
-#                    sudo apt-get install autoconf automake autotools-dev curl
-#                    sudo apt-get install libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev
-#                    sudo apt-get install gawk build-essential bison flex 
-#                    sudo apt-get install texinfo gperf libtool patchutils
-#                    sudo apt-get install bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev 
-#                    sudo apt-get install expat python-pexpect python libipt1 babeltrace
 #
 #            - run:
 #                name: Run MegaBoomConfig assembly tests
@@ -743,26 +577,30 @@ workflows:
     build-and-test-boom-configs:
         jobs:
             # Make the toolchain
-            - prepare-riscv-tools
+            - install-riscv-tools
+
+            - prepare-build-environment:
+                requires:
+                    - install-riscv-tools
 
             # Run generic syntax checking
             - run-scala-checkstyle:
                 requires:
-                    - prepare-riscv-tools
+                    - install-riscv-tools
 
             # Prepare the verilator builds
             - prepare-boomconfig:
                 requires:
-                    - prepare-riscv-tools
+                    - prepare-build-environment
             - prepare-smallboomconfig:
                 requires:
-                    - prepare-riscv-tools
+                    - prepare-build-environment
             - prepare-mediumboomconfig:
                 requires:
-                    - prepare-riscv-tools
+                    - prepare-build-environment
 #            - prepare-megaboomconfig:
 #                requires:
-#                    - prepare-riscv-tools
+#                    - prepare-build-environment
 
             # Run the respective tests
             # Run the BoomConfig tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -26,7 +26,7 @@ jobs:
                     - riscv-tools-installed-v1-{{ checksum "../rocket-chip.hash" }}
 
             - run: 
-                name: Building RISC-V Tools
+                name: Building riscv-tools
                 command: |
                     ci/prepare-riscv-tools.sh
                 no_output_timeout: 120m
@@ -48,7 +48,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of BoomTemplate
+                name: Create hash of boom-template
                 command: |
                     ci/create-hash.sh
 
@@ -79,7 +79,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools and BoomTemplate
+                name: Create hash of riscv-tools and boom-template
                 command: |
                     ci/create-hash.sh rocket-chip
                     ci/create-hash.sh
@@ -114,7 +114,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools and BoomTemplate
+                name: Create hash of riscv-tools and boom-template
                 command: |
                     ci/create-hash.sh rocket-chip
                     ci/create-hash.sh
@@ -149,7 +149,7 @@ jobs:
             - checkout
              
             - run:
-                name: Create hash of RISC-V Tools and BoomTemplate
+                name: Create hash of riscv-tools and boom-template
                 command: |
                     ci/create-hash.sh rocket-chip
                     ci/create-hash.sh
@@ -184,7 +184,7 @@ jobs:
 #            - checkout
 #
 #           - run:
-#               name: Create hash of RISC-V Tools and BoomTemplate
+#               name: Create hash of riscv-tools and boom-template
 #               command: |
 #                   ci/create-hash.sh rocket-chip
 #                   ci/create-hash.sh
@@ -219,7 +219,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -243,7 +243,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -271,7 +271,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -299,7 +299,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -328,7 +328,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -356,7 +356,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -384,7 +384,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -413,7 +413,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -441,7 +441,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -469,7 +469,7 @@ jobs:
             - checkout
 
             - run:
-                name: Create hash of RISC-V Tools based on RocketChip
+                name: Create hash of riscv-tools based on rocket-chip
                 command: |
                     ci/create-hash.sh rocket-chip
 
@@ -498,7 +498,7 @@ jobs:
 #           - checkout
 #
 #            - run:
-#               name: Create hash of RISC-V Tools based on RocketChip
+#               name: Create hash of riscv-tools based on rocket-chip
 #               command: |
 #                   ci/create-hash.sh rocket-chip
 #
@@ -526,7 +526,7 @@ jobs:
 #           - checkout
 #
 #           - run:
-#               name: Create hash of RISC-V Tools based on RocketChip
+#               name: Create hash of riscv-tools based on rocket-chip
 #               command: |
 #                   ci/create-hash.sh rocket-chip
 #
@@ -554,7 +554,7 @@ jobs:
 #           - checkout
 #
 #            - run:
-#               name: Create hash of RISC-V Tools based on RocketChip
+#               name: Create hash of riscv-tools based on rocket-chip
 #               command: |
 #                   ci/create-hash.sh rocket-chip
 #
@@ -579,6 +579,7 @@ workflows:
             # Make the toolchain
             - install-riscv-tools
 
+            # Build verilator
             - prepare-build-environment:
                 requires:
                     - install-riscv-tools

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,3 +1,4 @@
+### Note: This DockerFile is adapted from https://github.com/CircleCI-Public/example-images/openjdk
 ###
 ### this Dockerfile is an example representing one variant of this image;
 ### please see https://github.com/circleci-public/circleci-dockerfiles
@@ -112,7 +113,7 @@ RUN apt-get install -y autoconf automake autotools-dev curl libmpc-dev libmpfr-d
 # Update PATH for Java tools
 ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin:$PATH"
 
-# Update PATH for RISCV toolchain
+# Update PATH for RISCV toolchain (note: hardcoded for CircleCI)
 ENV RISCV="/home/circleci/riscv-tools-install"
 ENV PATH="$RISCV/bin:$PATH"
 

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,0 +1,128 @@
+###
+### this Dockerfile is an example representing one variant of this image;
+### please see https://github.com/circleci-public/circleci-dockerfiles
+### for a complete list of Dockerfiles for each tag/variant of this image
+###
+
+FROM openjdk:11.0.1-jdk-sid
+
+# make Apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# man directory is missing in some base images
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+RUN apt-get update \
+  && mkdir -p /usr/share/man/man1 \
+  && apt-get install -y \ 
+    git mercurial xvfb \
+    locales sudo openssh-client ca-certificates tar gzip parallel \
+    net-tools netcat unzip zip bzip2 gnupg curl wget
+
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Use unicode
+RUN locale-gen C.UTF-8 || true
+ENV LANG=C.UTF-8
+
+# install jq
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
+  && chmod +x /usr/bin/jq \
+  && jq --version
+
+# Install Docker
+
+# Docker.com returns the URL of the latest binary when you hit a directory listing
+# We curl this URL and `grep` the version out.
+# The output looks like this:
+
+#>    # To install, run the following commands as root:
+#>    curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-17.05.0-ce.tgz && tar --strip-components=1 -xvzf docker-17.05.0-ce.tgz -C /usr/local/bin
+#>
+#>    # Then start docker in daemon mode:
+#>    /usr/local/bin/dockerd
+
+RUN set -ex \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true)
+
+# docker compose
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
+  && chmod +x /usr/bin/docker-compose \
+  && docker-compose version
+
+# install dockerize
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
+  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
+  && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
+  && dockerize --version
+
+RUN groupadd --gid 3434 circleci \
+  && useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci \
+  && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci \
+  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+
+# BEGIN IMAGE CUSTOMIZATIONS
+
+# cacerts from OpenJDK 9-slim to workaround http://bugs.java.com/view_bug.do?bug_id=8189357
+# AND https://github.com/docker-library/openjdk/issues/145
+#
+# Created by running:
+# docker run --rm openjdk:9-slim cat /etc/ssl/certs/java/cacerts | #   aws s3 cp - s3://circle-downloads/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts --acl public-read
+RUN if java -fullversion 2>&1 | grep -q '"9.'; then   curl --silent --show-error --location --fail --retry 3 --output /etc/ssl/certs/java/cacerts        https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/openjdk-9-slim-cacerts;  fi
+
+# Install Maven Version: 3.6.0
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-maven.tar.gz     https://www.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz   && tar xf /tmp/apache-maven.tar.gz -C /opt/   && rm /tmp/apache-maven.tar.gz   && ln -s /opt/apache-maven-* /opt/apache-maven   && /opt/apache-maven/bin/mvn -version
+
+# Install Ant Version: 1.10.5
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/apache-ant.tar.gz     https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz   && tar xf /tmp/apache-ant.tar.gz -C /opt/   && ln -s /opt/apache-ant-* /opt/apache-ant   && rm -rf /tmp/apache-ant.tar.gz   && /opt/apache-ant/bin/ant -version
+
+ENV ANT_HOME=/opt/apache-ant
+
+# Install Gradle Version: 5.0
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/gradle.zip     https://services.gradle.org/distributions/gradle-5.0-bin.zip   && unzip -d /opt /tmp/gradle.zip   && rm /tmp/gradle.zip   && ln -s /opt/gradle-* /opt/gradle   && /opt/gradle/bin/gradle -version
+
+# Install sbt from https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/sbt-latest.tgz
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/sbt.tgz https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/sbt-latest.tgz   && tar -xzf /tmp/sbt.tgz -C /opt/   && rm /tmp/sbt.tgz   && /opt/sbt/bin/sbt sbtVersion
+
+# Install openjfx
+RUN apt-get install -y --no-install-recommends openjfx
+
+# Add build-essential
+RUN apt-get install -y build-essential
+
+# Add RISCV toolchain necessary dependencies
+RUN apt-get install -y autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev gawk bison flex texinfo gperf libtool patchutils bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev expat python-pexpect python babeltrace
+
+# Update PATH for Java tools
+ENV PATH="/opt/sbt/bin:/opt/apache-maven/bin:/opt/apache-ant/bin:/opt/gradle/bin:$PATH"
+
+# Update PATH for RISCV toolchain
+ENV RISCV="/home/circleci/riscv-tools-install"
+ENV PATH="$RISCV/bin:$PATH"
+
+# smoke test with path
+RUN mvn -version \
+  && ant -version \
+  && gradle -version \
+  && sbt sbtVersion
+# END IMAGE CUSTOMIZATIONS
+
+USER circleci 
+
+CMD ["/bin/sh"]

--- a/.circleci/images/README.md
+++ b/.circleci/images/README.md
@@ -1,7 +1,13 @@
-Steps to build a Docker container that has the necessary tools for riscv-boom
+General
+-------
+This DockerFile contains the necessary steps to build a Docker container that can run
+projects with riscv-tools, chisel3, firrtl, and verilator. It installs the necessary
+apt-get packages and sets the environment variables needed in CircleCI.
+
+Build and Deploy the container
 -----------------------------------------------------------------------------
 
-sudo docker build . # to test
-sudo docker build -t riscvboom/riscvboom-images:tag . # to build with tag (ex. 0.0.3)
-sudo docker login
-sudo docker push riscvboom/riscvboom-images:tag # to push to repo with tag
+    sudo docker build . # to test build before building it with a tag
+    sudo docker build -t riscvboom/riscvboom-images:tag . # to build with tag (ex. 0.0.3)
+    sudo docker login # login into the account to push to
+    sudo docker push riscvboom/riscvboom-images:tag # to push to repo with tag

--- a/.circleci/images/README.md
+++ b/.circleci/images/README.md
@@ -1,0 +1,7 @@
+Steps to build a Docker container that has the necessary tools for riscv-boom
+-----------------------------------------------------------------------------
+
+sudo docker build . # to test
+sudo docker build -t riscvboom/riscvboom-images:tag . # to build with tag (ex. 0.0.3)
+sudo docker login
+sudo docker push riscvboom/riscvboom-images:tag # to push to repo with tag

--- a/ci/create-hash.sh
+++ b/ci/create-hash.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# get the hash of repo and store in file
+
+# turn echo on and error on earliest command
+set -x
+set -e
+
+# move to top level dir
+cd ..
+if [ ! -d "/home/circleci/boom-template" ]; then
+    # clone boom-template and create the riscv-tools
+    git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
+fi
+cd boom-template
+
+if [ -z $1 ]; then
+    git rev-parse HEAD >> ../boom-template.hash
+    echo "Hashfile for boom-template created in ..$PWD"
+else
+    git rev-parse HEAD:$1 >> ../$1.hash
+    echo "Hashfile for $1 created in ..$PWD"
+fi
+

--- a/ci/prepare-for-build.sh
+++ b/ci/prepare-for-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# create the different verilator builds of BOOM based on arg
+# build verilator and init submodules
 
 # turn echo on and error on earliest command
 set -x

--- a/ci/prepare-for-build.sh
+++ b/ci/prepare-for-build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# create the different verilator builds of BOOM based on arg
+
+# turn echo on and error on earliest command
+set -x
+set -e
+
+# move to top level dir and remove boom-template if present
+cd ..
+cd boom-template
+./scripts/init-submodules-no-riscv-tools.sh
+
+# move the pull request riscv-boom repo into boom-template
+rm -rf boom
+mv /home/circleci/project/ boom/
+
+# enter the verisim directory and build verilator
+cd verisim
+make verilator_install

--- a/ci/prepare-riscv-tools.sh
+++ b/ci/prepare-riscv-tools.sh
@@ -6,11 +6,13 @@
 set -x
 set -e
 
-# move to top level dir and remove boom-template if present
-cd ..
-rm -rf boom-template
+if [ ! -d "/home/circleci/riscv-tools-install" ]; then
+    # move to top level dir and remove boom-template if present
+    cd ..
+    rm -rf boom-template
 
-# clone boom-template and create the riscv-tools
-git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
-cd boom-template
-./scripts/build-tools.sh
+    # clone boom-template and create the riscv-tools
+    git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
+    cd boom-template
+    ./scripts/build-tools.sh
+fi

--- a/ci/prepare-verilator-build.sh
+++ b/ci/prepare-verilator-build.sh
@@ -8,16 +8,7 @@ set -e
 
 # move to top level dir and remove boom-template if present
 cd ..
-rm -rf boom-template
-
-# clone boom-template and init submodules
-git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
 cd boom-template
-./scripts/init-submodules-no-riscv-tools.sh
-
-# move the pull request riscv-boom repo into boom-template
-rm -rf boom
-mv /home/circleci/project/ boom/
 
 # enter the verisim directory and build the specific config
 cd verisim


### PR DESCRIPTION
This is an improvement (#147) that caches riscv-tools and verilator. This uses a new docker image to store apt dependencies and setup environment variables. Riscv-tools and verilator are cached based on the commit hashes. Riscv-tools uses the commit hash of the submodule in boom-template. Verilator uses the commit hash of boom-template itself.