### PR TITLE
speed up ci by adding fast (removes verbose print)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,8 +246,8 @@ jobs:
             - run:
                 name: Run BoomConfig riscv tests
                 command: |
-                    make run-bmark-tests -C ../bhd/sims/verisim CONFIG=BoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
-                    make run-asm-tests -C ../bhd/sims/verisim CONFIG=BoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-bmark-tests-fast -C ../bhd/sims/verisim CONFIG=BoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-asm-tests-fast -C ../bhd/sims/verisim CONFIG=BoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
     smallrv32unifiedboomconfig-run-csmith-tests:
         docker:
             - image: riscvboom/riscvboom-images:0.0.5
@@ -292,7 +292,7 @@ jobs:
             - run:
                 name: Run SmallRV32UnifiedBoomConfig riscv tests
                 command: |
-                    make run-asm-tests -C ../bhd/sims/verisim CONFIG=SmallRV32UnifiedBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-asm-tests-fast -C ../bhd/sims/verisim CONFIG=SmallRV32UnifiedBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
     smallboomconfig-run-csmith-tests:
         docker:
             - image: riscvboom/riscvboom-images:0.0.5
@@ -337,8 +337,8 @@ jobs:
             - run:
                 name: Run SmallBoomConfig riscv tests
                 command: |
-                    make run-bmark-tests -C ../bhd/sims/verisim CONFIG=SmallBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
-                    make run-asm-tests -C ../bhd/sims/verisim CONFIG=SmallBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-bmark-tests-fast -C ../bhd/sims/verisim CONFIG=SmallBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-asm-tests-fast -C ../bhd/sims/verisim CONFIG=SmallBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
     mediumboomconfig-run-csmith-tests:
         docker:
             - image: riscvboom/riscvboom-images:0.0.5
@@ -382,8 +382,8 @@ jobs:
             - run:
                 name: Run MediumBoomConfig riscv tests
                 command: |
-                    make run-bmark-tests -C ../bhd/sims/verisim CONFIG=MediumBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
-                    make run-asm-tests -C ../bhd/sims/verisim CONFIG=MediumBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-bmark-tests-fast -C ../bhd/sims/verisim CONFIG=MediumBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-asm-tests-fast -C ../bhd/sims/verisim CONFIG=MediumBoomConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
     smallboomandrocketconfig-run-csmith-tests:
         docker:
             - image: riscvboom/riscvboom-images:0.0.5
@@ -427,8 +427,8 @@ jobs:
             - run:
                 name: Run SmallBoomAndRocketConfig riscv tests
                 command: |
-                    make run-bmark-tests -C ../bhd/sims/verisim CONFIG=SmallBoomAndRocketConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
-                    make run-asm-tests -C ../bhd/sims/verisim CONFIG=SmallBoomAndRocketConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-bmark-tests-fast -C ../bhd/sims/verisim CONFIG=SmallBoomAndRocketConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
+                    make run-asm-tests-fast -C ../bhd/sims/verisim CONFIG=SmallBoomAndRocketConfig SUB_PROJECT=boom TOP=ExampleBoomAndRocketSystem
 
 # Order and dependencies of jobs to run
 workflows:


### PR DESCRIPTION
My reasoning for defaulting to fast is so that verbose does not print. However, you still do get an error on asserts. It is just up to the PR owner to rerun that test with verbose.