### PR TITLE
[ftq] FTQ should update internal commit_ptr on flushes

### DIFF
--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -259,8 +259,9 @@ trait ScalarOpConstants
    val uopFSQRT_S   = 103.U(UOPC_SZ.W)
    val uopFSQRT_D   = 104.U(UOPC_SZ.W)
 
-   val uopSYSTEM    = 105.U(UOPC_SZ.W) // pass uop down the CSR pipeline and let it handle it
-   val uopSFENCE    = 106.U(UOPC_SZ.W)
+   val uopWFI       = 105.U(UOPC_SZ.W) // pass uop down the CSR pipeline
+   val uopERET      = 106.U(UOPC_SZ.W) // pass uop down the CSR pipeline, also is ERET
+   val uopSFENCE    = 107.U(UOPC_SZ.W)
 
    // The Bubble Instruction (Machine generated NOP)
    // Insert (XOR x0,x0,x0) which is different from software compiler

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -219,13 +219,13 @@ object XDecode extends DecodeConstants
    CSRRCI  -> List(Y, N, X, uopCSRRCI,IQT_INT, FU_CSR , RT_FIX, RT_PAS, RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.C),
 
    SFENCE_VMA->List(Y,N, X, uopSFENCE,IQT_MEM, FU_MEM , RT_X  , RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_SFENCE,MT_X,0.U, N, N, N, N, N, Y, Y, CSR.N),
-   SCALL   -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, Y, Y, N, CSR.I),
-   SBREAK  -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, Y, Y, N, CSR.I),
-   SRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, N, CSR.I),
-   MRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, N, CSR.I),
-   DRET    -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, N, CSR.I),
+   SCALL   -> List(Y, N, X, uopERET  ,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, Y, Y, Y, CSR.I),
+   SBREAK  -> List(Y, N, X, uopERET  ,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, Y, Y, Y, CSR.I),
+   SRET    -> List(Y, N, X, uopERET  ,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.I),
+   MRET    -> List(Y, N, X, uopERET  ,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.I),
+   DRET    -> List(Y, N, X, uopERET  ,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_I, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.I),
 
-   WFI     -> List(Y, N, X, uopSYSTEM,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.I),
+   WFI     -> List(Y, N, X, uopWFI   ,IQT_INT, FU_CSR , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.I),
 
    FENCE_I -> List(Y, N, X, uopNOP  , IQT_INT, FU_X   , RT_X  , RT_X  , RT_X  , N, IS_X, N, N, N, N, Y, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.N),
    FENCE   -> List(Y, N, X, uopFENCE, IQT_INT, FU_MEM , RT_X  , RT_X  , RT_X  , N, IS_X, N, Y, N, Y, N, M_X  , MT_X , 0.U, N, N, N, N, N, Y, Y, CSR.N), // TODO PERF make fence higher performance

--- a/src/main/scala/exu/fudecode.scala
+++ b/src/main/scala/exu/fudecode.scala
@@ -183,7 +183,8 @@ object CsrRRdDecode extends RRdDecodeConstants
          BitPat(uopCSRRSI)-> List(BR_N , Y, N, N, FN_ADD , DW_XPR, OP1_ZERO, OP2_IMMC, IS_I, REN_1, CSR.S),
          BitPat(uopCSRRCI)-> List(BR_N , Y, N, N, FN_ADD , DW_XPR, OP1_ZERO, OP2_IMMC, IS_I, REN_1, CSR.C),
 
-         BitPat(uopSYSTEM)-> List(BR_N , Y, N, N, FN_ADD , DW_XPR, OP1_ZERO, OP2_IMMC, IS_I, REN_0, CSR.I))
+         BitPat(uopWFI)   -> List(BR_N , Y, N, N, FN_ADD , DW_XPR, OP1_ZERO, OP2_IMMC, IS_I, REN_0, CSR.I),
+         BitPat(uopERET)  -> List(BR_N , Y, N, N, FN_ADD , DW_XPR, OP1_ZERO, OP2_IMMC, IS_I, REN_0, CSR.I))
 }
 
 object FpuRRdDecode extends RRdDecodeConstants

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -151,9 +151,11 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    io.enq.ready := !full
    io.enq_idx := enq_ptr.value
 
-   when (io.deq.valid)
+   when (io.deq.valid || io.flush.valid)
    {
-      commit_ptr := io.deq.bits
+      assert (!(io.deq.valid && io.flush.valid && io.deq.bits =/= io.flush.bits.ftq_idx),
+         "FTQ received conflicting flush and deq on same cycle")
+      commit_ptr := Mux(io.flush.valid, io.flush.bits.ftq_idx, io.deq.bits)
    }
 
    //-------------------------------------------------------------

--- a/src/main/scala/ifu/fetchtargetqueue.scala
+++ b/src/main/scala/ifu/fetchtargetqueue.scala
@@ -306,7 +306,8 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
             - Mux(io.flush.bits.edge_inst, 2.U, 0.U))
    com_pc_next := com_pc + Mux(io.flush.bits.is_rvc, 2.U, 4.U)
 
-   assert (RegNext(io.com_ftq_idx) === io.flush.bits.ftq_idx, "[ftq] this code depends on this assumption")
+   assert (!(io.flush.valid && RegNext(io.com_ftq_idx) =/= io.flush.bits.ftq_idx),
+      "[ftq] this code depends on this assumption")
 
    //-------------------------------------------------------------
    // **** Printfs ****


### PR DESCRIPTION
This is to resolve a pipeline hang when the core fetches no valid instructions. In this case, the FTQ receives repeated `flush` signals, but no `deq` signals, causing it to fill and stall the frontend.

I believe the issue is that excepting instructions don't send the ftq_idx's to the FTQ to be dequeued. In normal program execution, this doesn't break the FTQ since a later valid committed instruction would increment the commit_ptr past the entry of the excepting instruction. In the case where the core is only fetching invalid instructions (such as when the bootrom is invalid). the core should be able to spin on invalid instruction exceptions.

I'm not convinced that the flush ftq_idx and the commit ftq_idx will always match, however.