### PR TITLE
[lsu] Fix speculative load wakeups

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -159,7 +159,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    // Load/Store Unit & ExeUnits
    exe_units.memory_unit.io.lsu_io <> lsu.io
+
+   // TODO: Generate this in lsu
    val sxt_ldMiss = Wire(Bool())
+
 
 
 
@@ -679,6 +682,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       mem_iq.io.iss_valids(0) &&
       mem_iq.io.iss_uops(0).is_load &&
       !mem_iq.io.iss_uops(0).fp_val &&
+      mem_iq.io.iss_uops(0).pdst =/= 0.U &&
       !(sxt_ldMiss && (mem_iq.io.iss_uops(0).iw_p1_poisoned || mem_iq.io.iss_uops(0).iw_p2_poisoned))
    sxt_ldMiss :=
       ((lsu.io.nack.valid && lsu.io.nack.isload) || dc_shim.io.core.load_miss) &&

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -696,7 +696,9 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters,
       mem_ld_killed := true.B && mem_fired_ld
    }
 
-   io.mem_ldSpecWakeup.valid := RegNext(will_fire_load_incoming && !io.exe_resp.bits.uop.fp_val, init=false.B)
+   io.mem_ldSpecWakeup.valid := RegNext(will_fire_load_incoming
+                                     && !io.exe_resp.bits.uop.fp_val
+                                     && io.exe_resp.bits.uop.pdst =/= 0.U, init=false.B)
    io.mem_ldSpecWakeup.bits := mem_ld_uop.pdst
 
    // tell the ROB to clear the busy bit on the incoming store


### PR DESCRIPTION
Loads to zero register should not speculatively wakeup other uops,

Resolves #153