### PR TITLE
Instruction buffer in the ROB

### DIFF
--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -21,6 +21,7 @@ import freechips.rocketchip.config.Parameters
 import boom.bpu.BranchPredInfo
 import boom.exu.FUConstants
 
+
 /**
  * Extension to BoomBundle to add a MicroOp
  */
@@ -41,7 +42,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val valid            = Bool()
 
    val uopc             = UInt(UOPC_SZ.W)       // micro-op code
-   val inst             = UInt(32.W)
+   val debug_inst       = UInt(32.W)
    val is_rvc           = Bool()
    val pc               = UInt(coreMaxAddrBits.W) // TODO remove -- use FTQ to get PC. Change to debug_pc.
    val iqtype           = UInt(IQT_SZ.W)        // which issue unit do we use?

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1074,6 +1074,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // Dispatch
    rob.io.enq_valids := rename_stage.io.ren1_mask
    rob.io.enq_uops   := rename_stage.io.ren1_uops
+   rob.io.enq_insts  := dec_fbundle.insts
    rob.io.enq_new_packet := dec_finished_mask === 0.U
    rob.io.enq_partial_stall := dec_last_inst_was_stalled // TODO come up with better ROB compacting scheme.
    rob.io.debug_tsc := debug_tsc_reg
@@ -1522,7 +1523,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       {
          io.trace(w).valid      := rob.io.commit.valids(w)
          io.trace(w).iaddr      := Sext(rob.io.commit.uops(w).pc(vaddrBits-1,0), xLen)
-         io.trace(w).insn       := rob.io.commit.uops(w).debug_inst
+         io.trace(w).insn       := rob.io.commit.insts(w)
          // I'm uncertain the commit signals from the ROB match these CSR exception signals
          io.trace(w).priv       := csr.io.status.prv
          io.trace(w).exception  := csr.io.exception

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -504,6 +504,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       dec_valids(w)                      := io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid &&
                                             !dec_finished_mask(w)
       decode_units(w).io.enq.uop         := dec_fbundle.uops(w)
+      decode_units(w).io.enq.inst        := dec_fbundle.insts(w)
       decode_units(w).io.status          := csr.io.status
       decode_units(w).io.csr_decode      <> csr.io.decode(w)
       decode_units(w).io.interrupt       := csr.io.interrupt
@@ -738,7 +739,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          uop.br_prediction := DontCare
          uop.debug_wdata := DontCare
          if (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF) uop.pc := DontCare
-         if (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF) uop.inst := DontCare
+         if (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF) uop.debug_inst := DontCare
          if (!O3PIPEVIEW_PRINTF) uop.debug_events.fetch_seq := DontCare
       }
    }
@@ -1236,7 +1237,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          printf("(%c%c) " + "DASM(%x)" + " |  ",
                 Mux(io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid && !dec_finished_mask(w), Str("v"), Str("-")),
                 Mux(dec_will_fire(w), Str("V"), Str("-")),
-                dec_fbundle.uops(w).inst
+                dec_fbundle.uops(w).debug_inst
                 )
       }
 
@@ -1256,7 +1257,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       {
          printf(" (%c) " + "DASM(%x)" + " |  ",
                 Mux(rename_stage.io.ren2_mask(w), Str("V"), Str("-")),
-                rename_stage.io.ren2_uops(w).inst
+                rename_stage.io.ren2_uops(w).debug_inst
                 )
       }
 
@@ -1378,10 +1379,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          def printf_inst(uop: MicroOp) = {
             when (uop.is_rvc)
             {
-               printf("(0x%x)", uop.inst(15,0))
+               printf("(0x%x)", uop.debug_inst(15,0))
             }
             .otherwise {
-               printf("(0x%x)", uop.inst)
+               printf("(0x%x)", uop.debug_inst)
             }
          }
          when (rob.io.commit.valids(w))
