### PR TITLE
Fixed not working without RVC due to prev_is_half

### DIFF
--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -371,8 +371,8 @@ class FetchControlUnit(fetch_width: Int)(implicit p: Parameters) extends BoomMod
    {
       val last_idx  = Mux(inLastChunk(f3_fetch_bundle.pc) && icIsBanked.B,
                           (fetchWidth/2-1).U, (fetchWidth-1).U)
-      prev_is_half := (
-         !(f3_valid_mask(last_idx-1.U) && f3_fetch_bundle.insts(last_idx-1.U)(1,0) === 3.U)
+      prev_is_half := (usingCompressed.B
+      && !(f3_valid_mask(last_idx-1.U) && f3_fetch_bundle.insts(last_idx-1.U)(1,0) === 3.U)
       && !f3_kill_mask(last_idx)
       && f3_btb_mask(last_idx)
       && f3_bpd_mask(last_idx)


### PR DESCRIPTION
I have a configuration without RVC.

When doing benchmark medium.riscv, I have an assert:
about to abort: [fetch] Branch is followed by the wrong instruction
0x0010000511 =/= 0x0010000512, 0x0040001444 =/= 0x0040001490
Assertion failed: [fetch] branch is followed by the wrong instruction.
    at fetch-control-unit.scala:727 assert (fetch_pc === last_nextlinepc || f_pc === targ,

This assert occurred because btb_update was written as pc = 0x40001480, target = 0x40001444.
Here is the fetch packet from which it is clear that the target should be 0x40001448:
    40001480:	fd7994e3          	bne	s3,s7,40001448 <vprintfmt+0x38c>
    40001484:	fddff06f          	        j	40001460 <vprintfmt+0x3a4>
    40001488:	f40594e3          	bnez	 a1,400013d0 <vprintfmt+0x314>
    4000148c:	000b2983          	lw	s3,0(s6)

The address 0x40001448 has been reduced by 2 here: https://github.com/riscv-boom/riscv-boom/blob/c26e3d244a7c2b4d20c03e551441c19064168517/src/main/scala/ifu/fetch-control-unit.scala#L304
Then aligned to 0x40001444.

This happened because prev_is_half is 1.
This is because f3_valid_mask (last_idx-1.U) = 0 here:
https://github.com/riscv-boom/riscv-boom/blob/c26e3d244a7c2b4d20c03e551441c19064168517/src/main/scala/ifu/fetch-control-unit.scala#L375

I think the logic in PR is more correct. But I did not have time to test it and I can not in the next couple of days.