### PR TITLE
Config fixes

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -15,13 +15,14 @@ import freechips.rocketchip.devices.tilelink.{BootROMParams}
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile._
 
+import boom.ifu._
 import boom.bpu._
 import boom.exu._
 import boom.lsu._
 import boom.system.BoomTilesKey
 
 /**
- * Try to be a reasonable BOOM design point.
+ * Try to be a reasonable BOOM design point. Have a deep speculative window.
  */
 class DefaultBoomConfig extends Config((site, here, up) => {
 
@@ -36,7 +37,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       core = r.core.copy(
          fetchWidth = 4,
          decodeWidth = 2,
-         numRobEntries = 80,
+         numRobEntries = 100,
          issueParams = Seq(
             IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue),
             IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue),
@@ -45,8 +46,9 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          numFpPhysRegisters = 64,
          numLdqEntries = 32,
          numStqEntries = 18,
-         maxBrCount = 8,
-         btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=8, tagSz=13),
+         maxBrCount = 16,
+         ftq = FtqParameters(nEntries=25),
+         btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=16, tagSz=13),
          bpdBaseOnly = None,
          gshare = None,
          tage = Some(TageParameters()),
@@ -54,7 +56,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          nPerfCounters = 29,
          fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true))),
       btb = Some(BTBParams(nEntries = 0, updatesOutOfOrder = true)),
-      dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8, nMSHRs=4, nTLBEntries=16)),
+      dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8, nMSHRs=8, nTLBEntries=16)),
       icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBits, nSets=64, nWays=8))
       )}
 
@@ -130,6 +132,7 @@ class WithRVC extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map {r => r.copy(
       core = r.core.copy(
          fetchWidth = r.core.fetchWidth * 2,
+         ftq = FtqParameters(r.core.ftq.nEntries * 2/3),  // Assume ~67% of instructions are compressed.
          useCompressed = true))}
 })
 
@@ -152,6 +155,7 @@ class WithSmallBooms extends Config((site, here, up) => {
          numStqEntries=4,
          maxBrCount = 4,
          bpdBaseOnly = None,
+         ftq = FtqParameters(nEntries=8),
          gshare = Some(GShareParameters(historyLength=11, numSets=2048)),
          tage = None,
          bpdRandom = None,
@@ -178,9 +182,10 @@ class WithMediumBooms extends Config((site, here, up) => {
          numIntPhysRegisters = 70,
          numFpPhysRegisters = 64,
          numLdqEntries = 16,
-         numStqEntries = 9,
+         numStqEntries = 8,
          maxBrCount = 8,
          renameLatency = 2,
+         ftq = FtqParameters(nEntries=24),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=64, nWays=2,
                                  nRAS=8, tagSz=20, bypassCalls=false, rasCheckForEmpty=false),
          bpdBaseOnly = None,
@@ -196,23 +201,24 @@ class WithMediumBooms extends Config((site, here, up) => {
 })
 
 /**
- * Try to match the Cortex-A15. Don't expect good QoR (yet).
+ * Try to match the Cortex-A15.
  */
 class WithMegaBooms extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r =>r.copy(
       core = r.core.copy(
-         fetchWidth = 8,
-         decodeWidth = 4,
-         numRobEntries = 128,
+         fetchWidth = 4,
+         decodeWidth = 3,
+         numRobEntries = 96,
          issueParams = Seq(
             IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue),
             IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue),
             IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue)),
-         numIntPhysRegisters = 128,
-         numFpPhysRegisters = 128,
+         numIntPhysRegisters = 96,
+         numFpPhysRegisters = 64,
          numLdqEntries = 32,
-         numStqEntries = 18,
+         numStqEntries = 16,
          maxBrCount = 16,
+         ftq = FtqParameters(nEntries=24),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=16, tagSz=20),
          bpdBaseOnly = None,
          gshare = None,
@@ -220,7 +226,7 @@ class WithMegaBooms extends Config((site, here, up) => {
          bpdRandom = None),
       dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBytes*8,
                                  nSets=64, nWays=16, nMSHRs=8, nTLBEntries=32)),
-      icache = Some(ICacheParams(fetchBytes = 8*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=8))
+      icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=8))
       )}
 
    // Set TL network to 128bits wide

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -126,8 +126,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    val NUM_LDQ_ENTRIES = boomParams.numLdqEntries       // number of LAQ entries
    val NUM_STQ_ENTRIES = boomParams.numStqEntries       // number of SAQ/SDQ entries
    val MAX_BR_COUNT    = boomParams.maxBrCount          // number of branches we can speculate simultaneously
-   val ftqSz           = NUM_ROB_ENTRIES / fetchWidth   // number of FTQ entries should match
-                                                        //   (or slightly exceed) ROB entries
+   val ftqSz           = boomParams.ftq.nEntries        // number of FTQ entries
    val fetchBufferSz   = boomParams.fetchBufferSz       // number of instructions that stored between fetch&decode
 
    val numIntPhysRegs  = boomParams.numIntPhysRegisters // size of the integer physical register file

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -225,8 +225,6 @@ class Rob(
 
    require (num_rob_entries % width == 0)
 
-   require (isPow2(width))
-
    // ROB Finite State Machine
    val s_reset :: s_normal :: s_rollback :: s_wait_till_empty :: Nil = Enum(4)
    val rob_state = RegInit(s_reset)

--- a/src/main/scala/ifu/fetch-monitor.scala
+++ b/src/main/scala/ifu/fetch-monitor.scala
@@ -116,7 +116,7 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
 
       val valid_mask = VecInit(io.uops map {u => u.valid}).asUInt
       assert (valid_mask =/= 0.U)
-      val end_idx    = (fetchWidth-1).U - PriorityEncoder(Reverse(valid_mask))
+      val end_idx    = (decodeWidth-1).U - PriorityEncoder(Reverse(valid_mask))
       val end_uop    = io.uops(end_idx)
       val end_pc     = end_uop.pc
       val end_compressed = end_uop.inst(1,0) =/= 3.U && usingCompressed.B


### PR DESCRIPTION
Added FTQ sizes to each BoomConfig, as all were previously falling back on the default value of 16. FTQ size is decreased when RVC is enabled, assuming a 67% prevalence of compressible instructions / 33% code size reduction (too optimistic?).

Enabled non 2^n pipeline widths by removing a require in the Rob and fixing a mistake in FetchMonitor.