### PR TITLE
Work towards splitting away LSU and DCacheShim

### DIFF
--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -189,7 +189,9 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   outer.frontend.module.io.reset_vector := constants.reset_vector
   outer.frontend.module.io.hartid := constants.hartid
   outer.dcache.module.io.hartid := constants.hartid
-  dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
+
+  dc_shim.io.core <> core.io.dmem
+  dcachePorts += dc_shim.io.dmem
   //fpuOpt foreach { fpu => core.io.fpu <> fpu.io } RocketFpu - not needed in boom
   core.io.ptw <> ptw.io.dpath
   core.io.rocc := DontCare

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -192,6 +192,7 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
 
   dc_shim.io.core <> core.io.dmem
   dcachePorts += dc_shim.io.dmem
+  core.io.dc_perf <> dc_shim.io.dmem.perf
   //fpuOpt foreach { fpu => core.io.fpu <> fpu.io } RocketFpu - not needed in boom
   core.io.ptw <> ptw.io.dpath
   core.io.rocc := DontCare

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -69,7 +69,7 @@ class BoomTile(
     with HasExternalInterrupts
     //with HasLazyRoCC  // implies CanHaveSharedFPU with CanHavePTW with HasHellaCache
     with CanHaveBoomPTW
-    with HasBoomHellaCache
+    with HasBoomLSU
     with HasBoomICacheFrontend
 {
 
@@ -156,7 +156,7 @@ class BoomTile(
 class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
     //with HasLazyRoCCModule[BoomTile]
     with CanHaveBoomPTWModule
-    with HasBoomHellaCacheModule
+    with HasBoomLSUModule
     with HasBoomICacheFrontendModule
 {
   Annotated.params(this, outer.boomParams)

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -795,9 +795,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       !mem_iq.io.iss_uops(0).fp_val &&
       mem_iq.io.iss_uops(0).pdst =/= 0.U &&
       !(sxt_ldMiss && (mem_iq.io.iss_uops(0).iw_p1_poisoned || mem_iq.io.iss_uops(0).iw_p2_poisoned))
-   sxt_ldMiss :=
-      ((lsu.io.nack.valid && lsu.io.nack.isload) || dc_shim.io.core.load_miss) &&
-      Pipe(true.B, iss_loadIssued, 4).bits
+   sxt_ldMiss := lsu.io.ld_miss && Pipe(true.B, iss_loadIssued, 4).bits
    issue_units.map(_.io.sxt_ldMiss := sxt_ldMiss)
 
    // Check that IF we see a speculative load-wakeup and NO load-miss, then we should

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -999,10 +999,13 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    lsu.io.dmem_is_ordered:= dc_shim.io.core.ordered
    lsu.io.release := io.release
 
+   lsu.io.fp_stdata.valid := false.B
+   lsu.io.fp_stdata.bits  := DontCare
    if (usingFPU)
    {
       lsu.io.fp_stdata <> fp_pipeline.io.tosdq
    }
+
 
    //-------------------------------------------------------------
    //-------------------------------------------------------------

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1297,7 +1297,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
       if (DEBUG_PRINTF_ROB)
       {
-         printf("\n) ctate: (%c: %c %c %c %c %c %c) BMsk:%x Mode:%c\n",
+         printf("\n) ctate: (%c: %c %c %c %c %c) BMsk:%x Mode:%c\n",
                 Mux(rob.io.debug.state === 0.U, Str("R"),
                 Mux(rob.io.debug.state === 1.U, Str("N"),
                 Mux(rob.io.debug.state === 2.U, Str("B"),
@@ -1308,7 +1308,6 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                 Mux(lsu.io.stq_full, Str("S"), Str("_")),
                 Mux(rob.io.flush.valid, Str("F"), Str(" ")),
                 Mux(branch_mask_full.reduce(_|_), Str("B"), Str(" ")),
-                Mux(dc_shim.io.core.req.ready, Str("R"), Str("B")),
                 dec_brmask_logic.io.debug.branch_mask,
                 Mux(csr.io.status.prv === (0x3).U, Str("M"),
                 Mux(csr.io.status.prv === (0x0).U, Str("U"),

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -128,8 +128,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
                                  exe_units.withFilter(_.reads_irf).map(x => 2),
                                  exe_units.num_total_bypass_ports,
                                  xLen))
-   val dc_shim          = Module(new boom.lsu.DCacheShim())
-   val lsu              = Module(new boom.lsu.LoadStoreUnit(decodeWidth))
+   val dc_shim          = Module(new boom.lsu.DCacheShim)
+   val lsu              = Module(new boom.lsu.LoadStoreUnit)
    val rob              = Module(new Rob(
                                  decodeWidth,
                                  NUM_ROB_ENTRIES,

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -980,19 +980,12 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    // Handle Branch Mispeculations
    lsu.io.brinfo := br_unit.brinfo
-   io.dmem.brinfo := br_unit.brinfo
 
    new_ldq_idx := lsu.io.new_ldq_idx
    new_stq_idx := lsu.io.new_stq_idx
 
    lsu.io.debug_tsc := debug_tsc_reg
 
-   io.dmem.flush_pipe := rob.io.flush.valid
-
-   lsu.io.nack <> io.dmem.nack
-
-   lsu.io.dmem_req_ready := io.dmem.req.ready
-   lsu.io.dmem_is_ordered:= io.dmem.ordered
    lsu.io.release := io.release
 
    lsu.io.fp_stdata.valid := false.B

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -177,10 +177,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    // Shim to DCache
    io.dmem <> dc_shim.io.dmem
-   dc_shim.io.core <> exe_units.memory_unit.io.dmem
 
    // Load/Store Unit & ExeUnits
    exe_units.memory_unit.io.lsu_io <> lsu.io
+   dc_shim.io.core <> lsu.io.dmem
 
    // TODO: Generate this in lsu
    val sxt_ldMiss = Wire(Bool())

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -179,7 +179,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    io.dmem <> dc_shim.io.dmem
 
    // Load/Store Unit & ExeUnits
-   exe_units.memory_unit.io.lsu_io <> lsu.io
+   exe_units.memory_unit.io.lsu_io <> lsu.io.exe
    dc_shim.io.core <> lsu.io.dmem
 
    // TODO: Generate this in lsu
@@ -422,11 +422,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    // SFence needs access to the PC to inject an address into the TLB's CAM port. The ROB
    // will have to later redirect the PC back to the regularly scheduled program.
-   io.ifu.sfence_take_pc    := lsu.io.exe_resp.bits.sfence.valid
-   io.ifu.sfence_addr       := lsu.io.exe_resp.bits.sfence.bits.addr
+   io.ifu.sfence_take_pc    := lsu.io.exe.req.bits.sfence.valid
+   io.ifu.sfence_addr       := lsu.io.exe.req.bits.sfence.bits.addr
 
    // We must redirect the PC the cycle after playing the SFENCE game.
-   io.ifu.flush_take_pc     := rob.io.flush.valid || RegNext(lsu.io.exe_resp.bits.sfence.valid)
+   io.ifu.flush_take_pc     := rob.io.flush.valid || RegNext(lsu.io.exe.req.bits.sfence.valid)
 
    // TODO FIX THIS HACK
    // The below code works because of two quirks with the flush mechanism
@@ -459,7 +459,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       (br_unit.brinfo.mispredict && br_unit.brinfo.is_jr &&  csr.io.status.debug)
 
    // Delay sfence to match pushing the sfence.addr into the TLB's CAM port.
-   io.ifu.sfence := RegNext(lsu.io.exe_resp.bits.sfence)
+   io.ifu.sfence := RegNext(lsu.io.exe.req.bits.sfence)
 
    //-------------------------------------------------------------
    //-------------------------------------------------------------

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -60,6 +60,7 @@ trait HasBoomCoreIO extends freechips.rocketchip.tile.HasTileParameters
          val fpu = Flipped(new freechips.rocketchip.tile.FPUCoreIO())
          val rocc = Flipped(new freechips.rocketchip.tile.RoCCCoreIO())
          val ptw_tlb = new freechips.rocketchip.rocket.TLBPTWIO()
+         val dc_perf = Input(new freechips.rocketchip.rocket.HellaCachePerfEvents)
          val trace = Output(Vec(coreParams.retireWidth,
             new freechips.rocketchip.rocket.TracedInstruction))
          val release = Flipped(Valid(new boom.lsu.ReleaseInfo))
@@ -242,10 +243,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       // TODO: Re-enable D$ perf events
      new freechips.rocketchip.rocket.EventSet((mask, hits) => (mask & hits).orR, Seq(
         ("I$ miss",     () => io.ifu.perf.acquire),
-//        ("D$ miss",     () => io.dmem.perf.acquire),
-//        ("D$ release",  () => io.dmem.perf.release),
+        ("D$ miss",     () => io.dc_perf.acquire),
+        ("D$ release",  () => io.dc_perf.release),
         ("ITLB miss",   () => io.ifu.perf.tlbMiss),
-//        ("DTLB miss",   () => io.dmem.perf.tlbMiss),
+        ("DTLB miss",   () => io.dc_perf.tlbMiss),
         ("L2 TLB miss", () => io.ptw.perf.l2miss)))))
 
    val csr = Module(new freechips.rocketchip.rocket.CSRFile(perfEvents))

--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -94,7 +94,7 @@ class ExecutionUnitIO(
    val fcsr_rm = Input(Bits(tile.FPConstants.RM_SZ.W))
 
    // only used by the mem unit
-   val lsu_io = Flipped(new boom.lsu.LoadStoreUnitIO(decodeWidth))
+   val lsu_io = Flipped(new boom.lsu.LoadStoreUnitIO)
    val dmem   = new boom.lsu.DCMemPortIO() // TODO move this out of ExecutionUnit
    val com_exception = Input(Bool())
 }

--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -94,7 +94,7 @@ class ExecutionUnitIO(
    val fcsr_rm = Input(Bits(tile.FPConstants.RM_SZ.W))
 
    // only used by the mem unit
-   val lsu_io = Flipped(new boom.lsu.LoadStoreUnitIO)
+   val lsu_io = Flipped(new boom.lsu.LoadStoreUnitExeUnitIO)
    val com_exception = Input(Bool())
 }
 
@@ -360,8 +360,8 @@ class ALUExeUnit(
       io.bypass <> maddrcalc.io.bypass // TODO this is not where the bypassing should
                                        // occur from, is there any bypassing happening?!
 
-      io.lsu_io.exe_resp.valid := maddrcalc.io.resp.valid
-      io.lsu_io.exe_resp.bits  := maddrcalc.io.resp.bits
+      io.lsu_io.req.valid := maddrcalc.io.resp.valid
+      io.lsu_io.req.bits  := maddrcalc.io.resp.bits
 
       io.ll_iresp <> io.lsu_io.iresp
       assert(io.ll_iresp.ready)

--- a/src/main/scala/exu/execution-units/execution-units.scala
+++ b/src/main/scala/exu/execution-units/execution-units.scala
@@ -140,7 +140,6 @@ class ExecutionUnits(fpu: Boolean)(implicit val p: Parameters) extends HasBoomCo
          has_mem          = usingUnifiedMemIntIQs))
 
       aluExeUnit.io.lsu_io := DontCare
-      aluExeUnit.io.dmem := DontCare
       aluExeUnit.io.get_ftq_pc := DontCare
 
       exe_units += aluExeUnit
@@ -149,7 +148,6 @@ class ExecutionUnits(fpu: Boolean)(implicit val p: Parameters) extends HasBoomCo
       {
          val aluExeUnit = Module(new ALUExeUnit)
 
-         aluExeUnit.io.dmem := DontCare
          aluExeUnit.io.lsu_io := DontCare
          aluExeUnit.io.get_ftq_pc := DontCare
          aluExeUnit.io.status := DontCare
@@ -167,7 +165,6 @@ class ExecutionUnits(fpu: Boolean)(implicit val p: Parameters) extends HasBoomCo
                                                 has_fpiu = (w==0)))
          fpuExeUnit.io.status := DontCare
          fpuExeUnit.io.lsu_io := DontCare
-         fpuExeUnit.io.dmem := DontCare
          fpuExeUnit.io.get_ftq_pc := DontCare
 
          exe_units += fpuExeUnit

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -101,7 +101,7 @@ class LoadStoreUnitIO(implicit p: Parameters) extends BoomBundle()(p)
 
    // Inform core of speculative load wakeups
    val mem_ldSpecWakeup   = Valid(UInt(PREG_SZ.W)) // do NOT send out FP loads.
-
+   val ld_miss            = Output(Bool())
 
    // Commit Stage
    val commit_store_mask  = Input(Vec(DISPATCH_WIDTH, Bool()))
@@ -723,10 +723,13 @@ class LoadStoreUnit(implicit p: Parameters,
       mem_ld_killed := true.B && mem_fired_ld
    }
 
+   // For speculative load wakeups and kills
    io.mem_ldSpecWakeup.valid := RegNext(will_fire_load_incoming
                                      && !io.exe.req.bits.uop.fp_val
                                      && io.exe.req.bits.uop.pdst =/= 0.U, init=false.B)
    io.mem_ldSpecWakeup.bits := mem_ld_uop.pdst
+
+   io.ld_miss := (io.nack.valid && io.nack.isload) || io.dmem.load_miss
 
    // tell the ROB to clear the busy bit on the incoming store
    val clr_bsy_valid = RegInit(false.B)

--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -21,8 +21,8 @@ import freechips.rocketchip.tilelink.TLIdentityNode
 /**
  * Top level mixin to construct a tile with a BOOM HellaCache.
  */
-trait HasBoomHellaCache { this: BaseTile =>
-  val module: HasBoomHellaCacheModule
+trait HasBoomLSU { this: BaseTile =>
+  val module: HasBoomLSUModule
   implicit val p: Parameters
   def findScratchpadFromICache: Option[AddressSet]
   var nDCachePorts = 0
@@ -44,9 +44,9 @@ trait HasBoomHellaCache { this: BaseTile =>
 /**
  * Mixin to construct a tile with a BOOM HellaCache.
  */
-trait HasBoomHellaCacheModule
+trait HasBoomLSUModule
 {
-  val outer: HasBoomHellaCache
+  val outer: HasBoomLSU
   val dcachePorts = ListBuffer[HellaCacheIO]()
   val dcacheArb = Module(new HellaCacheArbiter(outer.nDCachePorts)(outer.p))
   outer.dcache.module.io.cpu <> dcacheArb.io.mem
@@ -55,7 +55,7 @@ trait HasBoomHellaCacheModule
 /**
  * Top level mixin to construct a tile with a BOOM PTW.
  */
-trait CanHaveBoomPTW extends HasTileParameters with HasBoomHellaCache { this: BaseTile =>
+trait CanHaveBoomPTW extends HasTileParameters with HasBoomLSU { this: BaseTile =>
   val module: CanHaveBoomPTWModule
   var nPTWPorts = 1
   nDCachePorts += (if (usingPTW) 1 else 0)
@@ -64,7 +64,7 @@ trait CanHaveBoomPTW extends HasTileParameters with HasBoomHellaCache { this: Ba
 /**
  * Mixin to construct a tile with a BOOM PTW.
  */
-trait CanHaveBoomPTWModule extends HasBoomHellaCacheModule
+trait CanHaveBoomPTWModule extends HasBoomLSUModule
 {
   val outer: CanHaveBoomPTW
   val ptwPorts = ListBuffer(outer.dcache.module.io.ptw)

--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -49,6 +49,9 @@ trait HasBoomLSUModule
   val outer: HasBoomLSU
   val dcachePorts = ListBuffer[HellaCacheIO]()
   val dcacheArb = Module(new HellaCacheArbiter(outer.nDCachePorts)(outer.p))
+
+  val dc_shim = Module(new boom.lsu.DCacheShim()(outer.p))
+
   outer.dcache.module.io.cpu <> dcacheArb.io.mem
 }
 


### PR DESCRIPTION
These changes move the DCacheShim into the Tile, out of the core. Eventually we should be able to choose at configuration between RocketDCache with DCacheShim, or our custom BoomDCache (which uses the DCacheShim interface).

Our custom BoomDCache will also not contain a TLB, or PMPCheckers. This requires that PTW, RoCC, and DTIM memory ops will need to contend with Core memory ops. 