### PR TITLE
Config fixes

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -132,6 +132,7 @@ class WithRVC extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map {r => r.copy(
       core = r.core.copy(
          fetchWidth = r.core.fetchWidth * 2,
+         fetchBufferSz = r.core.fetchBufferSz / 2,
          useCompressed = true))}
 })
 

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -47,7 +47,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          numLdqEntries = 32,
          numStqEntries = 18,
          maxBrCount = 16,
-         ftq = FtqParameters(nEntries=25),
+         ftq = FtqParameters(nEntries=32),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=16, tagSz=13),
          bpdBaseOnly = None,
          gshare = None,
@@ -132,7 +132,6 @@ class WithRVC extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map {r => r.copy(
       core = r.core.copy(
          fetchWidth = r.core.fetchWidth * 2,
-         ftq = FtqParameters(r.core.ftq.nEntries * 2/3),  // Assume ~67% of instructions are compressed.
          useCompressed = true))}
 })
 
@@ -184,8 +183,7 @@ class WithMediumBooms extends Config((site, here, up) => {
          numLdqEntries = 16,
          numStqEntries = 9,
          maxBrCount = 8,
-         renameLatency = 2,
-         ftq = FtqParameters(nEntries=24),
+         ftq = FtqParameters(nEntries=32),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=64, nWays=2,
                                  nRAS=8, tagSz=20, bypassCalls=false, rasCheckForEmpty=false),
          bpdBaseOnly = None,
@@ -218,7 +216,7 @@ class WithMegaBooms extends Config((site, here, up) => {
          numLdqEntries = 32,
          numStqEntries = 16,
          maxBrCount = 16,
-         ftq = FtqParameters(nEntries=24),
+         ftq = FtqParameters(nEntries=32),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=16, tagSz=20),
          bpdBaseOnly = None,
          gshare = None,

--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -15,13 +15,14 @@ import freechips.rocketchip.devices.tilelink.{BootROMParams}
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile._
 
+import boom.ifu._
 import boom.bpu._
 import boom.exu._
 import boom.lsu._
 import boom.system.BoomTilesKey
 
 /**
- * Try to be a reasonable BOOM design point.
+ * Try to be a reasonable BOOM design point with a deep speculation window.
  */
 class DefaultBoomConfig extends Config((site, here, up) => {
 
@@ -36,7 +37,7 @@ class DefaultBoomConfig extends Config((site, here, up) => {
       core = r.core.copy(
          fetchWidth = 4,
          decodeWidth = 2,
-         numRobEntries = 80,
+         numRobEntries = 100,
          issueParams = Seq(
             IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue, dispatchWidth=2),
             IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue, dispatchWidth=2),
@@ -45,8 +46,9 @@ class DefaultBoomConfig extends Config((site, here, up) => {
          numFpPhysRegisters = 64,
          numLdqEntries = 32,
          numStqEntries = 18,
-         maxBrCount = 8,
-         btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=8, tagSz=13),
+         maxBrCount = 16,
+         ftq = FtqParameters(nEntries=25),
+         btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=16, tagSz=13),
          bpdBaseOnly = None,
          gshare = None,
          tage = Some(TageParameters()),
@@ -130,6 +132,7 @@ class WithRVC extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map {r => r.copy(
       core = r.core.copy(
          fetchWidth = r.core.fetchWidth * 2,
+         ftq = FtqParameters(r.core.ftq.nEntries * 2/3),  // Assume ~67% of instructions are compressed.
          useCompressed = true))}
 })
 
@@ -152,6 +155,7 @@ class WithSmallBooms extends Config((site, here, up) => {
          numStqEntries=4,
          maxBrCount = 4,
          bpdBaseOnly = None,
+         ftq = FtqParameters(nEntries=8),
          gshare = Some(GShareParameters(historyLength=11, numSets=2048)),
          tage = None,
          bpdRandom = None,
@@ -181,6 +185,7 @@ class WithMediumBooms extends Config((site, here, up) => {
          numStqEntries = 9,
          maxBrCount = 8,
          renameLatency = 2,
+         ftq = FtqParameters(nEntries=24),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=64, nWays=2,
                                  nRAS=8, tagSz=20, bypassCalls=false, rasCheckForEmpty=false),
          bpdBaseOnly = None,
@@ -196,23 +201,24 @@ class WithMediumBooms extends Config((site, here, up) => {
 })
 
 /**
- * Try to match the Cortex-A15. Don't expect good QoR (yet).
+ * Try to match the Cortex-A15.
  */
 class WithMegaBooms extends Config((site, here, up) => {
    case BoomTilesKey => up(BoomTilesKey, site) map { r =>r.copy(
       core = r.core.copy(
-         fetchWidth = 8,
-         decodeWidth = 4,
-         numRobEntries = 128,
+         fetchWidth = 4,
+         decodeWidth = 3,
+         numRobEntries = 96,
          issueParams = Seq(
-            IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue, dispatchWidth=4),
-            IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue, dispatchWidth=4),
-            IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue , dispatchWidth=4)),
-         numIntPhysRegisters = 128,
-         numFpPhysRegisters = 128,
+            IssueParams(issueWidth=1, numEntries=20, iqType=IQT_MEM.litValue, dispatchWidth=3),
+            IssueParams(issueWidth=2, numEntries=20, iqType=IQT_INT.litValue, dispatchWidth=3),
+            IssueParams(issueWidth=1, numEntries=20, iqType=IQT_FP.litValue , dispatchWidth=3)),
+         numIntPhysRegisters = 96,
+         numFpPhysRegisters = 64,
          numLdqEntries = 32,
-         numStqEntries = 18,
+         numStqEntries = 16,
          maxBrCount = 16,
+         ftq = FtqParameters(nEntries=24),
          btb = BoomBTBParameters(btbsa=true, densebtb=false, nSets=512, nWays=4, nRAS=16, tagSz=20),
          bpdBaseOnly = None,
          gshare = None,
@@ -220,7 +226,7 @@ class WithMegaBooms extends Config((site, here, up) => {
          bpdRandom = None),
       dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBytes*8,
                                  nSets=64, nWays=16, nMSHRs=8, nTLBEntries=32)),
-      icache = Some(ICacheParams(fetchBytes = 8*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=8))
+      icache = Some(ICacheParams(fetchBytes = 4*4, rowBits = site(SystemBusKey).beatBytes*8, nSets=64, nWays=8))
       )}
 
    // Set TL network to 128bits wide

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -124,8 +124,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    val NUM_LDQ_ENTRIES = boomParams.numLdqEntries       // number of LAQ entries
    val NUM_STQ_ENTRIES = boomParams.numStqEntries       // number of SAQ/SDQ entries
    val MAX_BR_COUNT    = boomParams.maxBrCount          // number of branches we can speculate simultaneously
-   val ftqSz           = numRobEntries / fetchWidth   // number of FTQ entries should match
-                                                        //   (or slightly exceed) ROB entries
+   val ftqSz           = boomParams.ftq.nEntries        // number of FTQ entries
    val fetchBufferSz   = boomParams.fetchBufferSz       // number of instructions that stored between fetch&decode
 
    val numIntPhysRegs  = boomParams.numIntPhysRegisters // size of the integer physical register file

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -37,7 +37,7 @@ case class BoomCoreParams(
    enableCustomRf: Boolean = false,
    enableCustomRfModel: Boolean = true,
    maxBrCount: Int = 4,
-   fetchBufferSz: Int = 8,
+   fetchBufferSz: Int = 4,
    enableAgePriorityIssue: Boolean = true,
    enablePrefetching: Boolean = false,
    enableBrResolutionRegister: Boolean = true,

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -254,7 +254,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
    require (numIntPhysRegs >= (32 + coreWidth))
    require (numFpPhysRegs >= (32 + coreWidth))
    require (MAX_BR_COUNT >=2)
-   require (numRobRows % 2 == 0)
    require (numRobEntries % coreWidth == 0)
    require ((NUM_LDQ_ENTRIES-1) > coreWidth)
    require ((NUM_STQ_ENTRIES-1) > coreWidth)

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -217,8 +217,6 @@ class Rob(
 
   require (numRobEntries % coreWidth == 0)
 
-  require (isPow2(coreWidth))
-
   // ROB Finite State Machine
   val s_reset :: s_normal :: s_rollback :: s_wait_till_empty :: Nil = Enum(4)
   val rob_state = RegInit(s_reset)

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -724,7 +724,7 @@ class Rob(
   } else {
     val safe_to_inc    = rob_state === s_normal || rob_state === s_wait_till_empty
     val do_inc_row     = !rob_pnr_unsafe.reduce(_||_) && rob_pnr =/= rob_tail
-    val do_inc_partial = !rob_pnr_unsafe(rob_pnr_lsb) && (rob_pnr =/= rob_tail || (rob_pnr === rob_tail && rob_tail_vals(rob_pnr_lsb)))
+    val do_inc_partial = !rob_pnr_unsafe(rob_pnr_lsb) && (rob_pnr =/= rob_tail || !full && rob_tail_vals(rob_pnr_lsb))
     when (empty && io.enq_valids.asUInt =/= 0.U) {
       // Unforunately for us, the ROB does not use its entries in monotonically
       //  increasing order, even in the case of no exceptions. The edge case

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -215,8 +215,6 @@ class Rob(
 {
   val io = IO(new RobIo(numWakeupPorts, numFpuPorts))
 
-  require (numRobEntries % coreWidth == 0)
-
   // ROB Finite State Machine
   val s_reset :: s_normal :: s_rollback :: s_wait_till_empty :: Nil = Enum(4)
   val rob_state = RegInit(s_reset)

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -726,7 +726,7 @@ class Rob(
     val pnr_maybe_at_tail = RegInit(false.B)
 
     val safe_to_inc = rob_state === s_normal || rob_state === s_wait_till_empty
-    val do_inc_row  = !rob_pnr_unsafe.reduce(_||_) && (rob_pnr =/= rob_tail || full && !pnr_maybe_at_tail)
+    val do_inc_row  = !rob_pnr_unsafe.reduce(_||_) && (rob_pnr =/= rob_tail || (full && !pnr_maybe_at_tail))
     when (empty && io.enq_valids.asUInt =/= 0.U) {
       // Unforunately for us, the ROB does not use its entries in monotonically
       //  increasing order, even in the case of no exceptions. The edge case
@@ -737,7 +737,7 @@ class Rob(
     } .elsewhen (safe_to_inc && do_inc_row) {
       rob_pnr     := WrapInc(rob_pnr, numRobRows)
       rob_pnr_lsb := 0.U
-    } .elsewhen (safe_to_inc && (rob_pnr =/= rob_tail || full && !pnr_maybe_at_tail)) {
+    } .elsewhen (safe_to_inc && (rob_pnr =/= rob_tail || (full && !pnr_maybe_at_tail))) {
       rob_pnr_lsb := PriorityEncoder(rob_pnr_unsafe)
     } .elsewhen (safe_to_inc && !full && !empty) {
       rob_pnr_lsb := PriorityEncoder(rob_pnr_unsafe.asUInt | ~MaskLower(rob_tail_vals.asUInt))

--- a/src/main/scala/ifu/fetch-monitor.scala
+++ b/src/main/scala/ifu/fetch-monitor.scala
@@ -116,7 +116,7 @@ class FetchMonitor(implicit p: Parameters) extends BoomModule()(p)
 
       val valid_mask = VecInit(io.uops map {u => u.valid}).asUInt
       assert (valid_mask =/= 0.U)
-      val end_idx    = (fetchWidth-1).U - PriorityEncoder(Reverse(valid_mask))
+      val end_idx    = (decodeWidth-1).U - PriorityEncoder(Reverse(valid_mask))
       val end_uop    = io.uops(end_idx).bits
       val end_pc     = end_uop.pc
       val end_compressed = end_uop.debug_inst(1,0) =/= 3.U && usingCompressed.B

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -352,9 +352,26 @@ object AgePriorityEncoder
  */
 object IsOlder
 {
-   def apply(i0: UInt, i1: UInt, head: UInt) = ((i0 < i1) ^ (i0 < head) ^ (i1 < head))
+  def apply(i0: UInt, i1: UInt, head: UInt) = ((i0 < i1) ^ (i0 < head) ^ (i1 < head))
 }
 
+/**
+  * Object to determine whether queue
+  * index i0 is older than index i1.
+  *
+  * is i0 older than i1? (closest to zero). Provide the tail_ptr to the
+  *  queue. This is Cat(i1 <= tail, i1) because the rob_tail can point to a
+  * valid (partially dispatched) row.
+ */
+object MaskLower
+{
+  def apply(in: UInt) = (0 until in.getWidth).map(i => in >> i.U).reduce(_|_)
+}
+
+object MaskUpper
+{
+  def apply(in: UInt) = (0 until in.getWidth).map(i => in << i.U).reduce(_|_)
+}
 
 /**
  * Create a queue that can be killed with a branch kill signal.


### PR DESCRIPTION
Added FTQ sizes to each BoomConfig, as all were previously falling back on the default value of 16. FTQ size is decreased when RVC is enabled, assuming a 67% prevalence of compressible instructions / 33% code size reduction (too optimistic?).

Enabled non 2^n pipeline widths by removing a require in the Rob and fixing a mistake in FetchMonitor.