### PR TITLE
Clean up parameters

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -180,7 +180,6 @@ class WithMediumBooms extends Config((site, here, up) => {
          numLdqEntries = 16,
          numStqEntries = 9,
          maxBrCount = 8,
-         regreadLatency = 1,
          renameLatency = 2,
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=64, nWays=2,
                                  nRAS=8, tagSz=20, bypassCalls=false, rasCheckForEmpty=false),

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -114,7 +114,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    // dispatchWidth is number of uops any issue queue can accept per cycle
    // TODO: Let this be less than coreWidth
    val dispatchWidth = coreWidth
-   val COMMIT_WIDTH = coreWidth
 
    require (isPow2(fetchWidth))
    require (coreWidth <= fetchWidth)

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -111,7 +111,9 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
 
    // coreWidth is width of decode, width of integer rename, width of ROB, and commit width
    val coreWidth = decodeWidth
-   val DISPATCH_WIDTH = coreWidth
+   // dispatchWidth is number of uops any issue queue can accept per cycle
+   // TODO: Let this be less than coreWidth
+   val dispatchWidth = coreWidth
    val COMMIT_WIDTH = coreWidth
 
    require (isPow2(fetchWidth))

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -60,7 +60,6 @@ case class BoomCoreParams(
    imulLatency: Int = 3,
    fetchLatency: Int = 3,
    renameLatency: Int = 2,
-   regreadLatency: Int = 1,
    nPerfCounters: Int = 0,
    numRXQEntries: Int = 4,
    numRCQEntries: Int = 8,
@@ -156,8 +155,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    val fetchLatency = boomParams.fetchLatency // how many cycles does fetch occupy?
    require (fetchLatency == 3) // do not currently support changing this
    val renameLatency = boomParams.renameLatency // how many cycles does rename occupy?
-   val regreadLatency = boomParams.regreadLatency // how many cycles does rrd occupy?
-   require (regreadLatency == 1) // Any color you like, so long as its black.
 
    val enableBrResolutionRegister = boomParams.enableBrResolutionRegister
 

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -105,7 +105,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    val dec_brmask_logic = Module(new BranchMaskGenerationLogic(decodeWidth))
    val rename_stage     = Module(new RenameStage(decodeWidth, num_int_wakeup_ports, num_fp_wakeup_ports))
    val issue_units      = new boom.exu.IssueUnits(num_int_wakeup_ports)
-   val iregfile         = if (regreadLatency == 1 && enableCustomRf)
+   val iregfile         = if (enableCustomRf)
                           {
                               Module(new RegisterFileSeqCustomArray(numIntPhysRegs,
                                  num_irf_read_ports,
@@ -396,7 +396,6 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
           boomParams.btb.nSets + " x " + boomParams.btb.nWays + " ways)") else 0)
      + "\n   RAS Size              : " + (if (enableBTB) boomParams.btb.nRAS else 0)
      + "\n   Rename  Stage Latency : " + renameLatency
-     + "\n   RegRead Stage Latency : " + regreadLatency
      + "\n" + iregfile.toString
      + "\n   Num Slow Wakeup Ports : " + num_irf_write_ports
      + "\n   Num Fast Wakeup Ports : " + exe_units.count(_.bypassable)
@@ -777,7 +776,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       val exe_unit = exe_units(w)
       if (exe_unit.reads_irf)
       {
-         if (exe_unit.supportedFuncUnits.muld && regreadLatency > 0)
+         if (exe_unit.supportedFuncUnits.muld)
          {
             // Supress just-issued divides from issuing back-to-back, since it's an iterative divider.
             // But it takes a cycle to get to the Exe stage, so it can't tell us it is busy yet.

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -155,8 +155,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    val dec_rdy        = Wire(Bool())
 
    // Dispatch Stage
-   val dis_valids     = Wire(Vec(DISPATCH_WIDTH, Bool())) // true if uop WILL enter IW
-   val dis_uops       = Wire(Vec(DISPATCH_WIDTH, new MicroOp()))
+   val dis_valids     = Wire(Vec(dispatchWidth, Bool())) // true if uop WILL enter IW
+   val dis_uops       = Wire(Vec(dispatchWidth, new MicroOp()))
 
    // Issue Stage/Register Read
    val iss_valids     = Wire(Vec(exe_units.num_irf_readers, Bool()))
@@ -735,7 +735,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    // Input (Dispatch)
    for {
       iu <- issue_units
-      w <- 0 until DISPATCH_WIDTH
+      w <- 0 until dispatchWidth
    }{
       iu.io.dis_valids(w) := dis_valids(w) && dis_uops(w).iqtype === (iu.iqType).U
       iu.io.dis_uops(w) := dis_uops(w)

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -264,23 +264,23 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    // Old BOOM Core HPE's
    //// User-level instruction count.
-   //csr.io.events(2) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(2) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && (csr.io.status.prv === UInt(freechips.rocketchip.rocket.PRV.U))})
 
    //csr.io.events(5)  := csr.io.status.prv === UInt(freechips.rocketchip.rocket.PRV.U)
 
    //// Instruction mixes.
-   //csr.io.events(6)  := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(6)  := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal})
-   //csr.io.events(7)  := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(7)  := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_jal})
-   //csr.io.events(8)  := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(8)  := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_jump && !rob.io.commit.uops(w).is_jal})
-   //csr.io.events(9)  := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(9)  := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_load})
-   //csr.io.events(10) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(10) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_store})
-   //csr.io.events(11) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(11) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).fp_val})
 
    //// Decode stall causes.
@@ -297,29 +297,29 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //csr.io.events(20) := lsu.io.counters.ldld_order_fail
 
    //// Branch prediction stats.
-   //csr.io.events(21)  := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(21)  := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   rob.io.commit.uops(w).stat_brjmp_mispredicted})
-   //csr.io.events(22) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(22) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   rob.io.commit.uops(w).stat_btb_made_pred})
-   //csr.io.events(23) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(23) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   rob.io.commit.uops(w).stat_btb_mispredicted})
-   //csr.io.events(24) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(24) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   rob.io.commit.uops(w).stat_bpd_made_pred})
-   //csr.io.events(25) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(25) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   rob.io.commit.uops(w).stat_bpd_mispredicted})
 
    //// Branch prediction - no prediction made.
-   //csr.io.events(26) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(26) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   !rob.io.commit.uops(w).stat_btb_made_pred && !rob.io.commit.uops(w).stat_bpd_made_pred})
 
    //// Branch prediction - no predition made & a mispredict occurred.
-   //csr.io.events(27) := PopCount((Range(0,COMMIT_WIDTH)).map{w =>
+   //csr.io.events(27) := PopCount((Range(0,coreWidth)).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && !rob.io.commit.uops(w).is_jal &&
    //   !rob.io.commit.uops(w).stat_btb_made_pred && !rob.io.commit.uops(w).stat_bpd_made_pred &&
    //   rob.io.commit.uops(w).stat_brjmp_mispredicted})
@@ -335,7 +335,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //csr.io.events(32) := !issue_units(1).io.dis_readys.reduce(_&_)
    //csr.io.events(33) := !fp_pipeline.io.dis_readys.reduce(_&_)
 
-   //assert (!(Range(0,COMMIT_WIDTH).map{w =>
+   //assert (!(Range(0,coreWidth).map{w =>
    //   rob.io.commit.valids(w) && rob.io.commit.uops(w).is_br_or_jmp && rob.io.commit.uops(w).is_jal &&
    //   rob.io.commit.uops(w).stat_brjmp_mispredicted}.reduce(_|_)),
    //   "[dpath] A committed JAL was marked as having been mispredicted.")
@@ -453,7 +453,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    io.ifu.flush_info.bits   := rob.io.flush.bits
 
    // Tell the FTQ it can deallocate entries by passing youngest ftq_idx.
-   val youngest_com_idx     = (COMMIT_WIDTH-1).U - PriorityEncoder(rob.io.commit.valids.reverse)
+   val youngest_com_idx     = (coreWidth-1).U - PriorityEncoder(rob.io.commit.valids.reverse)
    io.ifu.commit.valid      := rob.io.commit.valids.reduce(_|_)
    io.ifu.commit.bits       := rob.io.commit.uops(youngest_com_idx).ftq_idx
 
@@ -1247,7 +1247,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       val numFtqWhitespace = if (DEBUG_PRINTF_FTQ) (ftqSz/4)+1 else 0
       val fetchWhitespace = if (fetchWidth >= 8) 2 else 0
        var whitespace = (debugScreenheight - 25 + 3 -10 + 3 + 4 - coreWidth - (NUM_LDQ_ENTRIES max NUM_STQ_ENTRIES) -
-         issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/COMMIT_WIDTH) -
+         issueParams.map(_.numEntries).sum - issueParams.length - (NUM_ROB_ENTRIES/coreWidth) -
          numFtqWhitespace - fetchWhitespace
      )
 
@@ -1408,7 +1408,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    if (COMMIT_LOG_PRINTF)
    {
       var new_commit_cnt = 0.U
-      for (w <- 0 until COMMIT_WIDTH)
+      for (w <- 0 until coreWidth)
       {
          val priv = csr.io.status.prv
 
@@ -1506,7 +1506,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          }
       }
 
-      for (i <- 0 until COMMIT_WIDTH)
+      for (i <- 0 until coreWidth)
       {
          when (rob.io.commit.valids(i))
          {
@@ -1552,7 +1552,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    //io.trace := csr.io.trace unused
    if (p(BoomTilesKey)(0).trace)
    {
-      for (w <- 0 until COMMIT_WIDTH)
+      for (w <- 0 until coreWidth)
       {
          io.trace(w).valid      := rob.io.commit.valids(w)
          io.trace(w).iaddr      := Sext(rob.io.commit.uops(w).pc(vaddrBits-1,0), xLen)

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1037,7 +1037,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
    var w_cnt = 1
    // 0th goes to ll_wbarb
-   iregfile.io.write_ports(0) <> WritePort(ll_wbarb.io.out, IPREG_SZ, xLen)
+   iregfile.io.write_ports(0) := WritePort(ll_wbarb.io.out, IPREG_SZ, xLen)
    for (i <- 0 until exe_units.length)
    {
       if (exe_units(i).writes_irf)
@@ -1052,7 +1052,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
          iregfile.io.write_ports(w_cnt).valid     := wbIsValid(RT_FIX)
          iregfile.io.write_ports(w_cnt).bits.addr := wbpdst
-         wbresp.ready := iregfile.io.write_ports(w_cnt).ready
+         wbresp.ready := true.B
          if (exe_units(i).uses_csr_wport)
          {
             iregfile.io.write_ports(w_cnt).bits.data := Mux(wbReadsCSR, csr.io.rw.rdata, wbdata)

--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -103,7 +103,7 @@ class ExecutionUnitIO(
    val fcsr_rm = if (has_fcsr) Input(Bits(tile.FPConstants.RM_SZ.W)) else null
 
    // only used by the mem unit
-   val lsu_io        = if (has_mem) Flipped(new boom.lsu.LoadStoreUnitIO(decodeWidth)) else null
+   val lsu_io        = if (has_mem) Flipped(new boom.lsu.LoadStoreUnitIO(coreWidth)) else null
    val dmem          = if (has_mem) new boom.lsu.DCMemPortIO() else null
    // TODO move this out of ExecutionUnit
    val com_exception = if (has_mem || has_rocc) Input(Bool()) else null

--- a/src/main/scala/exu/execution-units/execution-units.scala
+++ b/src/main/scala/exu/execution-units/execution-units.scala
@@ -171,7 +171,7 @@ class ExecutionUnits(fpu: Boolean)(implicit val p: Parameters) extends HasBoomCo
    if (!fpu)
    {
      exe_units_str.append(
-       ( "\n   ==" + Seq("One","Two","Three","Four")(decodeWidth-1) + "-wide Machine=="
+       ( "\n   ==" + Seq("One","Two","Three","Four")(coreWidth-1) + "-wide Machine=="
        + "\n   ==" + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue==\n"))
    }
 

--- a/src/main/scala/exu/execution-units/rocc.scala
+++ b/src/main/scala/exu/execution-units/rocc.scala
@@ -31,8 +31,8 @@ import boom.util._
 class RoCCShimCoreIO(implicit p: Parameters) extends BoomBundle()(p)
 {
   // Decode Stage
-  val dec_rocc_vals    = Input(Vec(decodeWidth, Bool()))
-  val dec_uops         = Input(Vec(decodeWidth, new MicroOp))
+  val dec_rocc_vals    = Input(Vec(coreWidth, Bool()))
+  val dec_uops         = Input(Vec(coreWidth, new MicroOp))
   val rxq_full         = Output(Bool())
   val rxq_empty        = Output(Bool())
   val rxq_idx          = Output(UInt(log2Ceil(NUM_RXQ_ENTRIES).W))
@@ -93,7 +93,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule()(p)
   val rocc_idx = WireInit(0.U)
   val br_mask = WireInit(0.U(MAX_BR_COUNT.W))
 
-  for (w <- 0 until decodeWidth) {
+  for (w <- 0 until coreWidth) {
     when (io.core.dec_rocc_vals(w)
        && io.core.dec_uops(w).uopc === uopROCC) {
       enq_val      := true.B

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -39,9 +39,9 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
       val flush_pipeline   = Input(Bool())
       val fcsr_rm          = Input(UInt(width=freechips.rocketchip.tile.FPConstants.RM_SZ.W))
 
-      val dis_valids       = Input(Vec(DISPATCH_WIDTH, Bool())) // REFACTOR into single Decoupled()
-      val dis_uops         = Input(Vec(DISPATCH_WIDTH, new MicroOp()))
-      val dis_readys       = Output(Vec(DISPATCH_WIDTH, Bool()))
+      val dis_valids       = Input(Vec(dispatchWidth, Bool())) // REFACTOR into single Decoupled()
+      val dis_uops         = Input(Vec(dispatchWidth, new MicroOp()))
+      val dis_readys       = Output(Vec(dispatchWidth, Bool()))
 
       // +1 for recoding.
       val ll_wport         = Flipped(Decoupled(new ExeUnitResp(fLen+1)))// from memory unit
@@ -104,7 +104,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
    //-------------------------------------------------------------
 
    // Input (Dispatch)
-   for (w <- 0 until DISPATCH_WIDTH)
+   for (w <- 0 until dispatchWidth)
    {
       issue_unit.io.dis_valids(w) := io.dis_valids(w) && io.dis_uops(w).iqtype === issue_unit.iqType.U
       issue_unit.io.dis_uops(w) := io.dis_uops(w)

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -195,7 +195,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
    // Cut up critical path by delaying the write by a cycle.
    // Wakeup signal is sent on cycle S0, write is now delayed until end of S1,
    // but Issue happens on S1 and RegRead doesn't happen until S2 so we're safe.
-   fregfile.io.write_ports(0) <> WritePort(ll_wbarb.io.out, FPREG_SZ, fLen+1)
+   fregfile.io.write_ports(0) := RegNext(WritePort(ll_wbarb.io.out, FPREG_SZ, fLen+1))
 
    assert (ll_wbarb.io.in(0).ready) // never backpressure the memory unit.
    when (ifpu_resp.valid) { assert (ifpu_resp.bits.uop.ctrl.rf_wen && ifpu_resp.bits.uop.dst_rtype === RT_FLT) }
@@ -208,7 +208,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule()(p) with tile.HasFP
          fregfile.io.write_ports(w_cnt).valid     := eu.io.fresp.valid && eu.io.fresp.bits.uop.ctrl.rf_wen
          fregfile.io.write_ports(w_cnt).bits.addr := eu.io.fresp.bits.uop.pdst
          fregfile.io.write_ports(w_cnt).bits.data := eu.io.fresp.bits.data
-         eu.io.fresp.ready                        := fregfile.io.write_ports(w_cnt).ready
+         eu.io.fresp.ready                        := true.B
          when (eu.io.fresp.valid)
          {
             assert(eu.io.fresp.ready, "No backpressuring the FPU")

--- a/src/main/scala/exu/issue-units/issue-unit-age-ordered.scala
+++ b/src/main/scala/exu/issue-units/issue-unit-age-ordered.scala
@@ -37,13 +37,13 @@ class IssueUnitCollapsing(
    //-------------------------------------------------------------
    // Figure out how much to shift entries by
 
-   val MAX_SHIFT = DISPATCH_WIDTH
+   val MAX_SHIFT = dispatchWidth
    val shamt_oh = Array.fill(num_issue_slots){UInt(width=issue_width.W)}
    // count total grants before this entry, and tus how many to shift upwards by
    val shamt = Array.fill(num_issue_slots){UInt(width=log2Ceil(issue_width+1).W)}
 
    val vacants = issue_slots.map(s => !(s.valid)) ++ io.dis_valids.map(!_.toBool)
-   val shamts_oh = Array.fill(num_issue_slots+DISPATCH_WIDTH) {Wire(UInt(width=MAX_SHIFT.W))}
+   val shamts_oh = Array.fill(num_issue_slots+dispatchWidth) {Wire(UInt(width=MAX_SHIFT.W))}
    // track how many to shift up this entry by by counting previous vacant spots
    def SaturatingCounterOH(count_oh:UInt, inc: Bool, max: Int): UInt =
    {
@@ -60,7 +60,7 @@ class IssueUnitCollapsing(
       next
    }
    shamts_oh(0) := 0.U
-   for (i <- 1 until num_issue_slots + DISPATCH_WIDTH)
+   for (i <- 1 until num_issue_slots + dispatchWidth)
    {
       shamts_oh(i) := SaturatingCounterOH(shamts_oh(i-1), vacants(i-1), MAX_SHIFT)
    }
@@ -69,7 +69,7 @@ class IssueUnitCollapsing(
 
    // which entries' uops will still be next cycle? (not being issued and vacated)
    val will_be_valid = (0 until num_issue_slots).map(i => issue_slots(i).will_be_valid) ++
-                       (0 until DISPATCH_WIDTH).map(i => io.dis_valids(i) &&
+                       (0 until dispatchWidth).map(i => io.dis_valids(i) &&
                                                          !io.dis_uops(i).exception &&
                                                          !io.dis_uops(i).is_fence &&
                                                          !io.dis_uops(i).is_fencei)
@@ -102,7 +102,7 @@ class IssueUnitCollapsing(
    val will_be_available = (0 until num_issue_slots).map(i =>
                               (!issue_slots(i).will_be_valid || issue_slots(i).clear) && !(issue_slots(i).in_uop.valid))
    val num_available = PopCount(will_be_available)
-   for (w <- 0 until DISPATCH_WIDTH)
+   for (w <- 0 until dispatchWidth)
    {
       io.dis_readys(w) := RegNext(num_available > w.U)
    }

--- a/src/main/scala/exu/issue-units/issue-unit-unordered.scala
+++ b/src/main/scala/exu/issue-units/issue-unit-unordered.scala
@@ -37,7 +37,7 @@ class IssueUnitStatic(
    //-------------------------------------------------------------
    // Issue Table
 
-   val entry_wen_oh  = VecInit(Seq.fill(num_issue_slots){ Wire(Bits(DISPATCH_WIDTH.W)) })
+   val entry_wen_oh  = VecInit(Seq.fill(num_issue_slots){ Wire(Bits(dispatchWidth.W)) })
    for (i <- 0 until num_issue_slots)
    {
       issue_slots(i).in_uop.valid := entry_wen_oh(i).orR
@@ -53,15 +53,15 @@ class IssueUnitStatic(
    // Dispatch/Entry Logic
    // find a slot to enter a new dispatched instruction
 
-   val entry_wen_oh_array = Array.fill(num_issue_slots,DISPATCH_WIDTH){false.B}
-   var allocated = VecInit(Seq.fill(DISPATCH_WIDTH){false.B}) // did an instruction find an issue width?
+   val entry_wen_oh_array = Array.fill(num_issue_slots,dispatchWidth){false.B}
+   var allocated = VecInit(Seq.fill(dispatchWidth){false.B}) // did an instruction find an issue width?
 
    for (i <- 0 until num_issue_slots)
    {
-      var next_allocated = Wire(Vec(DISPATCH_WIDTH, Bool()))
+      var next_allocated = Wire(Vec(dispatchWidth, Bool()))
       var can_allocate = !(issue_slots(i).valid)
 
-      for (w <- 0 until DISPATCH_WIDTH)
+      for (w <- 0 until dispatchWidth)
       {
          entry_wen_oh_array(i)(w) = can_allocate && !(allocated(w))
 
@@ -76,9 +76,9 @@ class IssueUnitStatic(
    // also, translate from Scala data structures to Chisel Vecs
    for (i <- 0 until num_issue_slots)
    {
-      val temp_uop_val = Wire(Vec(DISPATCH_WIDTH, Bool()))
+      val temp_uop_val = Wire(Vec(dispatchWidth, Bool()))
 
-      for (w <- 0 until DISPATCH_WIDTH)
+      for (w <- 0 until dispatchWidth)
       {
          // TODO add ctrl bit for "allocates iss_slot"
          temp_uop_val (w) := io.dis_valids(w) &&
@@ -90,7 +90,7 @@ class IssueUnitStatic(
       entry_wen_oh(i) := temp_uop_val.asUInt
    }
 
-   for (w <- 0 until DISPATCH_WIDTH)
+   for (w <- 0 until dispatchWidth)
    {
       io.dis_readys(w) := allocated(w)
    }

--- a/src/main/scala/exu/issue-units/issue-unit.scala
+++ b/src/main/scala/exu/issue-units/issue-unit.scala
@@ -69,9 +69,9 @@ class IssueUnitIO(
    val num_wakeup_ports: Int)
    (implicit p: Parameters) extends BoomBundle()(p)
 {
-   val dis_valids     = Input(Vec(DISPATCH_WIDTH, Bool()))
-   val dis_uops       = Input(Vec(DISPATCH_WIDTH, new MicroOp()))
-   val dis_readys     = Output(Vec(DISPATCH_WIDTH, Bool()))
+   val dis_valids     = Input(Vec(dispatchWidth, Bool()))
+   val dis_uops       = Input(Vec(dispatchWidth, new MicroOp()))
+   val dis_readys     = Output(Vec(dispatchWidth, Bool()))
 
    val iss_valids     = Output(Vec(issue_width, Bool()))
    val iss_uops       = Output(Vec(issue_width, new MicroOp()))
@@ -114,8 +114,8 @@ abstract class IssueUnit(
    // Set up the dispatch uops
    // special case "storing" 2 uops within one issue slot.
 
-   val dis_uops = Array.fill(DISPATCH_WIDTH) {Wire(new MicroOp())}
-   for (w <- 0 until DISPATCH_WIDTH)
+   val dis_uops = Array.fill(dispatchWidth) {Wire(new MicroOp())}
+   for (w <- 0 until dispatchWidth)
    {
       dis_uops(w) := io.dis_uops(w)
       dis_uops(w).iw_p1_poisoned := false.B

--- a/src/main/scala/exu/register-read/regfile-custom.scala
+++ b/src/main/scala/exu/register-read/regfile-custom.scala
@@ -56,7 +56,6 @@ class RegisterFileSeqCustomArray(
   {
     regfile.io.WD(w) := io.write_ports(w).bits.data
     waddr_OH(w) := UIntToOH(io.write_ports(w).bits.addr) // what register are you writing in OH
-    io.write_ports(w).ready := true.B
   }
 
   val read_data = Wire(Vec(num_read_ports, UInt(register_width.W)))
@@ -107,7 +106,7 @@ class RegisterFileSeqCustomArray(
   if (bypassable_array.reduce(_||_))
   {
     // bypass specific write ports
-    val bypassable_wports = ArrayBuffer[DecoupledIO[RegisterFileWritePort]]()
+    val bypassable_wports = ArrayBuffer[Valid[RegisterFileWritePort]]()
     io.write_ports zip bypassable_array map { case (wport, b) => if (b) { bypassable_wports += wport} }
 
     for (i <- 0 until num_read_ports)

--- a/src/main/scala/exu/register-read/register-read.scala
+++ b/src/main/scala/exu/register-read/register-read.scala
@@ -97,17 +97,9 @@ class RegisterRead(
       rrd_decode_unit.io.iss_valid := io.iss_valids(w)
       rrd_decode_unit.io.iss_uop   := io.iss_uops(w)
 
-      if (regreadLatency == 1)
-      {
-         rrd_valids(w) := RegNext(rrd_decode_unit.io.rrd_valid &&
-                           !IsKilledByBranch(io.brinfo, rrd_decode_unit.io.rrd_uop))
-         rrd_uops(w)   := RegNext(GetNewUopAndBrMask(rrd_decode_unit.io.rrd_uop, io.brinfo))
-      }
-      else
-      {
-         rrd_valids(w) := rrd_decode_unit.io.rrd_valid
-         rrd_uops(w)   := rrd_decode_unit.io.rrd_uop
-      }
+      rrd_valids(w) := RegNext(rrd_decode_unit.io.rrd_valid &&
+                  !IsKilledByBranch(io.brinfo, rrd_decode_unit.io.rrd_uop))
+      rrd_uops(w)   := RegNext(GetNewUopAndBrMask(rrd_decode_unit.io.rrd_uop, io.brinfo))
    }
 
    //-------------------------------------------------------------
@@ -128,10 +120,9 @@ class RegisterRead(
       val num_read_ports = num_read_ports_array(w)
 
       // NOTE:
-      // If rrdLatency==0, ISS and RRD are in same cycle so this "just works".
-      // If rrdLatency==1, we need to send read address at end of ISS stage,
+      // rrdLatency==1, we need to send read address at end of ISS stage,
       //    in order to get read data back at end of RRD stage.
-      require (regreadLatency == 0 || regreadLatency == 1)
+
       val rs1_addr = io.iss_uops(w).pop1
       val rs2_addr = io.iss_uops(w).pop2
       val rs3_addr = io.iss_uops(w).pop3

--- a/src/main/scala/exu/rename/rename-stage.scala
+++ b/src/main/scala/exu/rename/rename-stage.scala
@@ -65,7 +65,7 @@ class RenameStageIO(
    // branch resolution (execute)
    val brinfo    = Input(new BrResolutionInfo())
 
-   val dis_inst_can_proceed = Input(Vec(DISPATCH_WIDTH, Bool()))
+   val dis_inst_can_proceed = Input(Vec(dispatchWidth, Bool()))
 
    // issue stage (fast wakeup)
    val int_wakeups = Flipped(Vec(num_int_wb_ports, Valid(new ExeUnitResp(xLen))))

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -1010,7 +1010,7 @@ class Rob(
 
       var r_idx = 0
       // scalastyle:off
-      for (i <- 0 until (NUM_ROB_ENTRIES/COMMIT_WIDTH))
+      for (i <- 0 until (NUM_ROB_ENTRIES/coreWidth))
       {
 //            rob[ 0]           (  )(  ) 0x00002000 [ -                       ][unknown                  ]    ,   (d:X p 1, bm:0 - sdt: 0) (d:- p 3, bm:f - sdt:60)
 //            rob[ 1]           (  )(B ) 0xc71cb68e [flw     fa3, -961(s11)   ][ -                       ] E31,   (d:- p22, bm:e T sdt:57) (d:- p 0, bm:0 - sdt: 0)
@@ -1018,7 +1018,7 @@ class Rob(
 //            rob[ 3]           (vv)(bb) 0x00002010 [lw      s1, 0(ra)        ][lui     t3, 0xff0        ]    ,   (d:x p 4, bm:0 - sdt: 0) (d:x p 5, bm:0 - sdt: 0)
 //            rob[ 4]      TL-> (v )(b ) 0x00002015 - 2018 [addiw   t3, t3, 255      ][li      t2, 2            ]    ,   (d:x p 6, bm:0 - sdt: 5) (d:x p 7, bm:0 - sdt: 0)
 
-         val row = if (COMMIT_WIDTH == 1) r_idx else (r_idx >> log2Ceil(COMMIT_WIDTH))
+         val row = if (coreWidth == 1) r_idx else (r_idx >> log2Ceil(coreWidth))
          val r_head = rob_head
          val r_tail = rob_tail
 
@@ -1031,7 +1031,7 @@ class Rob(
             Mux(rob_pnr === row.U, Str("P"), Str(" "))
           )
 
-         if (COMMIT_WIDTH == 1)
+         if (coreWidth == 1)
          {
             printf("(%c)(%c)(%c) 0x%x [DASM(%x)] %c ",
                    Mux(debug_entry(r_idx+0).valid, Str("V"), Str(" ")),
@@ -1042,7 +1042,7 @@ class Rob(
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-"))
                    )
          }
-         else if (COMMIT_WIDTH == 2)
+         else if (coreWidth == 2)
          {
             val row_is_val = debug_entry(r_idx+0).valid || debug_entry(r_idx+1).valid
             printf("(%c%c)(%c%c)(%c%c) 0x%x %x [DASM(%x)][DASM(%x)" + "] %c,%c %d,%d ",
@@ -1062,7 +1062,7 @@ class Rob(
                    debug_entry(r_idx+1).uop.ftq_idx
                    )
          }
-         else if (COMMIT_WIDTH == 4)
+         else if (coreWidth == 4)
          {
             val row_is_val = debug_entry(r_idx+0).valid || debug_entry(r_idx+1).valid || debug_entry(r_idx+2).valid || debug_entry(r_idx+3).valid
             printf("(%c%c%c%c)(%c%c%c%c)(%c%c%c%c) 0x%x %x %x %x [DASM(%x)][DASM(%x)][DASM(%x)][DASM(%x)" + "]%c%c%c%c",
@@ -1094,11 +1094,11 @@ class Rob(
          }
          else
          {
-            println("  BOOM's Chisel printf does not support commit_width >= " + COMMIT_WIDTH)
+            println("  BOOM's Chisel printf does not support commit_width >= " + coreWidth)
          }
 
          var temp_idx = r_idx
-         for (w <- 0 until COMMIT_WIDTH)
+         for (w <- 0 until coreWidth)
          {
             printf("(d:%c p%d, bm:%x sdt:%d) ",
                    Mux(debug_entry(temp_idx).uop.dst_rtype === RT_FIX, Str("X"),
@@ -1112,7 +1112,7 @@ class Rob(
             temp_idx = temp_idx + 1
          }
 
-         r_idx = r_idx + COMMIT_WIDTH
+         r_idx = r_idx + coreWidth
 
          printf("\n")
       }

--- a/src/main/scala/ifu/fetch-monitor.scala
+++ b/src/main/scala/ifu/fetch-monitor.scala
@@ -34,7 +34,7 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
       // The stream is valid and accepted by the backend.
       val fire = Input(Bool())
       // The stream of uops being sent to the backend.
-      val uops = Input(Vec(decodeWidth, new MicroOp()))
+      val uops = Input(Vec(coreWidth, new MicroOp()))
       // Was the pipeline redirected? Clear/reset the fetchbuffer.
       val clear = Input(Bool())
    })

--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -1352,7 +1352,7 @@ class LoadStoreUnit(pl_width: Int)(implicit p: Parameters,
    var stq_is_full = false.B
 
    // TODO refactor this logic
-   for (w <- 0 until decodeWidth)
+   for (w <- 0 until coreWidth)
    {
       val l_temp = laq_tail + w.U
       laq_is_full = ((l_temp === laq_head || l_temp === (laq_head + NUM_LDQ_ENTRIES.U)) && laq_maybe_full) | laq_is_full


### PR DESCRIPTION
- Deprecate regreadLatency = 0. Resolves #240 
- Previously we had decodeWidth, COMMIT_WIDTH, retireWidth, and `require`'d that these were equal. Now just use `coreWidth` instead.
- Change regfile to use ValidIO instead of Decoupled for its write ports