### PR TITLE
Fix Interrupt/Hart Mapping and BOOM Hart 0 Default

### DIFF
--- a/src/main/scala/system/BoomSubsystem.scala
+++ b/src/main/scala/system/BoomSubsystem.scala
@@ -46,21 +46,19 @@ trait HasBoomTiles extends HasTiles
 
     connectMasterPortsToSBus(boom, crossing)
     connectSlavePortsToCBus(boom, crossing)
-    connectInterrupts(boom, Some(debug), clintOpt, plicOpt)
+
+    def treeNode: RocketTileLogicalTreeNode = new RocketTileLogicalTreeNode(boom.rocketLogicalTree.getOMInterruptTargets)
+    LogicalModuleTree.add(logicalTreeNode, boom.rocketLogicalTree)
 
     boom
   }
 
-  boomTiles.map {
-    b =>
-      def treeNode: RocketTileLogicalTreeNode = new RocketTileLogicalTreeNode(b.rocketLogicalTree.getOMInterruptTargets)
-      LogicalModuleTree.add(logicalTreeNode, b.rocketLogicalTree)
+  // connect interrupts based on the order of harts
+  boomTiles.sortWith(_.tileParams.hartId < _.tileParams.hartId).map {
+    b => connectInterrupts(b, Some(debug), clintOpt, plicOpt)
   }
 
-  def coreMonitorBundles = (boomTiles map { t =>
-    t.module.core.coreMonitorBundle
-  }).toList
-
+  def coreMonitorBundles = (boomTiles map { t => t.module.core.coreMonitorBundle }).toList
 }
 
 trait HasBoomTilesModuleImp extends HasTilesModuleImp

--- a/src/main/scala/system/ConfigMixins.scala
+++ b/src/main/scala/system/ConfigMixins.scala
@@ -79,7 +79,7 @@ class WithL1DECC(tecc: String, decc: String) extends Config((site, here, up) => 
  * Also makes support for multiple harts depend on Rocket + BOOM
  * Note: Must come after all harts are assigned for it to apply
  */
-class WithRenumberHarts(rocketFirst: Boolean = true) extends Config((site, here, up) => {
+class WithRenumberHarts(rocketFirst: Boolean = false) extends Config((site, here, up) => {
   case RocketTilesKey => up(RocketTilesKey, site).zipWithIndex map { case (r, i) =>
     r.copy(hartId = i + (if(rocketFirst) 0 else up(BoomTilesKey, site).length))
   }


### PR DESCRIPTION
Fixes a bug where assigning `hartId` of 0 to BOOM would not match with that the interrupts would be assigned in the PLIC and CLINT. This was due to the ordering of the `connectInterrupts` function.

Additionally, have the `WithRenumberHarts` have BOOM harts be ordered before Rocket harts.