### PR TITLE
MicroOp cleanup

### DIFF
--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -294,7 +294,6 @@ trait ScalarOpConstants
       uop.is_load    := false.B
       uop.pdst       := 0.U
       uop.dst_rtype  := RT_X
-      uop.valid      := false.B
       // TODO these unnecessary? used in regread stage?
       uop.is_br_or_jmp := false.B
 

--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -36,10 +36,6 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    with freechips.rocketchip.rocket.constants.MemoryOpConstants
    with freechips.rocketchip.rocket.constants.ScalarOpConstants
 {
-   // Is this uop valid? or has it been masked out,
-   // Used by fetch buffer and Decode stage.
-   val valid            = Bool()
-
    val uopc             = UInt(UOPC_SZ.W)       // micro-op code
    val inst             = UInt(32.W)
    val is_rvc           = Bool()

--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -37,7 +37,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle()(p)
    with freechips.rocketchip.rocket.constants.ScalarOpConstants
 {
    val uopc             = UInt(UOPC_SZ.W)       // micro-op code
-   val inst             = UInt(32.W)
+   val debug_inst       = UInt(32.W)
    val is_rvc           = Bool()
    val pc               = UInt(coreMaxAddrBits.W) // TODO remove -- use FTQ to get PC. Change to debug_pc.
    val iqtype           = UInt(IQT_SZ.W)        // which issue unit do we use?

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -761,7 +761,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          uop.br_prediction := DontCare
          uop.debug_wdata := DontCare
          if (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF) uop.pc := DontCare
-         if (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF) uop.inst := DontCare
+         if (!DEBUG_PRINTF && !COMMIT_LOG_PRINTF) uop.debug_inst := DontCare
          if (!O3PIPEVIEW_PRINTF) uop.debug_events.fetch_seq := DontCare
       }
    }
@@ -1274,7 +1274,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          printf("(%c%c) " + "DASM(%x)" + " |  ",
                 Mux(io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid && !dec_finished_mask(w), Str("v"), Str("-")),
                 Mux(dec_will_fire(w), Str("V"), Str("-")),
-                dec_fbundle.uops(w).bits.inst
+                dec_fbundle.uops(w).bits.debug_inst
                 )
       }
 
@@ -1294,7 +1294,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       {
          printf(" (%c) " + "DASM(%x)" + " |  ",
                 Mux(rename_stage.io.ren2_mask(w), Str("V"), Str("-")),
-                rename_stage.io.ren2_uops(w).inst
+                rename_stage.io.ren2_uops(w).debug_inst
                 )
       }
 
@@ -1416,10 +1416,10 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          def printf_inst(uop: MicroOp) = {
             when (uop.is_rvc)
             {
-               printf("(0x%x)", uop.inst(15,0))
+               printf("(0x%x)", uop.debug_inst(15,0))
             }
             .otherwise {
-               printf("(0x%x)", uop.inst)
+               printf("(0x%x)", uop.debug_inst)
             }
          }
          when (rob.io.commit.valids(w))
