### PR TITLE
fix to allow more than 2 boom cores in configs

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -8,6 +8,7 @@
 package boom.common
 
 import chisel3._
+import chisel3.util.{log2Up}
 
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.subsystem.{SystemBusKey}
@@ -62,6 +63,9 @@ class DefaultBoomConfig extends Config((site, here, up) => {
 
    // Set TL network to 128bits wide
    case SystemBusKey => up(SystemBusKey, site).copy(beatBytes = 16)
+
+   // Make sure there are enough hart bits to support multiple cores
+   case MaxHartIdBits => log2Up(site(BoomTilesKey).size)
 })
 
 /**


### PR DESCRIPTION
Small fix to make sure you can build multiple BOOM cores in a single config (more than 2)