### PR TITLE
Revert "Do not connect the PTW if not usingPTW"

### DIFF
--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -191,11 +191,7 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   outer.dcache.module.io.hartid := constants.hartid
   dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
   //fpuOpt foreach { fpu => core.io.fpu <> fpu.io } RocketFpu - not needed in boom
-  core.io.ptw := DontCare
-  if (usingPTW)
-  {
-    core.io.ptw <> ptw.io.dpath
-  }
+  core.io.ptw <> ptw.io.dpath
   core.io.rocc := DontCare
   core.io.fpu := DontCare
   core.io.reset_vector := DontCare
@@ -223,11 +219,8 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   // TODO figure out how to move the below into their respective mix-ins
   dcacheArb.io.requestor <> dcachePorts
   ptwPorts += core.io.ptw_tlb
-  core.io.ptw_tlb := DontCare
-  if (usingPTW)
-  {
-    ptw.io.requestor <> ptwPorts
-  }
+  ptw.io.requestor <> ptwPorts
+
   val frontendStr = outer.frontend.module.toString
   ElaborationArtefacts.add(
     """core.config""",

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -194,7 +194,7 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   core.io.ptw := DontCare
   if (usingPTW)
   {
-    core.io.ptw <> ptw.get.io.dpath
+    core.io.ptw <> ptw.io.dpath
   }
   core.io.rocc := DontCare
   core.io.fpu := DontCare
@@ -226,7 +226,7 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   core.io.ptw_tlb := DontCare
   if (usingPTW)
   {
-    ptw.get.io.requestor <> ptwPorts
+    ptw.io.requestor <> ptwPorts
   }
   val frontendStr = outer.frontend.module.toString
   ElaborationArtefacts.add(

--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -68,7 +68,8 @@ trait CanHaveBoomPTWModule extends HasBoomHellaCacheModule
 {
   val outer: CanHaveBoomPTW
   val ptwPorts = ListBuffer(outer.dcache.module.io.ptw)
-  val ptw = if (outer.usingPTW) Module(new PTW(outer.nPTWPorts)(outer.dcache.node.edges.out(0), outer.p)) else null
+  val ptw = Module(new PTW(outer.nPTWPorts)(outer.dcache.node.edges.out(0), outer.p))
+  ptw.io <> DontCare // Is overridden below if PTW is connected
   if (outer.usingPTW)
   {
     dcachePorts += ptw.io.mem

--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -11,7 +11,6 @@ import scala.collection.mutable.ListBuffer
 
 import chisel3._
 
-import freechips.rocketchip.util._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule}
 import freechips.rocketchip.rocket.{DCache, HellaCache, HellaCacheArbiter, HellaCacheIO, NonBlockingDCache, PTW}
@@ -69,10 +68,10 @@ trait CanHaveBoomPTWModule extends HasBoomHellaCacheModule
 {
   val outer: CanHaveBoomPTW
   val ptwPorts = ListBuffer(outer.dcache.module.io.ptw)
-  val ptw: Option[PTW] = (outer.usingPTW).option(Module(new PTW(outer.nPTWPorts)(outer.dcache.node.edges.out(0), outer.p)))
+  val ptw = if (outer.usingPTW) Module(new PTW(outer.nPTWPorts)(outer.dcache.node.edges.out(0), outer.p)) else null
   if (outer.usingPTW)
   {
-    dcachePorts += ptw.get.io.mem
+    dcachePorts += ptw.io.mem
   }
 }
 


### PR DESCRIPTION
Reverts riscv-boom/riscv-boom#198

The issue is that when synthesizing without PTW's, it optimizes out all of the core. So I am going to revert this until we know how to properly disconnect the PTW's.