@@ -1556,7 +1556,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
       {
          io.trace(w).valid      := rob.io.commit.valids(w)
          io.trace(w).iaddr      := Sext(rob.io.commit.uops(w).pc(vaddrBits-1,0), xLen)
-         io.trace(w).insn       := rob.io.commit.uops(w).inst
+         io.trace(w).insn       := rob.io.commit.uops(w).debug_inst
          // I'm uncertain the commit signals from the ROB match these CSR exception signals
          io.trace(w).priv       := csr.io.status.prv
          io.trace(w).exception  := csr.io.exception

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -511,7 +511,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
    {
       dec_valids(w)                      := io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid &&
                                             !dec_finished_mask(w)
-      decode_units(w).io.enq.uop         := dec_fbundle.uops(w)
+      decode_units(w).io.enq.uop         := dec_fbundle.uops(w).bits
       decode_units(w).io.status          := csr.io.status
       decode_units(w).io.csr_decode      <> csr.io.decode(w)
       decode_units(w).io.interrupt       := csr.io.interrupt
@@ -1274,7 +1274,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
          printf("(%c%c) " + "DASM(%x)" + " |  ",
                 Mux(io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid && !dec_finished_mask(w), Str("v"), Str("-")),
                 Mux(dec_will_fire(w), Str("V"), Str("-")),
-                dec_fbundle.uops(w).inst
+                dec_fbundle.uops(w).bits.inst
                 )
       }
 

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -475,9 +475,9 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule()(p)
    decode_table ++= (if (xLen == 64) X64Decode.table else X32Decode.table)
 
    val rvc_exp    = Module(new RVCExpander)
-   rvc_exp.io.in := io.enq.uop.inst
+   rvc_exp.io.in := io.enq.uop.debug_inst
    uop.is_rvc    := rvc_exp.io.rvc
-   val inst       = Mux(rvc_exp.io.rvc, rvc_exp.io.out.bits, io.enq.uop.inst)
+   val inst       = Mux(rvc_exp.io.rvc, rvc_exp.io.out.bits, io.enq.uop.debug_inst)
 
    val cs = Wire(new CtrlSigs()).decode(inst, decode_table)
 

--- a/src/main/scala/exu/execution-units/rocc.scala
+++ b/src/main/scala/exu/execution-units/rocc.scala
@@ -75,6 +75,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule()(p)
   val rxq_op_val    = Reg(Vec(NUM_RXQ_ENTRIES, Bool()))
   val rxq_committed = Reg(Vec(NUM_RXQ_ENTRIES, Bool()))
   val rxq_uop       = Reg(Vec(NUM_RXQ_ENTRIES, new MicroOp()))
+  val rxq_inst      = Reg(Vec(NUM_RXQ_ENTRIES, UInt(32.W)))
   val rxq_rs1       = Reg(Vec(NUM_RXQ_ENTRIES, UInt(xLen.W)))
   val rxq_rs2       = Reg(Vec(NUM_RXQ_ENTRIES, UInt(xLen.W)))
 
@@ -106,6 +107,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule()(p)
     rxq_op_val   (rxq_tail) := false.B
     rxq_committed(rxq_tail) := false.B
     rxq_uop      (rxq_tail) := io.core.dec_uops(rocc_idx)
+    rxq_inst     (rxq_tail) := io.core.dec_uops(rocc_idx).debug_inst
     rxq_tail                := WrapInc(rxq_tail, NUM_RXQ_ENTRIES)
   }
 
@@ -141,7 +143,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule()(p)
         io.core.rocc.cmd.ready &&
         rcq.io.enq.ready) {
     io.core.rocc.cmd.valid         := true.B
-    io.core.rocc.cmd.bits.inst     := rxq_uop(rxq_head).inst.asTypeOf(new RoCCInstruction)
+    io.core.rocc.cmd.bits.inst     := rxq_inst(rxq_head).asTypeOf(new RoCCInstruction)
     io.core.rocc.cmd.bits.rs1      := rxq_rs1(rxq_head)
     io.core.rocc.cmd.bits.rs2      := rxq_rs2(rxq_head)
     io.core.rocc.cmd.bits.status   := io.status

--- a/src/main/scala/exu/issue-units/issue-unit.scala
+++ b/src/main/scala/exu/issue-units/issue-unit.scala
@@ -187,7 +187,7 @@ abstract class IssueUnit(
                 Mux(issue_slots(i).uop.dst_rtype === RT_X, Str("-"),
                 Mux(issue_slots(i).uop.dst_rtype === RT_FLT, Str("f"),
                 Mux(issue_slots(i).uop.dst_rtype === RT_PAS, Str("C"), Str("?"))))),
-                issue_slots(i).uop.inst,
+                issue_slots(i).uop.debug_inst,
                 issue_slots(i).uop.pc(31,0),
                 issue_slots(i).uop.uopc,
                 issue_slots(i).uop.rob_idx,

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -333,7 +333,7 @@ class Rob(
       }
       .elsewhen (io.enq_valids.reduce(_|_) && !rob_val(rob_tail))
       {
-         rob_uop(rob_tail).inst := BUBBLE // just for debug purposes
+         rob_uop(rob_tail).debug_inst := BUBBLE // just for debug purposes
       }
 
       //-----------------------------------------------
@@ -471,7 +471,7 @@ class Rob(
             {
                rob_val(i)      := false.B
                rob_bsy(i)      := false.B
-               rob_uop(i).inst := BUBBLE
+               rob_uop(i).debug_inst := BUBBLE
             }
          }
       }
