### PR TITLE
[ras] Work towards re-enabling the RAS

### DIFF
--- a/src/main/scala/bpu/bpd-pipeline.scala
+++ b/src/main/scala/bpu/bpd-pipeline.scala
@@ -143,20 +143,19 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
 
    //************************************************
    // Update the RAS
-   // TODO XXX  reenable RAS
 
    // update RAS based on BTB's prediction information (or the branch-check correction).
-//   val jmp_idx = f2_btb.bits.cfi_idx
 
-   btb.io.ras_update := io.f3_ras_update
-   btb.io.ras_update.valid := false.B // TODO XXX renable RAS (f2_btb.valid || io.f3_ras_update.valid) &&
-                                      // !io.fetch_stalled
-//   when (f2_btb.valid)
-//   {
-//      btb.io.ras_update.bits.is_call      := BpredType.isCall(f2_btb.bits.bpd_type)
-//      btb.io.ras_update.bits.is_ret       := BpredType.isReturn(f2_btb.bits.bpd_type)
-//      btb.io.ras_update.bits.return_addr  := f2_aligned_pc + (jmp_idx << 2.U) + 4.U
-//   }
+   // val jmp_idx = io.f2_btb_resp.bits.cfi_idx
+
+   btb.io.ras_update       := io.f3_ras_update
+   btb.io.ras_update.valid := io.f3_ras_update.valid
+   // when (f2_btb.valid)
+   // {
+   //    btb.io.ras_update.bits.is_call      := BpredType.isCall(f2_btb.bits.bpd_type)
+   //    btb.io.ras_update.bits.is_ret       := BpredType.isReturn(f2_btb.bits.bpd_type)
+   //    btb.io.ras_update.bits.return_addr  := f2_aligned_pc + (jmp_idx << 2.U) + 4.U
+   // }
 
    //************************************************
    // Update the BTB/BIM

--- a/src/main/scala/bpu/btb/btb-sa.scala
+++ b/src/main/scala/bpu/btb/btb-sa.scala
@@ -170,7 +170,7 @@ class BTBsa(implicit p: Parameters) extends BoomBTB
       val doingPeek = Wire(Bool())
       doingPeek := doPeek
       chisel3.experimental.dontTouch(doingPeek)
-      val isEmpty = if (rasCheckForEmpty) ras.isEmpty else false.B
+      val isEmpty = if (rasCheckForEmpty) ras.io.empty else false.B
       when (!isEmpty && doPeek)
       {
          s1_resp_bits.target := ras.io.peek

--- a/src/main/scala/bpu/btb/btb.scala
+++ b/src/main/scala/bpu/btb/btb.scala
@@ -133,6 +133,7 @@ class PCReq(implicit p: Parameters) extends BoomBTBBundle()(p)
 
 class RAS(nras: Int, coreInstBytes: Int)(implicit p: Parameters) extends BoomModule()(p)
 {
+   require(nras > 1)
    val count = Reg(UInt(log2Ceil(nras+1).W))
    val pos   = Reg(UInt(log2Ceil(nras).W))
    val stack = Mem(nras, UInt())
@@ -145,10 +146,10 @@ class RAS(nras: Int, coreInstBytes: Int)(implicit p: Parameters) extends BoomMod
       val pop  = Input(Bool())
       val empty = Output(Bool())
    })
-   def isEmpty: Bool = count === 0.U
+
 
    io.peek  := Cat(stack(pos), 0.U(log2Ceil(coreInstBytes).W))
-   io.empty := isEmpty
+   io.empty := count === 0.U
 
    when (io.push)
    {
@@ -160,7 +161,7 @@ class RAS(nras: Int, coreInstBytes: Int)(implicit p: Parameters) extends BoomMod
    }
    when (io.pop)
    {
-      when (!isEmpty)
+      when (!io.empty)
       {
          count := count - 1.U
          pos := Mux(isPow2(nras).B || pos > 0.U, pos-1.U, (nras-1).U)

--- a/src/main/scala/bpu/btb/dense-btb.scala
+++ b/src/main/scala/bpu/btb/dense-btb.scala
@@ -371,20 +371,24 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
 
    if (nRAS > 0)
    {
-      val ras = new RAS(nRAS, coreInstBytes)
+      val ras = Module(new RAS(nRAS, coreInstBytes))
+      ras.io.push := false.B
+      ras.io.addr := 0.U
+      ras.io.pop  := false.B
       // TODO: assumes only short branches...need to verify this
       val doPeek = (hits_oh zip data_out map {case(hit, d) => hit && BpredType.isReturn(d.bpd_type)}).reduce(_||_)
       val isEmpty = if (rasCheckForEmpty) ras.isEmpty else false.B
       when (!isEmpty && doPeek)
       {
-         s1_resp_bits.target := ras.peek
+         s1_resp_bits.target := ras.io.peek
       }
 
       when (io.ras_update.valid)
       {
          when (io.ras_update.bits.is_call)
          {
-            ras.push(io.ras_update.bits.return_addr)
+            ras.io.push := true.B
+            ras.io.addr := io.ras_update.bits.return_addr
             if (bypassCalls)
             {
                // bypassing couples ras_update.valid to the critical path.
@@ -396,7 +400,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
          }
          .elsewhen (io.ras_update.bits.is_ret) // only pop if BTB hit!
          {
-            ras.pop()
+            ras.io.pop := true.B
          }
       }
    }

--- a/src/main/scala/bpu/btb/dense-btb.scala
+++ b/src/main/scala/bpu/btb/dense-btb.scala
@@ -377,7 +377,7 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
       ras.io.pop  := false.B
       // TODO: assumes only short branches...need to verify this
       val doPeek = (hits_oh zip data_out map {case(hit, d) => hit && BpredType.isReturn(d.bpd_type)}).reduce(_||_)
-      val isEmpty = if (rasCheckForEmpty) ras.isEmpty else false.B
+      val isEmpty = if (rasCheckForEmpty) ras.io.empty else false.B
       when (!isEmpty && doPeek)
       {
          s1_resp_bits.target := ras.io.peek

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -386,6 +386,7 @@ trait RISCVConstants
    {
       val bdecode = Module(new boom.exu.BranchDecode)
       bdecode.io.inst := inst
+      bdecode.io.pc := 0.U
       bdecode.io.cfi_type
    }
 }


### PR DESCRIPTION
This RAS is technically re-enabled, but performance is terrible. It is probably not working correctly. There are several points which confuse me.
 - Why do we only take the RAS value if we hit in the BTB arrays? 
 - When F3 sees a JAL that was missed by the BTB, the next fetchpacket is not ignored. In the following code segment, where each instruction is on a different fetchpacket,
```
jal <funct1>
jal <funct2>
```
The branch-checker will send updates to the RAS for both packets, messing up the RAS stack. This makes me doubt if RAS pop operations should be done in F3, in BranchDecode. 

Branch prediction is hard.
