### PR TITLE
Fixed doc copyright to be UCB

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'RISCV-BOOM'
-copyright = '2018, Chris Celio, Jerry Zhao, Abraham Gonzalez, Ben Korpan'
+copyright = '2019, The Regents of the University of California'
 author = 'Chris Celio, Jerry Zhao, Abraham Gonzalez, Ben Korpan'
 
 # The short X.Y version


### PR DESCRIPTION
@jwright6323 Mentioned that this is incorrect and should instead refer to UCB Regents.