@@ -487,7 +487,7 @@ class Rob(
          when (io.brinfo.valid && io.brinfo.mispredict && entry_match)
          {
             rob_val(i) := false.B
-            rob_uop(i.U).inst := BUBBLE
+            rob_uop(i.U).debug_inst := BUBBLE
          }
          .elsewhen (io.brinfo.valid && !io.brinfo.mispredict && entry_match)
          {
@@ -523,11 +523,11 @@ class Rob(
       // debugging write ports that should not be synthesized
       when (will_commit(w))
       {
-         rob_uop(rob_head).inst := BUBBLE
+         rob_uop(rob_head).debug_inst := BUBBLE
       }
       .elsewhen (rbk_row)
       {
-         rob_uop(rob_tail).inst := BUBBLE
+         rob_uop(rob_tail).debug_inst := BUBBLE
       }
 
       //--------------------------------------------------
@@ -1038,7 +1038,7 @@ class Rob(
                    Mux(debug_entry(r_idx+0).busy, Str("B"),  Str(" ")),
                    Mux(debug_entry(r_idx+0).unsafe, Str("U"),  Str(" ")),
                    debug_entry(r_idx+0).uop.pc(31,0),
-                   debug_entry(r_idx+0).uop.inst,
+                   debug_entry(r_idx+0).uop.debug_inst,
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-"))
                    )
          }
@@ -1054,8 +1054,8 @@ class Rob(
                    Mux(debug_entry(r_idx+1).unsafe,  Str("U"), Str(" ")),
                    debug_entry(r_idx+0).uop.pc(31,0),
                    debug_entry(r_idx+1).uop.pc(15,0),
-                   debug_entry(r_idx+0).uop.inst,
-                   debug_entry(r_idx+1).uop.inst,
+                   debug_entry(r_idx+0).uop.debug_inst,
+                   debug_entry(r_idx+1).uop.debug_inst,
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-")),
                    Mux(debug_entry(r_idx+1).exception, Str("E"), Str("-")),
                    debug_entry(r_idx+0).uop.ftq_idx,
@@ -1082,10 +1082,10 @@ class Rob(
                    debug_entry(r_idx+1).uop.pc(15,0),
                    debug_entry(r_idx+2).uop.pc(15,0),
                    debug_entry(r_idx+3).uop.pc(15,0),
-                   debug_entry(r_idx+0).uop.inst,
-                   debug_entry(r_idx+1).uop.inst,
-                   debug_entry(r_idx+2).uop.inst,
-                   debug_entry(r_idx+3).uop.inst,
+                   debug_entry(r_idx+0).uop.debug_inst,
+                   debug_entry(r_idx+1).uop.debug_inst,
+                   debug_entry(r_idx+2).uop.debug_inst,
+                   debug_entry(r_idx+3).uop.debug_inst,
                    Mux(debug_entry(r_idx+0).exception, Str("E"), Str("-")),
                    Mux(debug_entry(r_idx+1).exception, Str("E"), Str("-")),
                    Mux(debug_entry(r_idx+2).exception, Str("E"), Str("-")),

--- a/src/main/scala/ifu/fetch-buffer.scala
+++ b/src/main/scala/ifu/fetch-buffer.scala
@@ -83,7 +83,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    {
       compact_mask(i) := false.B
       compact_uops(i) := DontCare
-      compact_uops(i).inst := 7.U
+      compact_uops(i).debug_inst := 7.U
    }
 
    // Step 1. Convert input FetchPacket into an array of MicroOps.
@@ -106,7 +106,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
          }
       }
       in_uops(i).ftq_idx        := io.enq.bits.ftq_idx
-      in_uops(i).inst           := io.enq.bits.insts(i)
+      in_uops(i).debug_inst     := io.enq.bits.insts(i)
       in_uops(i).is_rvc         := io.enq.bits.insts(i)(1,0) =/= 3.U && usingCompressed.B
       in_uops(i).xcpt_pf_if     := io.enq.bits.xcpt_pf_if
       in_uops(i).xcpt_ae_if     := io.enq.bits.xcpt_ae_if

--- a/src/main/scala/ifu/fetch-buffer.scala
+++ b/src/main/scala/ifu/fetch-buffer.scala
@@ -30,7 +30,7 @@ import boom.common._
  */
 class FetchBufferResp(implicit p: Parameters) extends BoomBundle()(p)
 {
-   val uops = Vec(coreWidth, new MicroOp())
+   val uops = Vec(coreWidth, Valid(new MicroOp()))
 }
 
 /**
@@ -72,6 +72,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    io.enq.ready := count < (num_elements-fetchWidth).U
 
    // Input microops.
+   val in_mask = Wire(Vec(fetchWidth, Bool()))
    val in_uops = Wire(Vec(fetchWidth, new MicroOp()))
 
    // Compacted/shifted microops (and the shifted valid mask).
@@ -89,7 +90,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    for (i <- 0 until fetchWidth)
    {
       in_uops(i)                := DontCare
-      in_uops(i).valid          := io.enq.valid && io.enq.bits.mask(i)
+      in_mask(i)                := io.enq.valid && io.enq.bits.mask(i)
       in_uops(i).edge_inst      := false.B
       in_uops(i).pc             := (alignToFetchBoundary(io.enq.bits.pc)
                                   + (i << log2Ceil(coreInstBytes)).U)
@@ -131,7 +132,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    var compact_idx = 0.U(log2Ceil(fetchWidth).W)
    for (i <- 0 until fetchWidth)
    {
-      val use_uop = i.U >= first_index && in_uops(i.U).valid
+      val use_uop = i.U >= first_index && in_mask(i.U)
       when (use_uop)
       {
          compact_uops(compact_idx) := in_uops(i.U)
@@ -148,7 +149,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
 
    // all enqueuing uops have been compacted.
    // How many incoming uops are there?
-   val popc_enqmask = PopCount(in_uops.map(_.valid))
+   val popc_enqmask = PopCount(in_mask)
    // What is the count of uops being added to the ram. Subtract off the bypassed uops.
    // But only bypass if ram is empty AND dequeue flops will be consumed.
    val enq_count =
@@ -181,14 +182,14 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
    //-------------------------------------------------------------
 
    val r_valid = RegInit(false.B)
-   val r_uops = Reg(Vec(coreWidth, new MicroOp()))
+   val r_uops = Reg(Vec(coreWidth, Valid(new MicroOp())))
 
    for (w <- 0 until coreWidth)
    {
       when (io.deq.ready)
       {
          r_valid := count > 0.U || io.enq.valid
-         r_uops(w) := Mux(count === 0.U, compact_uops(w), ram(read_ptr + w.U))
+         r_uops(w).bits  := Mux(count === 0.U, compact_uops(w), ram(read_ptr + w.U))
          r_uops(w).valid := Mux(count === 0.U, compact_mask(w), count > w.U)
       }
    }
@@ -249,7 +250,7 @@ class FetchBuffer(num_entries: Int)(implicit p: Parameters) extends BoomModule()
       printf("\n Fetch4 : %d deq_count (%d) pc=0x%x\n",
          io.deq.valid,
          deq_count,
-         io.deq.bits.uops(0).pc
+         io.deq.bits.uops(0).bits.pc
          )
    }
 

--- a/src/main/scala/ifu/fetch-monitor.scala
+++ b/src/main/scala/ifu/fetch-monitor.scala
@@ -90,7 +90,7 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
       prev_valid = uop.valid && io.fire
       prev_pc  = uop.bits.pc
       prev_npc = prev_pc + Mux(uop.bits.is_rvc, 2.U, 4.U)
-      val inst = ExpandRVC(uop.bits.inst)
+      val inst = ExpandRVC(uop.bits.debug_inst)
       prev_cfitype = GetCfiType(inst)
       prev_target =
          Mux(prev_cfitype === CfiType.jal,
@@ -119,8 +119,8 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
       val end_idx    = (fetchWidth-1).U - PriorityEncoder(Reverse(valid_mask))
       val end_uop    = io.uops(end_idx).bits
       val end_pc     = end_uop.pc
-      val end_compressed = end_uop.inst(1,0) =/= 3.U && usingCompressed.B
-      val inst       = ExpandRVC(end_uop.inst)
+      val end_compressed = end_uop.debug_inst(1,0) =/= 3.U && usingCompressed.B
+      val inst       = ExpandRVC(end_uop.debug_inst)
       last_pc := end_pc
       when (end_compressed) {
          last_npc := end_pc + 2.U


### PR DESCRIPTION
- Remove valid from MicroOp bundle, since most places use a separate valid mask or the Valid interface
- Rename inst to debug_inst, since uop.inst should only be referenced for asserts and prints