### PR TITLE
Refactor the execution unit generation

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -160,8 +160,9 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    val brunit_idx = exe_units.br_unit_idx
    br_unit <> exe_units.br_unit_io
 
-   for (eu <- exe_units) {
-      eu.io.brinfo := br_unit.brinfo
+   for (eu <- exe_units)
+   {
+      eu.io.brinfo        := br_unit.brinfo
       eu.io.com_exception := rob.io.flush.valid
    }
    if (usingFPU)

--- a/src/main/scala/exu/execution_units.scala
+++ b/src/main/scala/exu/execution_units.scala
@@ -173,7 +173,7 @@ class ExecutionUnits(fpu: Boolean)(implicit val p: Parameters) extends HasBoomCo
    require (exe_units.length != 0)
    if (!fpu)
    {
-      // if this is for FPU units, we don't need a memory unit (or other integer units)..
+      // if this is for FPU units, we don't need a memory unit (or other integer units).
       require (exe_units.map(_.has_mem).reduce(_|_), "Datapath is missing a memory unit.")
       require (exe_units.map(_.has_mul).reduce(_|_), "Datapath is missing a multiplier.")
       require (exe_units.map(_.has_div).reduce(_|_), "Datapath is missing a divider.")

--- a/src/main/scala/exu/fppipeline.scala
+++ b/src/main/scala/exu/fppipeline.scala
@@ -65,8 +65,8 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
                                  exe_units.num_frf_read_ports,
                                  exe_units.num_frf_write_ports + 1, // + 1 for ll writeback
                                  fLen+1,
-                                 // No bypassing for FP
-                                 Seq(false) ++ (0 until exe_units.num_frf_write_ports).map(x=>false)
+                                 // No bypassing for any FP units, + 1 for ll_wb
+                                 Seq.fill(exe_units.num_frf_write_ports + 1){ false }
                                  ))
    val fregister_read   = Module(new RegisterRead(
                            issue_unit.issue_width,

--- a/src/main/scala/exu/issue.scala
+++ b/src/main/scala/exu/issue.scala
@@ -201,5 +201,8 @@ class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters)
 //      issue_Units =issueConfigs colect {if iqType=....)
    iss_units += Module(new IssueUnitCollasping(issueParams.find(_.iqType == IQT_MEM.litValue).get, num_wakeup_ports))
    iss_units += Module(new IssueUnitCollasping(issueParams.find(_.iqType == IQT_INT.litValue).get, num_wakeup_ports))
+
+   def mem_iq = iss_units.find(_.iqType == IQT_MEM.litValue).get
+   def int_iq = iss_units.find(_.iqType == IQT_INT.litValue).get
 }
 

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -183,7 +183,7 @@ class Rob(
    width: Int,
    num_rob_entries: Int,
    val num_wakeup_ports: Int,
-   num_fpu_ports: Int
+   val num_fpu_ports: Int
    )(implicit p: Parameters) extends BoomModule()(p)
 {
    val io = IO(new RobIo(width, num_wakeup_ports, num_fpu_ports))


### PR DESCRIPTION
The previous code had a lot of hard hacks to map execution units
to read ports, write ports, issue units, etc.

These changes hope to reduce the number of hard hacks and clarify
the core. This will also make it easier to generate a unified-issue
machine.

Sorry about the massive commit, this couldn't really be done incrementally.

In summary, the changes are
- Explicitly label destinations of exe unit responses, whether they get a port to IRF or FRF (iresp/fresp), or if they share a long-latency port (ll_iresp/ll_fresp)
- Cleanup usage of attributes carried by the ExecutionUnits collection
- Move IFPU to the integer pipeline execution unit collection.