### PR TITLE
Refactored LDQ/STQ entry allocation logic.

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -606,11 +606,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       // (thus the LSB of the rob_idx gives part of the PC)
       if (coreWidth == 1)
       {
-         dec_uops(w).rob_idx := rob.io.curr_rob_tail_idx
+         dec_uops(w).rob_idx := rob.io.rob_tail_idx
       }
       else
       {
-         dec_uops(w).rob_idx := Cat(rob.io.curr_rob_tail_idx >> log2Ceil(coreWidth).U,
+         dec_uops(w).rob_idx := Cat(rob.io.rob_tail_idx >> log2Ceil(coreWidth).U,
                                     w.U(log2Ceil(coreWidth).W))
       }
    }
@@ -1521,8 +1521,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    {
       exe_units.rocc_unit.io.rocc.rocc         <> io.rocc
       exe_units.rocc_unit.io.rocc.dec_uops     := dec_uops
-      exe_units.rocc_unit.io.rocc.rob_tail_idx := rob.io.curr_rob_tail_idx
-      exe_units.rocc_unit.io.rocc.rob_pnr_idx  := rob.io.curr_rob_pnr_idx
+      exe_units.rocc_unit.io.rocc.rob_head_idx := rob.io.rob_head_idx
+      exe_units.rocc_unit.io.rocc.rob_pnr_idx  := rob.io.rob_pnr_idx
       exe_units.rocc_unit.io.com_exception     := rob.io.com_xcpt.valid
       exe_units.rocc_unit.io.status            := csr.io.status
       for (w <- 0 until coreWidth)

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -526,8 +526,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                         || (dec_uops(w).is_unique &&
                            (!(rob.io.empty) || !lsu.io.lsu_fencei_rdy || prev_insts_in_bundle_valid))
                         || !rob.io.ready
-                        || lsu.io.laq_full
-                        || lsu.io.stq_full
+                        || lsu.io.laq_full(w) && dec_uops(w).is_load
+                        || lsu.io.stq_full(w) && dec_uops(w).is_store
                         || branch_mask_full(w)
                         || br_unit.brinfo.mispredict
                         || rob.io.flush.valid
@@ -540,7 +540,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
       // stall the next instruction following me in the decode bundle?
       dec_last_inst_was_stalled = stall_me
-      dec_stall_next_inst  = stall_me || (dec_valids(w) && dec_uops(w).is_unique)
+      dec_stall_next_inst = stall_me || (dec_valids(w) && dec_uops(w).is_unique)
       dec_rocc_found = dec_rocc_found || (dec_valids(w) && dec_uops(w).uopc === uopROCC)
 
       dec_will_fire(w) := dec_valids(w) && !stall_me && !io.ifu.clear_fetchbuffer
@@ -580,20 +580,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //-------------------------------------------------------------
    // LD/ST Unit Allocation Logic
 
-   // TODO this is dupliciated logic with the the LSU... do we need ldq_idx/stq elsewhere?
-   val new_ldq_idx = Wire(UInt())
-   val new_stq_idx = Wire(UInt())
-
-   var new_lidx = new_ldq_idx
-   var new_sidx = new_stq_idx
-
-   for (w <- 0 until coreWidth)
+   for (w <- 0 until decodeWidth)
    {
-      dec_uops(w).ldq_idx := new_lidx
-      dec_uops(w).stq_idx := new_sidx
-
-      new_lidx = Mux(dec_will_fire(w) && dec_uops(w).is_load,  WrapInc(new_lidx, NUM_LDQ_ENTRIES), new_lidx)
-      new_sidx = Mux(dec_will_fire(w) && dec_uops(w).is_store, WrapInc(new_sidx, NUM_STQ_ENTRIES), new_sidx)
+      dec_uops(w).ldq_idx := lsu.io.new_ldq_idx(w)
+      dec_uops(w).stq_idx := lsu.io.new_stq_idx(w)
    }
 
    //-------------------------------------------------------------
@@ -992,12 +982,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    for (w <- 0 until coreWidth)
    {
-      lsu.io.dec_st_vals(w) := dec_will_fire(w) && rename_stage.io.inst_can_proceed(w) && !rob.io.flush.valid &&
-                               dec_uops(w).is_store
-      lsu.io.dec_ld_vals(w) := dec_will_fire(w) && rename_stage.io.inst_can_proceed(w) && !rob.io.flush.valid &&
-                               dec_uops(w).is_load
+      // Decoding instructions request load/store queue entries when they can proceed.
+      lsu.io.dec_ld_vals(w) := dec_will_fire(w) && dec_uops(w).is_load
+      lsu.io.dec_st_vals(w) := dec_will_fire(w) && dec_uops(w).is_store
 
-      lsu.io.dec_uops(w).rob_idx := dec_uops(w).rob_idx // for debug purposes (comit logging)
+      lsu.io.dec_uops(w).rob_idx := dec_uops(w).rob_idx // for debug purposes (commit logging)
    }
 
    lsu.io.commit_store_mask := rob.io.commit.st_mask
@@ -1010,9 +999,6 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // Handle Branch Mispeculations
    lsu.io.brinfo := br_unit.brinfo
    dc_shim.io.core.brinfo := br_unit.brinfo
-
-   new_ldq_idx := lsu.io.new_ldq_idx
-   new_stq_idx := lsu.io.new_stq_idx
 
    lsu.io.debug_tsc := debug_tsc_reg
 
@@ -1338,8 +1324,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                 Mux(rob.io.debug.state === 3.U, Str("W"),
                                                     Str(" "))))),
                 Mux(rob.io.ready,Str("_"), Str("!")),
