### PR TITLE
BOOM Crossings

### DIFF
--- a/src/main/scala/common/configs.scala
+++ b/src/main/scala/common/configs.scala
@@ -20,7 +20,7 @@ import boom.ifu._
 import boom.bpu._
 import boom.exu._
 import boom.lsu._
-import boom.system.BoomTilesKey
+import boom.system.{BoomTilesKey}
 
 /**
  * Try to be a reasonable BOOM design point with a deep speculation window.

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -47,7 +47,7 @@ case class BoomTileParams(
     btb: Option[BTBParams] = Some(BTBParams()),
     dataScratchpadBytes: Int = 0,
     trace: Boolean = false,
-    name: Option[String] = Some("tile"),
+    name: Option[String] = Some("boom_tile"),
     hartId: Int = 0,
     beuAddr: Option[BigInt] = None,
     blockerCtrlAddr: Option[BigInt] = None,

--- a/src/main/scala/lsu/types.scala
+++ b/src/main/scala/lsu/types.scala
@@ -14,7 +14,6 @@ import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule}
 import freechips.rocketchip.rocket.{DCache, HellaCache, HellaCacheArbiter, HellaCacheIO, NonBlockingDCache, PTW}
-import freechips.rocketchip.subsystem.RocketCrossingKey
 import freechips.rocketchip.tile.{BaseTile, HasTileParameters}
 import freechips.rocketchip.tilelink.TLIdentityNode
 

--- a/src/main/scala/system/ConfigMixins.scala
+++ b/src/main/scala/system/ConfigMixins.scala
@@ -88,3 +88,30 @@ class WithRenumberHarts(rocketFirst: Boolean = true) extends Config((site, here,
   }
   case MaxHartIdBits => log2Up(up(BoomTilesKey, site).size + up(RocketTilesKey, site).size)
 })
+
+/**
+ * Add a synchronous clock crossing to the tile boundary
+ */
+class WithSynchronousBoomTiles extends Config((site, here, up) => {
+  case BoomCrossingKey => up(BoomCrossingKey, site) map { b =>
+    b.copy(crossingType = SynchronousCrossing())
+  }
+})
+
+/**
+ * Add an asynchronous clock crossing to the tile boundary
+ */
+class WithAsynchronousBoomTiles(depth: Int, sync: Int) extends Config((site, here, up) => {
+  case BoomCrossingKey => up(BoomCrossingKey, site) map { b =>
+    b.copy(crossingType = AsynchronousCrossing(depth, sync))
+  }
+})
+
+/**
+ * Add a rational clock crossing to the tile boundary (used when the clocks are related by a fraction).
+ */
+class WithRationalBoomTiles extends Config((site, here, up) => {
+  case BoomCrossingKey => up(BoomCrossingKey, site) map { b =>
+    b.copy(crossingType = RationalCrossing())
+  }
+})


### PR DESCRIPTION
Similar to how Rocket supports different clock crossings on the tile-level, now duplicate `RocketCrossingKey` into the `BoomCrossingKey`. This makes it clearer to split up the two different sets of tiles and adds its own set of mixins.

Functionally, this is no different from the `RocketCrossingKey`, it just makes it easier to understand in the code.

Finally, there are minor changes in naming the tile and comments.