### PR TITLE
[lsu] When VM is disabled pass firrtl build

### DIFF
--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -56,6 +56,7 @@ trait CanHaveBoomPTWModule extends HasBoomHellaCacheModule {
   val outer: CanHaveBoomPTW
   val ptwPorts = ListBuffer(outer.dcache.module.io.ptw)
   val ptw = Module(new PTW(outer.nPTWPorts)(outer.dcache.node.edges.out(0), outer.p))
+  ptw.io <> DontCare // Is overridden below if PTW is connected
   if (outer.usingPTW) {
     dcachePorts += ptw.io.mem
   }


### PR DESCRIPTION
In the title! Firrtl build fails when disabling VM. This allows the build to pass by connecting the PTW to dontCare first.