### PR TITLE
cleanup elab prints | add option for null btb | misc comments

### DIFF
--- a/src/main/scala/bpu/bpd-pipeline.scala
+++ b/src/main/scala/bpu/bpd-pipeline.scala
@@ -38,16 +38,16 @@ import boom.exu.BranchUnitResp
  */
 class BranchPredInfo(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val btb_blame         = Bool() // Does the BTB get credit for the prediction? (during BRU check).
-   val btb_hit           = Bool() // this instruction was the br/jmp predicted by the BTB
-   val btb_taken         = Bool() // this instruction was the br/jmp predicted by the BTB and was taken
+   val btb_blame = Bool() // Does the BTB get credit for the prediction? (during BRU check).
+   val btb_hit   = Bool() // this instruction was the br/jmp predicted by the BTB
+   val btb_taken = Bool() // this instruction was the br/jmp predicted by the BTB and was taken
 
-   val bpd_blame         = Bool() // Does the BPD get credit for this prediction? (during BRU check).
-   val bpd_hit           = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
-   val bpd_taken         = Bool() // did the bpd predict taken for this instruction?
+   val bpd_blame = Bool() // Does the BPD get credit for this prediction? (during BRU check).
+   val bpd_hit   = Bool() // did the bpd predict this instruction? (ie, tag hit in the BPD)
+   val bpd_taken = Bool() // did the bpd predict taken for this instruction?
 
-   val bim_resp         = new BimResp
-   val bpd_resp         = new BpdResp
+   val bim_resp  = new BimResp
+   val bpd_resp  = new BpdResp
 }
 
 /**
@@ -209,8 +209,8 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
       assert (io.f2_valid, "[bpd-pipeline] BTB has a valid request but imem.resp is invalid.")
    }
 
-   // forward progress into F3 will be made.
-   when (io.f2_valid)
+   // forward progress into F3 will be made assuming the BTB is giving valid resp
+   when (io.f2_valid && btb.io.resp.valid)
    {
       assert (btb.io.resp.bits.fetch_pc(15,0) === io.debug_imemresp_pc(15,0),
          "[bpd-pipeline] mismatch between BTB and I$.")
@@ -221,5 +221,5 @@ class BranchPredictionStage(fetch_width: Int)(implicit p: Parameters) extends Bo
       assert (!(io.f2_btb_resp.valid), "[bpd_pipeline] BTB predicted, but it's been disabled.")
    }
 
-   override def toString: String = btb.toString + "\n" + bpd.toString
+   override def toString: String = btb.toString + "\n\n" + bpd.toString
 }

--- a/src/main/scala/bpu/bpd/gshare/gshare.scala
+++ b/src/main/scala/bpu/bpd/gshare/gshare.scala
@@ -259,7 +259,7 @@ class GShareBrPredictor(
    }
 
    override def toString: String =
-      "\n   ==GShare==" +
+      "   ==GShare BPU==" +
       "\n   (" + (nSets * fetch_width * 2/8/1024) +
       " kB) GShare Predictor, with " + history_length + " bits of history for (" +
       fetch_width + "-wide fetch) and " + nSets + " entries."

--- a/src/main/scala/bpu/bpd/simple-predictors/base-only.scala
+++ b/src/main/scala/bpu/bpd/simple-predictors/base-only.scala
@@ -93,5 +93,6 @@ class BaseOnlyBrPredictor(
 
    // Nothing to update, as the BIM is handled externally.
 
-   override def toString: String = "  Building no predictor (just using BIM as a base predictor)."
+   override def toString: String = "   ==Base Only BPU==" +
+     "\n   Building no predictor (just using BIM as a base predictor)."
 }

--- a/src/main/scala/bpu/bpd/simple-predictors/simple-predictors.scala
+++ b/src/main/scala/bpu/bpd/simple-predictors/simple-predictors.scala
@@ -27,7 +27,7 @@ import boom.exu.BranchUnitResp
 import boom.util.ElasticReg
 
 /**
- * Create a null branch predictor that makes no predictions
+ * A null branch predictor that makes no predictions
  *
  * @param fetch_width # of instructions fetched
  * @param history_length length of the BHR in bits
@@ -37,7 +37,8 @@ class NullBrPredictor(
    history_length: Int = 12
    )(implicit p: Parameters) extends BoomBrPredictor(fetch_width, history_length)(p)
 {
-   override def toString: String = "  Building (0 kB) Null Predictor (never predict)."
+   override def toString: String = "   ==Null BPU==" +
+     "\n   Building (0 kB) Null Predictor (never predict)."
    io.resp.valid := false.B
 }
 
@@ -72,7 +73,8 @@ class RandomBrPredictor(
    fetch_width: Int
    )(implicit p: Parameters) extends BoomBrPredictor(fetch_width, history_length = 1)(p)
 {
-   override def toString: String = "  Building Random Branch Predictor."
+   override def toString: String = "   ==Random BPU==" +
+     "\n  Building Random Branch Predictor."
    private val rand_val = RegInit(false.B)
    rand_val := ~rand_val
    private var lfsr= LFSR16(true.B)

--- a/src/main/scala/bpu/bpd/tage/tage.scala
+++ b/src/main/scala/bpu/bpd/tage/tage.scala
@@ -510,7 +510,7 @@ class TageBrPredictor(
    }
 
    override def toString: String =
-      "\n   ==TAGE==" +
+      "   ==TAGE BPU==" +
       "\n   " + (size_in_bits/8/1024.0) + " kB TAGE Predictor (" +
       (size_in_bits/1024) + " Kbits) (max history length: " + history_lengths.max + " bits)\n" +
       tables.mkString("\n")

--- a/src/main/scala/bpu/btb/bim.scala
+++ b/src/main/scala/bpu/btb/bim.scala
@@ -364,7 +364,7 @@ class BimodalTable(implicit p: Parameters) extends BoomModule()(p) with HasBimPa
 
    val size_kbits = nSets * fetchWidth * 2/1024 // assumes 2 bits / fetchWidth
    override def toString: String =
-      "\n   ==BIM==" +
+      "   ==BIM==" +
       "\n   (" + size_kbits + " Kbits = " + size_kbits/8 + " kB) Bimodal Table (" +
       nSets + " entries across " + nBanks + " banks)"
 }

--- a/src/main/scala/bpu/btb/btb-sa.scala
+++ b/src/main/scala/bpu/btb/btb-sa.scala
@@ -38,7 +38,12 @@ import freechips.rocketchip.util.Str
 import boom.common._
 import boom.exu._
 
-// Set-associative branch target buffer.
+/**
+ * Normal set-associative branch target buffer. Checks an incoming
+ * address against the BTB, returns a target if any, then uses
+ * a bi-modal table to determine whether the prediction is taken or not
+ * taken.
+ */
 class BTBsa(implicit p: Parameters) extends BoomBTB
 {
    val bim = Module(new BimodalTable())
@@ -51,6 +56,9 @@ class BTBsa(implicit p: Parameters) extends BoomBTB
    private def getTag (addr: UInt): UInt = addr(tag_sz+idx_sz+lsb_sz-1, idx_sz+lsb_sz)
    private def getIdx (addr: UInt): UInt = addr(idx_sz+lsb_sz-1, lsb_sz)
 
+   /**
+    * Data stored in the BTB entry
+    */
    class BTBSetData extends Bundle
    {
       val target = UInt((vaddrBits - log2Ceil(coreInstBytes)).W)
@@ -215,10 +223,10 @@ class BTBsa(implicit p: Parameters) extends BoomBTB
    }
 
    override def toString: String =
-      "\n   ==BTB==" +
+      "   ==BTB-SA==" +
       "\n   Sets          : " + nSets +
       "\n   Ways          : " + nWays +
-      "\n   Tag Size      : " + tag_sz + "\n" +
+      "\n   Tag Size      : " + tag_sz +
+      "\n\n" +
       bim.toString
 }