@@ -1521,7 +1522,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       {
          io.trace(w).valid      := rob.io.commit.valids(w)
          io.trace(w).iaddr      := Sext(rob.io.commit.uops(w).pc(vaddrBits-1,0), xLen)
-         io.trace(w).insn       := rob.io.commit.uops(w).inst
+         io.trace(w).insn       := rob.io.commit.uops(w).debug_inst
          // I'm uncertain the commit signals from the ROB match these CSR exception signals
          io.trace(w).priv       := csr.io.status.prv
          io.trace(w).exception  := csr.io.exception

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -398,7 +398,10 @@ object FDivSqrtDecode extends DecodeConstants
  */
 class DecodeUnitIo(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val enq = new Bundle { val uop = Input(new MicroOp()) }
+   val enq = new Bundle {
+      val uop  = Input(new MicroOp())
+      val inst = Input(UInt(32.W))
+   }
    val deq = new Bundle { val uop = Output(new MicroOp()) }
 
    // from CSRFile
@@ -425,9 +428,9 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    decode_table ++= (if (xLen == 64) X64Decode.table else X32Decode.table)
 
    val rvc_exp    = Module(new RVCExpander)
-   rvc_exp.io.in := io.enq.uop.inst
+   rvc_exp.io.in := io.enq.inst
    uop.is_rvc    := rvc_exp.io.rvc
-   val inst       = Mux(rvc_exp.io.rvc, rvc_exp.io.out.bits, io.enq.uop.inst)
+   val inst       = Mux(rvc_exp.io.rvc, rvc_exp.io.out.bits, io.enq.inst)
 
    val cs = Wire(new CtrlSigs()).decode(inst, decode_table)
 

--- a/src/main/scala/exu/issue-units/issue-unit.scala
+++ b/src/main/scala/exu/issue-units/issue-unit.scala
@@ -187,7 +187,7 @@ abstract class IssueUnit(
                 Mux(issue_slots(i).uop.dst_rtype === RT_X, Str("-"),
                 Mux(issue_slots(i).uop.dst_rtype === RT_FLT, Str("f"),
                 Mux(issue_slots(i).uop.dst_rtype === RT_PAS, Str("C"), Str("?"))))),
-                issue_slots(i).uop.inst,
+                issue_slots(i).uop.debug_inst,
                 issue_slots(i).uop.pc(31,0),
                 issue_slots(i).uop.uopc,
                 issue_slots(i).uop.rob_idx,

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -302,7 +302,7 @@ class Rob(
       }
       .elsewhen (io.enq_valids.reduce(_|_) && !rob_val(rob_tail))
       {
-         rob_uop(rob_tail).inst := BUBBLE // just for debug purposes
+         rob_uop(rob_tail).debug_inst := BUBBLE // just for debug purposes
       }
 
       //-----------------------------------------------
@@ -423,7 +423,7 @@ class Rob(
             {
                rob_val(i)      := false.B
                rob_bsy(i)      := false.B
-               rob_uop(i).inst := BUBBLE
+               rob_uop(i).debug_inst := BUBBLE
             }
          }
       }
@@ -439,7 +439,7 @@ class Rob(
          when (io.brinfo.valid && io.brinfo.mispredict && entry_match)
          {
             rob_val(i) := false.B
-            rob_uop(i.U).inst := BUBBLE
+            rob_uop(i.U).debug_inst := BUBBLE
          }
          .elsewhen (io.brinfo.valid && !io.brinfo.mispredict && entry_match)
          {
@@ -466,11 +466,11 @@ class Rob(
       // debugging write ports that should not be synthesized
       when (will_commit(w))
       {
-         rob_uop(rob_head).inst := BUBBLE
+         rob_uop(rob_head).debug_inst := BUBBLE
       }
       .elsewhen (rob_state === s_rollback)
       {
-         rob_uop(rob_tail).inst := BUBBLE
+         rob_uop(rob_tail).debug_inst := BUBBLE
       }
 
       //--------------------------------------------------
@@ -658,7 +658,7 @@ class Rob(
          // This should be handled by the front-end.
          when ((io.enq_uops(idx).uopc === uopJAL) && !io.enq_uops(idx).exc_cause.orR)
          {
-            r_xcpt_badvaddr := ComputeJALTarget(io.enq_uops(idx).pc, ExpandRVC(io.enq_uops(idx).inst), xLen)
+            r_xcpt_badvaddr := ComputeJALTarget(io.enq_uops(idx).pc, ExpandRVC(io.enq_uops(idx).debug_inst), xLen)
          }
       }
    }
@@ -901,7 +901,7 @@ class Rob(
                    Mux(debug_entry(r_idx+0).valid, Str("V"), Str(" ")),
                    Mux(debug_entry(r_idx+0).busy, Str("B"),  Str(" ")),
                    debug_entry(r_idx+0).uop.pc(31,0),
-                   debug_entry(r_idx+0).uop.inst,
+                   debug_entry(r_idx+0).uop.debug_inst,
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-"))
                    )
          }
@@ -915,8 +915,8 @@ class Rob(
                    Mux(debug_entry(r_idx+1).busy,  Str("B"), Str(" ")),
                    debug_entry(r_idx+0).uop.pc(31,0),
                    debug_entry(r_idx+1).uop.pc(15,0),
-                   debug_entry(r_idx+0).uop.inst,
-                   debug_entry(r_idx+1).uop.inst,
+                   debug_entry(r_idx+0).uop.debug_inst,
+                   debug_entry(r_idx+1).uop.debug_inst,
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-")),
                    Mux(debug_entry(r_idx+1).exception, Str("E"), Str("-")),
                    debug_entry(r_idx+0).uop.ftq_idx,
@@ -939,10 +939,10 @@ class Rob(
                    debug_entry(r_idx+1).uop.pc(15,0),
                    debug_entry(r_idx+2).uop.pc(15,0),
                    debug_entry(r_idx+3).uop.pc(15,0),
-                   debug_entry(r_idx+0).uop.inst,
-                   debug_entry(r_idx+1).uop.inst,
-                   debug_entry(r_idx+2).uop.inst,
-                   debug_entry(r_idx+3).uop.inst,
+                   debug_entry(r_idx+0).uop.debug_inst,
+                   debug_entry(r_idx+1).uop.debug_inst,
+                   debug_entry(r_idx+2).uop.debug_inst,
+                   debug_entry(r_idx+3).uop.debug_inst,
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-")),
                    Mux(debug_entry(r_idx+1).exception, Str("E"), Str("-")),
                    Mux(debug_entry(r_idx+2).exception, Str("E"), Str("-")),

--- a/src/main/scala/ifu/fetch-monitor.scala
+++ b/src/main/scala/ifu/fetch-monitor.scala
@@ -90,7 +90,7 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
       prev_valid = uop.valid && io.fire
       prev_pc  = uop.pc
       prev_npc = prev_pc + Mux(uop.is_rvc, 2.U, 4.U)
-      val inst = ExpandRVC(uop.inst)
+      val inst = ExpandRVC(uop.debug_inst)
       prev_cfitype = GetCfiType(inst)
       prev_target =
          Mux(prev_cfitype === CfiType.jal,
@@ -119,8 +119,8 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
       val end_idx    = (fetchWidth-1).U - PriorityEncoder(Reverse(valid_mask))
       val end_uop    = io.uops(end_idx)
       val end_pc     = end_uop.pc
-      val end_compressed = end_uop.inst(1,0) =/= 3.U && usingCompressed.B
-      val inst       = ExpandRVC(end_uop.inst)
+      val end_compressed = end_uop.debug_inst(1,0) =/= 3.U && usingCompressed.B
+      val inst       = ExpandRVC(end_uop.debug_inst)
       last_pc := end_pc
       when (end_compressed) {
          last_npc := end_pc + 2.U


### PR DESCRIPTION
We get a vector of instruction bits at rename-1. We write this into a ROB-sized 1R1W memory, and read it at commit. 

Questions:

- Why is it bad to use io.enq.uop.inst in the ROB for handling ma_fetch? We get this in rename-1, so passing the instruction bits into the ROB seems harmless.
- Getting PCs is trickier, since we store them earlier in the FTQ, and a ROB row may contain uops requesting multiple ftq entries. This needs some additional work to make the trace port reasonable, but is not necessary for RoCC.
- Also is it possible for the FTQ to dequeue entries early? What happens when two uops share the same FTQ entry, and the first is committed before the second? When the first commits, the ROB sends the ftq commit signals. When the second instruction needs to look up its ftq entry, isn't it possible for some other PC to have been written there?