-                Mux(lsu.io.laq_full, Str("L"), Str("_")),
-                Mux(lsu.io.stq_full, Str("S"), Str("_")),
+                Mux(lsu.io.laq_full(0), Str("L"), Str("_")),
+                Mux(lsu.io.stq_full(0), Str("S"), Str("_")),
                 Mux(rob.io.flush.valid, Str("F"), Str(" ")),
                 Mux(branch_mask_full.reduce(_|_), Str("B"), Str(" ")),
                 Mux(dc_shim.io.core.req.ready, Str("R"), Str("B")),

--- a/src/main/scala/exu/execution-units/rocc.scala
+++ b/src/main/scala/exu/execution-units/rocc.scala
@@ -37,7 +37,7 @@ class RoCCShimCoreIO(implicit p: Parameters) extends BoomBundle()(p)
   val rxq_empty        = Output(Bool())
   val rxq_idx          = Output(UInt(log2Ceil(NUM_RXQ_ENTRIES).W))
   val rob_pnr_idx      = Input(UInt(ROB_ADDR_SZ.W))
-  val rob_tail_idx     = Input(UInt(ROB_ADDR_SZ.W))
+  val rob_head_idx     = Input(UInt(ROB_ADDR_SZ.W))
 
   val rocc             = Flipped(new RoCCCoreIO)
 }
@@ -126,7 +126,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule()(p)
   // Commit
   when (rxq_op_val(rxq_com_head) &&
         rxq_val   (rxq_com_head) &&
-        IsOlder(rxq_uop(rxq_com_head).rob_idx, io.core.rob_pnr_idx, io.core.rob_tail_idx)) {
+        IsOlder(rxq_uop(rxq_com_head).rob_idx, io.core.rob_pnr_idx, io.core.rob_head_idx)) {
     rxq_committed(rxq_com_head) := true.B
     rxq_com_head                  := WrapInc(rxq_com_head, NUM_RXQ_ENTRIES)
   }

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -1047,7 +1047,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters,
    }
       .elsewhen (do_ldld_search)
       {
-         val searcher_is_older = IsOlder(lcam_ldq_idx, i.U, laq_tail)
+         val searcher_is_older = IsOlder(lcam_ldq_idx, i.U, laq_head)
 
          // Does the load entry depend on the searching load?
          // Aka, is the searching load older than the load entry?

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -352,7 +352,7 @@ object AgePriorityEncoder
  */
 object IsOlder
 {
-   def apply(i0: UInt, i1: UInt, tail: UInt) = (Cat(i0 <= tail, i0) < Cat(i1 <= tail, i1))
+   def apply(i0: UInt, i1: UInt, head: UInt) = ((i0 < i1) ^ (i0 < head) ^ (i1 < head))
 }
 
 


### PR DESCRIPTION
LDQ and STQ will try to fill all entries. Decode is only stalled when at least one load or store cannot be allocated an entry.