### PR TITLE
named fb/ftq rams | named issue queues | renamed regfile

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -114,7 +114,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                           }
                           else
                           {
-                              Module(new RegisterFileBehavorial(numIntPhysRegs,
+                              Module(new RegisterFileSynthesizable(numIntPhysRegs,
                                  num_irf_read_ports,
                                  num_irf_write_ports + 1, // + 1 for ll writebacks
                                  xLen,

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -64,7 +64,8 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
    val issue_unit       = Module(new IssueUnitCollasping(
                            issueParams.find(_.iqType == IQT_FP.litValue).get,
                            num_wakeup_ports))
-   val fregfile         = Module(new RegisterFileBehavorial(numFpPhysRegs,
+   issue_unit.suggestName("fp_issue_unit")
+   val fregfile         = Module(new RegisterFileSynthesizable(numFpPhysRegs,
                                  exe_units.num_frf_read_ports,
                                  exe_units.num_frf_write_ports + 1, // + 1 for ll writeback
                                  fLen+1,

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -61,7 +61,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
    // construct all of the modules
 
    val exe_units        = new boom.exu.ExecutionUnits(fpu=true)
-   val issue_unit       = Module(new IssueUnitCollasping(
+   val issue_unit       = Module(new IssueUnitCollapsing(
                            issueParams.find(_.iqType == IQT_FP.litValue).get,
                            num_wakeup_ports))
    issue_unit.suggestName("fp_issue_unit")

--- a/src/main/scala/exu/issue-units/issue-unit-age-ordered.scala
+++ b/src/main/scala/exu/issue-units/issue-unit-age-ordered.scala
@@ -28,7 +28,7 @@ import boom.common._
  * @param params issue queue params
  * @param num_wakeup_ports number of wakeup ports for the issue queue
  */
-class IssueUnitCollasping(
+class IssueUnitCollapsing(
    params: IssueParams,
    num_wakeup_ports: Int)
    (implicit p: Parameters)

--- a/src/main/scala/exu/issue-units/issue-units.scala
+++ b/src/main/scala/exu/issue-units/issue-units.scala
@@ -52,12 +52,19 @@ class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters)
 
    for (issueParam <- issueParams.filter(_.iqType != IQT_FP.litValue))
    {
-      val issueUnit = Module(new IssueUnitCollasping(issueParam, num_wakeup_ports))
+      val issueUnit = Module(new IssueUnitCollapsing(issueParam, num_wakeup_ports))
 
       // name the issue units
       if (issueParam.iqType == IQT_INT.litValue)
       {
-        issueUnit.suggestName("int_issue_unit")
+        if (usingUnifiedMemIntIQs)
+        {
+          issueUnit.suggestName("intmem_issue_unit")
+        }
+        else
+        {
+          issueUnit.suggestName("int_issue_unit")
+        }
       }
       else if (issueParam.iqType == IQT_MEM.litValue)
       {

--- a/src/main/scala/exu/issue-units/issue-units.scala
+++ b/src/main/scala/exu/issue-units/issue-units.scala
@@ -50,9 +50,21 @@ class IssueUnits(num_wakeup_ports: Int)(implicit val p: Parameters)
 
    require (enableAgePriorityIssue) // unordered is currently unsupported.
 
-   for (issParam <- issueParams.filter(_.iqType != IQT_FP.litValue))
+   for (issueParam <- issueParams.filter(_.iqType != IQT_FP.litValue))
    {
-      iss_units += Module(new IssueUnitCollasping(issParam, num_wakeup_ports))
+      val issueUnit = Module(new IssueUnitCollasping(issueParam, num_wakeup_ports))
+
+      // name the issue units
+      if (issueParam.iqType == IQT_INT.litValue)
+      {
+        issueUnit.suggestName("int_issue_unit")
+      }
+      else if (issueParam.iqType == IQT_MEM.litValue)
+      {
+        issueUnit.suggestName("mem_issue_unit")
+      }
+
+      iss_units += issueUnit
    }
 
    def mem_iq = if (usingUnifiedMemIntIQs)

--- a/src/main/scala/exu/register-read/regfile.scala
+++ b/src/main/scala/exu/register-read/regfile.scala
@@ -98,7 +98,7 @@ abstract class RegisterFile(
 }
 
 /**
- * A behavorial model of a Register File. You will likely want to blackbox this for more than modest port counts.
+ * A synthesizable model of a Register File. You will likely want to blackbox this for more than modest port counts.
  *
  * @param num_registers number of registers
  * @param num_read_ports number of read ports
@@ -106,7 +106,7 @@ abstract class RegisterFile(
  * @param register_width size of registers in bits
  * @param bypassable_array list of write ports from func units to the read port of the regfile
  */
-class RegisterFileBehavorial(
+class RegisterFileSynthesizable(
    num_registers: Int,
    num_read_ports: Int,
    num_write_ports: Int,

--- a/src/main/scala/ifu/fetch-buffer.scala
+++ b/src/main/scala/ifu/fetch-buffer.scala
@@ -55,6 +55,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    require (num_entries > 1)
    private val num_elements = num_entries*fetchWidth
    private val ram = Mem(num_elements, new MicroOp())
+   ram.suggestName("fb_uop_ram")
    private val write_ptr = RegInit(0.U(log2Ceil(num_elements).W))
    private val read_ptr = RegInit(0.U(log2Ceil(num_elements).W))
 

--- a/src/main/scala/ifu/fetch-target-queue.scala
+++ b/src/main/scala/ifu/fetch-target-queue.scala
@@ -135,6 +135,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
    val commit_ptr = RegInit(0.asUInt(log2Ceil(num_entries).W))
 
    val ram = Mem(num_entries, new FTQBundle())
+   ram.suggestName("ftq_bundle_ram")
    val cfi_info = Reg(Vec(num_entries, new CfiMissInfo()))
 
    private def initCfiInfo(br_seen: Bool, cfi_idx: UInt): CfiMissInfo =


### PR DESCRIPTION
- Renamed RegFile from `Behavioral` to `Synthesizable` since "behavioral" normally indicates that the instance cannot be synthesized. 
- Named all issue units so that it is easier to read the output verilog signals
- Named FTQ and FB ram so that it is easier to read the output verilog signals