### PR TITLE
[pnr] Initial simple point-of-no-return implementation in ROB

### DIFF
--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -68,6 +68,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
 
    val br_prediction    = new BranchPredInfo
 
+
    // stat tracking of committed instructions
    val stat_brjmp_mispredicted = Bool()                 // number of mispredicted branches/jmps
    val stat_btb_made_pred      = Bool()                 // the BTB made a prediction (even if BPD overrided it)
@@ -138,6 +139,10 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    // purely debug information
    val debug_wdata      = UInt(xLen.W)
    val debug_events     = new DebugStageEvents
+
+
+   // Is it possible for this uop to not commit once it is in the ROB?
+   def may_xcpt         = (is_load || is_store || is_br_or_jmp || exception) && !(is_fence || is_fencei)
 
    def fu_code_is(_fu: UInt) = fu_code === _fu
 }

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1156,8 +1156,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    exe_units(brunit_idx).io.status := csr.io.status
 
    // LSU <> ROB
-   rob.io.lsu_clr_bsy_valid   := lsu.io.lsu_clr_bsy_valid
-   rob.io.lsu_clr_bsy_rob_idx := lsu.io.lsu_clr_bsy_rob_idx
+   rob.io.lsu_clr_bsy_valid      := lsu.io.clr_bsy_valid
+   rob.io.lsu_clr_bsy_rob_idx    := lsu.io.clr_bsy_rob_idx
+   rob.io.lsu_ld_success         := lsu.io.ld_success
+   rob.io.lsu_ld_success_rob_idx := lsu.io.ld_success_rob_idx
    rob.io.lxcpt <> lsu.io.xcpt
 
    assert (!(csr.io.singleStep), "[core] single-step is unsupported.")

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1158,8 +1158,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // LSU <> ROB
    rob.io.lsu_clr_bsy_valid      := lsu.io.clr_bsy_valid
    rob.io.lsu_clr_bsy_rob_idx    := lsu.io.clr_bsy_rob_idx
-   rob.io.lsu_ld_success         := lsu.io.ld_success
-   rob.io.lsu_ld_success_rob_idx := lsu.io.ld_success_rob_idx
+   rob.io.lsu_mem_success         := lsu.io.mem_success
+   rob.io.lsu_mem_success_rob_idx := lsu.io.mem_success_rob_idx
    rob.io.lxcpt <> lsu.io.xcpt
 
    assert (!(csr.io.singleStep), "[core] single-step is unsupported.")

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -301,7 +301,7 @@ class Rob(
          rob_val(rob_tail)       := true.B
          rob_bsy(rob_tail)       := !io.enq_uops(w).is_fence &&
                                     !(io.enq_uops(w).is_fencei)
-         rob_safe(rob_tail)      := !io.enq_uops(w).may_xcpt
+         rob_safe(rob_tail)      := !io.enq_uops(w).may_xcpt && !io.enq_uops(w).exception
          rob_uop(rob_tail)       := io.enq_uops(w)
          rob_exception(rob_tail) := io.enq_uops(w).exception
          rob_fflags(rob_tail)    := 0.U
@@ -394,10 +394,15 @@ class Rob(
       when (io.lxcpt.valid && MatchBank(GetBankIdx(io.lxcpt.bits.uop.rob_idx)))
       {
          rob_exception(GetRowIdx(io.lxcpt.bits.uop.rob_idx)) := true.B
+         assert(!rob_safe(GetRowIdx(io.lxcpt.bits.uop.rob_idx)),
+            "An instruction marked as safe is causing an exception")
       }
       when (io.bxcpt.valid && MatchBank(GetBankIdx(io.bxcpt.bits.uop.rob_idx)))
       {
          rob_exception(GetRowIdx(io.bxcpt.bits.uop.rob_idx)) := true.B
+         assert(!rob_safe(GetRowIdx(io.bxcpt.bits.uop.rob_idx)),
+            "An instruction marked as safe is causing an exception")
+
       }
       can_throw_exception(w) := rob_val(rob_head) && rob_exception(rob_head)
 

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -71,8 +71,8 @@ class RobIo(
 
    val lsu_clr_bsy_valid      = Input(Vec(2, Bool()))
    val lsu_clr_bsy_rob_idx    = Input(Vec(2, UInt(ROB_ADDR_SZ.W)))
-   val lsu_ld_success         = Input(Bool())
-   val lsu_ld_success_rob_idx = Input(UInt(ROB_ADDR_SZ.W))
+   val lsu_mem_success         = Input(Bool())
+   val lsu_mem_success_rob_idx = Input(UInt(ROB_ADDR_SZ.W))
 
    // Track side-effects for debug purposes.
    // Also need to know when loads write back, whereas we don't need loads to unbusy.
@@ -362,9 +362,9 @@ class Rob(
          }
       }
 
-      when (io.lsu_ld_success && MatchBank(GetBankIdx(io.lsu_ld_success_rob_idx)))
+      when (io.lsu_mem_success && MatchBank(GetBankIdx(io.lsu_mem_success_rob_idx)))
       {
-         val cidx = GetRowIdx(io.lsu_ld_success_rob_idx)
+         val cidx = GetRowIdx(io.lsu_mem_success_rob_idx)
          rob_safe(cidx) := true.B
       }
 


### PR DESCRIPTION
This is taken from work on the secureboom project.
A simple PNR head that advances one ROB row per cycle.
Currently drives nothing.

The LSU should eventually be able to mark loads as safe to eventually commit, when they are guaranteed to not cause a memory-ordering failure. This will substantially improve the run-ahead of the PNR. I left a signal from the LSU to control this, but kept it tied off for now.