### PR TITLE
redo boom-template clones across ci steps

### DIFF
--- a/.circleci/create-hash.sh
+++ b/.circleci/create-hash.sh
@@ -17,6 +17,7 @@ if [ $1 == "boom-template" ]; then
     git rev-parse HEAD >> $HOME/$1-temp.hash
     cat $HOME/project/ROCKETCHIP_VERSION $HOME/$1-temp.hash > $HOME/$1.hash
     echo "Hashfile for $1 created in $HOME (note: combined with rocket-chip hash)"
+    echo "Contents: $(cat $HOME/$1.hash)"
 elif [ $1 == "riscv-tools" ]; then
     # Use riscv-boom rocket-chip hash to specify version of rocket-chip to use
     git submodule update --init rocket-chip
@@ -29,6 +30,7 @@ elif [ $1 == "riscv-tools" ]; then
     # rocket-chip now provides their own hash for the tools
     cp riscv-tools.hash $HOME/$1.hash
     echo "Hashfile for $1 created in $HOME"
+    echo "Contents: $(cat $HOME/$1.hash)"
 fi
 
 # delete boom-template

--- a/.circleci/create-hash.sh
+++ b/.circleci/create-hash.sh
@@ -5,18 +5,12 @@
 # turn echo on and error on earliest command
 set -ex
 
-# only execute if boom-template is not present (if it is present then it should have run this command before already)
-if [ ! -d "$HOME/boom-template" ]; then
-    cd $HOME
+# clone the boom-template repo
+cd $HOME
 
-    # clone boom-template and create the riscv-tools
-    git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
-    cd boom-template
-fi
-
-# move the pull request riscv-boom repo into boom-template
-rm -rf $HOME/boom-template/boom
-cp -r $HOME/project $HOME/boom-template/boom/
+# clone boom-template and create the riscv-tools
+git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
+cd boom-template
 
 cd $HOME/boom-template
 if [ $1 == "boom-template" ]; then
@@ -25,10 +19,10 @@ if [ $1 == "boom-template" ]; then
 elif [ $1 == "riscv-tools" ]; then
     # Use riscv-boom rocket-chip hash to specify version of rocket-chip to use
     git submodule update --init rocket-chip
-    echo "Checking out rocket-chip with hash: $(cat boom/ROCKETCHIP_VERSION)"
+    echo "Checking out rocket-chip with hash: $(cat $HOME/project/ROCKETCHIP_VERSION)"
     cd rocket-chip
     git fetch
-    git checkout $(cat ../boom/ROCKETCHIP_VERSION)
+    git checkout $(cat $HOME/project/ROCKETCHIP_VERSION)
     git submodule update --recursive
 
     # rocket-chip now provides their own hash for the tools
@@ -36,3 +30,5 @@ elif [ $1 == "riscv-tools" ]; then
     echo "Hashfile for $1 created in $HOME"
 fi
 
+# delete boom-template
+rm -rf $HOME/boom-template

--- a/.circleci/create-hash.sh
+++ b/.circleci/create-hash.sh
@@ -15,7 +15,8 @@ cd boom-template
 cd $HOME/boom-template
 if [ $1 == "boom-template" ]; then
     git rev-parse HEAD >> $HOME/$1.hash
-    echo "Hashfile for $1 created in $HOME"
+    cat $HOME/project/ROCKETCHIP_VERSION $HOME/$1.hash > $HOME/$1.hash
+    echo "Hashfile for $1 created in $HOME (note: combined with rocket-chip hash)"
 elif [ $1 == "riscv-tools" ]; then
     # Use riscv-boom rocket-chip hash to specify version of rocket-chip to use
     git submodule update --init rocket-chip

--- a/.circleci/create-hash.sh
+++ b/.circleci/create-hash.sh
@@ -14,8 +14,8 @@ cd boom-template
 
 cd $HOME/boom-template
 if [ $1 == "boom-template" ]; then
-    git rev-parse HEAD >> $HOME/$1.hash
-    cat $HOME/project/ROCKETCHIP_VERSION $HOME/$1.hash > $HOME/$1.hash
+    git rev-parse HEAD >> $HOME/$1-temp.hash
+    cat $HOME/project/ROCKETCHIP_VERSION $HOME/$1-temp.hash > $HOME/$1.hash
     echo "Hashfile for $1 created in $HOME (note: combined with rocket-chip hash)"
 elif [ $1 == "riscv-tools" ]; then
     # Use riscv-boom rocket-chip hash to specify version of rocket-chip to use

--- a/.circleci/do-rtl-build.sh
+++ b/.circleci/do-rtl-build.sh
@@ -5,6 +5,9 @@
 # turn echo on and error on earliest command
 set -ex
 
