### PR TITLE
Rob changes

### DIFF
--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -141,8 +141,8 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    val debug_events     = new DebugStageEvents
 
 
-   // Is it possible for this uop to not commit once it is in the ROB?
-   def may_xcpt         = (is_load || is_store || is_br_or_jmp || exception) && !(is_fence || is_fencei)
+   // Is it possible for this uop to misspeculate, preventing the commit of subsequent uops?
+   def unsafe           = is_load || is_store && !is_fence || is_br_or_jmp && !is_jal
 
    def fu_code_is(_fu: UInt) = fu_code === _fu
 }

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -42,6 +42,7 @@ case class BoomCoreParams(
    enablePrefetching: Boolean = false,
    enableBrResolutionRegister: Boolean = true,
    enableCommitMapTable: Boolean = false,
+   enableFastPNR: Boolean = true,
    enableBTBContainsBranches: Boolean = true,
    enableBranchPredictor: Boolean = false,
    enableBpdUModeOnly: Boolean = false,
@@ -232,6 +233,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    //************************************
    // Extra Knobs and Features
    val ENABLE_COMMIT_MAP_TABLE = boomParams.enableCommitMapTable
+   val enableFastPNR = boomParams.enableFastPNR
 
    //************************************
    // Implicitly calculated constants

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1158,8 +1158,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // LSU <> ROB
    rob.io.lsu_clr_bsy_valid      := lsu.io.clr_bsy_valid
    rob.io.lsu_clr_bsy_rob_idx    := lsu.io.clr_bsy_rob_idx
-   rob.io.lsu_mem_success         := lsu.io.mem_success
-   rob.io.lsu_mem_success_rob_idx := lsu.io.mem_success_rob_idx
+   rob.io.lsu_clr_unsafe_valid   := lsu.io.clr_unsafe_valid
+   rob.io.lsu_clr_unsafe_rob_idx := lsu.io.clr_unsafe_rob_idx
    rob.io.lxcpt <> lsu.io.xcpt
 
    assert (!(csr.io.singleStep), "[core] single-step is unsupported.")

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -642,10 +642,6 @@ class Rob(
    // Exception Tracking Logic
    // only store the oldest exception, since only one can happen!
 
-   // is i0 older than i1? (closest to zero). Provide the tail_ptr to the
-   // queue. This is Cat(i1 <= tail, i1) because the rob_tail can point to a
-   // valid (partially dispatched) row.
-   def IsOlder(i0: UInt, i1: UInt, tail: UInt) = (Cat(i0 <= tail, i0) < Cat(i1 <= tail, i1))
    val next_xcpt_uop = Wire(new MicroOp())
    next_xcpt_uop := r_xcpt_uop
    val enq_xcpts = Wire(Vec(width, Bool()))
@@ -661,10 +657,10 @@ class Rob(
          val load_is_older =
             (io.lxcpt.valid && !io.bxcpt.valid) ||
             (io.lxcpt.valid && io.bxcpt.valid &&
-            IsOlder(io.lxcpt.bits.uop.rob_idx, io.bxcpt.bits.uop.rob_idx, rob_tail_idx))
+            IsOlder(io.lxcpt.bits.uop.rob_idx, io.bxcpt.bits.uop.rob_idx, rob_head_idx))
          val new_xcpt_uop = Mux(load_is_older, io.lxcpt.bits.uop, io.bxcpt.bits.uop)
 
-         when (!r_xcpt_val || IsOlder(new_xcpt_uop.rob_idx, r_xcpt_uop.rob_idx, rob_tail_idx))
+         when (!r_xcpt_val || IsOlder(new_xcpt_uop.rob_idx, r_xcpt_uop.rob_idx, rob_head_idx))
          {
             r_xcpt_val              := true.B
             next_xcpt_uop           := new_xcpt_uop

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -120,9 +120,10 @@ class LoadStoreUnitIO(val pl_width: Int)(implicit p: Parameters) extends BoomBun
    val clr_bsy_valid      = Output(Vec(2, Bool()))
    val clr_bsy_rob_idx    = Output(Vec(2, UInt(ROB_ADDR_SZ.W)))
 
-   // Tell the ROB we've successfully translated this operation
-   val mem_success         = Output(Bool())
-   val mem_success_rob_idx = Output(UInt(ROB_ADDR_SZ.W))
+   // LSU can mark its instructions as speculatively safe in the ROB.
+   val clr_unsafe_valid   = Output(Bool())
+   val clr_unsafe_rob_idx = Output(UInt(ROB_ADDR_SZ.W))
+
    val lsu_fencei_rdy     = Output(Bool())
 
    val xcpt = new ValidIO(new Exception)
@@ -696,6 +697,12 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters,
    val mem_fired_stdf = RegNext(io.fp_stdata.valid, init=false.B)
    val mem_fired_sfence = RegNext(will_fire_sfence, init=false.B)
 
+   // Mark instructions as safe after successful address translation.
+   // Need to delay to same cycle as exception broadcast into ROB to avoid
+   // the PNR 'jumping the gun' over a misspeculated ordering.
+   io.clr_unsafe_valid := RegNext(!mem_tlb_miss && (mem_ld_used_tlb || mem_fired_sta))
+   io.clr_unsafe_rob_idx := RegNext(mem_tlb_uop.rob_idx)
+
    mem_ld_killed := false.B
    when (RegNext(
          (IsKilledByBranch(io.brinfo, exe_ld_uop) ||
@@ -1095,16 +1102,6 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters,
 
    io.xcpt.valid := r_xcpt_valid && !io.exception && !IsKilledByBranch(io.brinfo, r_xcpt.uop)
    io.xcpt.bits := r_xcpt
-
-   // A memory operation can mark its entry in the ROB as "safe" when
-   //  1) it hits in the TLB and does not raise PF or AE xcpt
-   //  2) it does not cause younger load to fail
-   // 2) happens cycle after 1), so we delay accordingly
-   io.mem_success         := RegNext(RegNext(dtlb.io.req.valid) &&
-                                     !mem_xcpt_valid &&
-                                     !RegNext(dtlb.io.resp.miss)) && !failed_loads.reduce(_|_)
-   io.mem_success_rob_idx := RegNext(RegNext(exe_tlb_uop.rob_idx))
-
 
    //-------------------------------------------------------------
    // Kill speculated entries on branch mispredict

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -240,6 +240,18 @@ object WrapDec
 }
 
 /**
+ * Object to determine whether queue
+ * index i0 is older than index i1.
+ */
+object IsOlder
+{
+   def apply(i0: UInt, i1: UInt, head: UInt): Bool =
+   {
+      (i0 < i1) ^ (i0 < head) ^ (i1 < head)
+   }
+}
+
+/**
  * Object to mask off lower bits of a PC to align to a "b"
  * Byte boundary.
  */


### PR DESCRIPTION
Moved IsOlder comparison for wrapping queues to util.scala
The IsOlder comparison for tracking the oldest exception now uses rob_head to disambiguate order instead of rob_tail. Otherwise, an exception in the middle of a partially dispatched rob row (rob width > 2) could erroneously replace an older exception.

General refactor of PNR logic.
- Track "unsafeness" of entries rather than "safeness".
- Don't consider unconditional jumps to known addresses unsafe.
- No reason to check whether an ordering failure occurred before marking a load/store as safe
- Compute pnr_idx on instruction granularity to prevent potential deadlocks with atomic instructions dispatching to an upper column of a rob row, while a resource used by an instruction in a lower column of the same row is being held up by the PNR

Added fast PNR which can jump over large ranges of safe instructions in a cycle.

Let the ROB fill all of its entries.