-

--- a/src/main/scala/bpu/btb/btb.scala
+++ b/src/main/scala/bpu/btb/btb.scala
@@ -44,6 +44,7 @@ import freechips.rocketchip.util.Str
  * @param offsetSz offset size for the DenseBTB
  * @param bypassCalls bypass RAS update to the BTB resp target
  * @param rasCheckForEmpty check if RAS is empty before reading
+ * @param numBufferEntries num entries for the BTB update queue
  */
 case class BoomBTBParameters(
    btbsa: Boolean = false,
@@ -58,6 +59,7 @@ case class BoomBTBParameters(
    // Extra knobs
    bypassCalls: Boolean = true,
    rasCheckForEmpty: Boolean = true,
+   numBufferEntries: Int = 8
 )
 
 /**
@@ -75,6 +77,7 @@ trait HasBoomBTBParameters extends HasBoomCoreParameters
    val idx_sz = log2Ceil(nSets)
    val bypassCalls = btbParams.bypassCalls
    val rasCheckForEmpty = btbParams.rasCheckForEmpty
+   val num_buff_entries = btbParams.numBufferEntries
 }
 
 /**

--- a/src/main/scala/bpu/btb/dense-btb.scala
+++ b/src/main/scala/bpu/btb/dense-btb.scala
@@ -433,12 +433,13 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
    }
 
    override def toString: String =
-      "\n   ==Dense BTB==" +
+      "   ==Dense BTB==" +
       "\n   Sets          : " + nSets +
       "\n   Banks         : " + nBanks +
       "\n   Ways          : " + nWays +
       "\n   Branch Levels : " + branch_levels +
       "\n   Tag Size      : " + tag_sz +
-      "\n   Offset Size   : " + offset_sz + "\n" +
+      "\n   Offset Size   : " + offset_sz +
+      "\n\n" +
       bim.toString
 }

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -44,6 +44,7 @@ case class BoomCoreParams(
    enableCommitMapTable: Boolean = false,
    enableBTBContainsBranches: Boolean = true,
    enableBranchPredictor: Boolean = true,
+   enableBTB: Boolean = true,
    enableBpdUModeOnly: Boolean = false,
    enableBpdUSModeHistory: Boolean = false,
    useAtomicsOnlyForIO: Boolean = false,
@@ -175,7 +176,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    //************************************
    // Branch Prediction
 
-   val enableBTB = true
+   val enableBTB = boomParams.enableBTB
    val enableBTBContainsBranches = boomParams.enableBTBContainsBranches
 
    val ENABLE_BRANCH_PREDICTOR = boomParams.enableBranchPredictor

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -375,40 +375,41 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    val rob_str = rob.toString
 
    override def toString: String =
-   ( exe_units_str + "\n"
-   + fp_pipeline_str + "\n"
-   + rob_str + "\n"
-   + (if (usingFPU)      ("\n    FPU Unit Enabled") else  ("\n    FPU Unit Disabled"))
-   + (if (usingVM)       ("\n    VM       Enabled") else  ("\n    VM       Disabled"))
-   + (if (usingFDivSqrt) ("\n    FDivSqrt Enabled") else  ("\n    FDivSqrt Disabled"))
-   + "\n\n   Fetch Width           : " + fetchWidth
-   + "\n   Decode Width          : " + decodeWidth
-   + "\n   Issue Width           : " + issueParams.map(_.issueWidth).sum
-   + "\n   ROB Size              : " + NUM_ROB_ENTRIES
-   + "\n   Issue Window Size     : " + issueParams.map(_.numEntries) + iss_str
-   + "\n   Load/Store Unit Size  : " + NUM_LDQ_ENTRIES + "/" + NUM_STQ_ENTRIES
-   + "\n   Num Int Phys Registers: " + numIntPhysRegs
-   + "\n   Num FP  Phys Registers: " + numFpPhysRegs
-   + "\n   Max Branch Count      : " + MAX_BR_COUNT
-   + "\n   BTB Size              : " +
-      (if (enableBTB) ("" + boomParams.btb.nSets * boomParams.btb.nWays + " entries (" +
-         boomParams.btb.nSets + " x " + boomParams.btb.nWays + " ways)") else 0)
-   + "\n   RAS Size              : " + (if (enableBTB) boomParams.btb.nRAS else 0)
-   + "\n   Rename  Stage Latency : " + renameLatency
-   + "\n   RegRead Stage Latency : " + regreadLatency
-   + "\n" + iregfile.toString
-   + "\n   Num Slow Wakeup Ports : " + num_irf_write_ports
-   + "\n   Num Fast Wakeup Ports : " + exe_units.count(_.bypassable)
-   + "\n   Num Bypass Ports      : " + exe_units.num_total_bypass_ports
-   + "\n" + (if (usingFPU) fp_pipeline.toString else "")
-   + "\n   DCache Ways           : " + dcacheParams.nWays
-   + "\n   DCache Sets           : " + dcacheParams.nSets
-   + "\n   ICache Ways           : " + icacheParams.nWays
-   + "\n   ICache Sets           : " + icacheParams.nSets
-   + "\n   D-TLB Entries         : " + dcacheParams.nTLBEntries
-   + "\n   I-TLB Entries         : " + icacheParams.nTLBEntries
-   + "\n   Paddr Bits            : " + paddrBits
-   + "\n   Vaddr Bits            : " + vaddrBits)
+     ( exe_units_str + "\n"
+     + fp_pipeline_str + "\n"
+     + rob_str + "\n"
+     + "\n   ==Overall Core Params=="
+     + "\n   Fetch Width           : " + fetchWidth
+     + "\n   Decode Width          : " + decodeWidth
+     + "\n   Issue Width           : " + issueParams.map(_.issueWidth).sum
+     + "\n   ROB Size              : " + NUM_ROB_ENTRIES
+     + "\n   Issue Window Size     : " + issueParams.map(_.numEntries) + iss_str
+     + "\n   Load/Store Unit Size  : " + NUM_LDQ_ENTRIES + "/" + NUM_STQ_ENTRIES
+     + "\n   Num Int Phys Registers: " + numIntPhysRegs
+     + "\n   Num FP  Phys Registers: " + numFpPhysRegs
+     + "\n   Max Branch Count      : " + MAX_BR_COUNT
+     + "\n   BTB Size              : "
+     + (if (enableBTB) ("" + boomParams.btb.nSets * boomParams.btb.nWays + " entries (" +
+          boomParams.btb.nSets + " x " + boomParams.btb.nWays + " ways)") else 0)
+     + "\n   RAS Size              : " + (if (enableBTB) boomParams.btb.nRAS else 0)
+     + "\n   Rename  Stage Latency : " + renameLatency
+     + "\n   RegRead Stage Latency : " + regreadLatency
+     + "\n" + iregfile.toString
+     + "\n   Num Slow Wakeup Ports : " + num_irf_write_ports
+     + "\n   Num Fast Wakeup Ports : " + exe_units.count(_.bypassable)
+     + "\n   Num Bypass Ports      : " + exe_units.num_total_bypass_ports
+     + "\n" + (if (usingFPU) fp_pipeline.toString else "")
+     + "\n   DCache Ways           : " + dcacheParams.nWays
+     + "\n   DCache Sets           : " + dcacheParams.nSets
+     + "\n   ICache Ways           : " + icacheParams.nWays
+     + "\n   ICache Sets           : " + icacheParams.nSets
+     + "\n   D-TLB Entries         : " + dcacheParams.nTLBEntries
+     + "\n   I-TLB Entries         : " + icacheParams.nTLBEntries
+     + "\n   Paddr Bits            : " + paddrBits
+     + "\n   Vaddr Bits            : " + vaddrBits
+     + "\n\n   Using FPU Unit?       : " + usingFPU.toString
+     + "\n   Using FDivSqrt?       : " + usingFDivSqrt.toString
+     + "\n   Using VM?             : " + usingVM.toString)
 
    //-------------------------------------------------------------
    //-------------------------------------------------------------

--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -217,12 +217,12 @@ class ALUExeUnit(
       "TODO. Currently do not support AluMemExeUnit with FP")
 
    val out_str = new StringBuilder
-   out_str.append("\n     ExeUnit--")
-   if (has_alu)  out_str.append("\n       - ALU")
-   if (has_mul)  out_str.append("\n       - Mul")
-   if (has_div)  out_str.append("\n       - Div")
-   if (has_ifpu) out_str.append("\n       - IFPU")
-   if (has_mem)  out_str.append("\n       - Mem")
+   out_str.append("\n   ==ExeUnit==")
+   if (has_alu)  out_str.append("\n     - ALU")
+   if (has_mul)  out_str.append("\n     - Mul")
+   if (has_div)  out_str.append("\n     - Div")
+   if (has_ifpu) out_str.append("\n     - IFPU")
+   if (has_mem)  out_str.append("\n     - Mem")
    override def toString: String = out_str.toString
 
    val div_busy  = WireInit(false.B)
@@ -463,10 +463,10 @@ class FPUExeUnit(
       has_fpiu = has_fpiu)(p) with tile.HasFPUParameters
 {
    val out_str = new StringBuilder
-   out_str.append("\n     ExeUnit--")
-   if (has_fpu)  out_str.append("\n       - FPU (Latency: " + dfmaLatency + ")")
-   if (has_fdiv) out_str.append("\n       - FDiv/FSqrt")
-   if (has_fpiu) out_str.append("\n       - FPIU (writes to Integer RF)")
+   out_str.append("\n   ==ExeUnit==")
+   if (has_fpu)  out_str.append("\n     - FPU (Latency: " + dfmaLatency + ")")
+   if (has_fdiv) out_str.append("\n     - FDiv/FSqrt")
+   if (has_fpiu) out_str.append("\n     - FPIU (writes to Integer RF)")
 
    val fdiv_busy = WireInit(false.B)
    val fpiu_busy = WireInit(false.B)

--- a/src/main/scala/exu/execution-units/execution-units.scala
+++ b/src/main/scala/exu/execution-units/execution-units.scala
@@ -175,13 +175,12 @@ class ExecutionUnits(fpu: Boolean)(implicit val p: Parameters) extends HasBoomCo
    }
 
    val exe_units_str = new StringBuilder
-   exe_units_str.append(
-      if (!fpu)
-      {
-         ( "\n   ~*** " + Seq("One","Two","Three","Four")(decodeWidth-1) + "-wide Machine ***~\n"
-         + "\n    -== " + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue ==- \n")
-      }
-   )
+   if (!fpu)
+   {
+     exe_units_str.append(
+       ( "\n   ==" + Seq("One","Two","Three","Four")(decodeWidth-1) + "-wide Machine=="
+       + "\n   ==" + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue==\n"))
+   }
 
    for (exe_unit <- exe_units)
    {


### PR DESCRIPTION
Cleaned up comments and added some new ones.
Added option to use a `NullBTB` that makes no predictions (similar to the `NullBrPredictor`).
Cleaned up the parameter printing that happens during elaboration.