+# this file assumes cache is updated correctly
+
+# TODO: this is redundant but safe
 # move the pull request riscv-boom repo into boom-template
 rm -rf $HOME/boom-template/boom
 cp -r $HOME/project $HOME/boom-template/boom/

--- a/.circleci/prepare-for-rtl-build.sh
+++ b/.circleci/prepare-for-rtl-build.sh
@@ -5,33 +5,35 @@
 # turn echo on and error on earliest command
 set -ex
 
-# clone the boom-template repo
-cd $HOME
+if [ ! -d "$HOME/boom-template" ]; then
+    # clone the boom-template repo
+    cd $HOME
 
-# clone boom-template and create the riscv-tools
-git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
-cd boom-template
+    # clone boom-template and create the riscv-tools
+    git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
+    cd boom-template
 
-# init all submodules (according to what boom-template wants)
-./scripts/init-submodules-no-riscv-tools.sh
+    # init all submodules (according to what boom-template wants)
+    ./scripts/init-submodules-no-riscv-tools.sh
 
-# move the pull request riscv-boom repo into boom-template
-rm -rf $HOME/boom-template/boom
-cp -r $HOME/project $HOME/boom-template/boom/
+    # move the pull request riscv-boom repo into boom-template
+    rm -rf $HOME/boom-template/boom
+    cp -r $HOME/project $HOME/boom-template/boom/
 
-# get boom specific rocket-chip version
-echo "Checking out rocket-chip with hash: $(cat boom/ROCKETCHIP_VERSION)"
-cd rocket-chip
-git fetch
-git checkout $(cat ../boom/ROCKETCHIP_VERSION)
+    # get boom specific rocket-chip version
+    echo "Checking out rocket-chip with hash: $(cat boom/ROCKETCHIP_VERSION)"
+    cd rocket-chip
+    git fetch
+    git checkout $(cat ../boom/ROCKETCHIP_VERSION)
 
-echo "Initialize final submodules"
-git submodule update --init --recursive
+    echo "Initialize final submodules"
+    git submodule update --init --recursive
 
-# extra patches
-# TODO: Remove FIRRTL patch in next rocket-bump (fixes const prop issue)
-git -C firrtl checkout 9535e03020c6e654dae3ce7e95f4d8649405ce3d
+    # extra patches
+    # TODO: Remove FIRRTL patch in next rocket-bump (fixes const prop issue)
+    git -C firrtl checkout 9535e03020c6e654dae3ce7e95f4d8649405ce3d
 
-# make boom-template verilator version
-cd ../verisim
-make verilator_install
+    # make boom-template verilator version
+    cd ../verisim
+    make verilator_install
+fi

--- a/.circleci/prepare-for-rtl-build.sh
+++ b/.circleci/prepare-for-rtl-build.sh
@@ -5,17 +5,21 @@
 # turn echo on and error on earliest command
 set -ex
 
-cd $HOME/boom-template
+# clone the boom-template repo
+cd $HOME
 
-# Same steps as ./scripts/init-submodules-no-riscv-tools.sh
-# Main difference is that you checkout the rocket-chip version
-echo "Initialize top-level submodules"
-git submodule update --init
+# clone boom-template and create the riscv-tools
+git clone --progress --verbose https://github.com/riscv-boom/boom-template.git
+cd boom-template
+
+# init all submodules (according to what boom-template wants)
+./scripts/init-submodules-no-riscv-tools.sh
 
 # move the pull request riscv-boom repo into boom-template
 rm -rf $HOME/boom-template/boom
 cp -r $HOME/project $HOME/boom-template/boom/
 
+# get boom specific rocket-chip version
 echo "Checking out rocket-chip with hash: $(cat boom/ROCKETCHIP_VERSION)"
 cd rocket-chip
 git fetch
@@ -24,11 +28,9 @@ git checkout $(cat ../boom/ROCKETCHIP_VERSION)
 echo "Initialize final submodules"
 git submodule update --init --recursive
 
+# extra patches
 # TODO: Remove FIRRTL patch in next rocket-bump (fixes const prop issue)
 git -C firrtl checkout 9535e03020c6e654dae3ce7e95f4d8649405ce3d
-
-cd ../torture
-git submodule update --init --recursive
 
 # make boom-template verilator version
 cd ../verisim


### PR DESCRIPTION
`create-hash.sh` does not create a `boom-template` for future steps to use. Now the main thing is that `prepare-for-rtl.sh` needs to get + update `boom-template` accordingly. Hopefully, it is a bit clearer to read.