### PR TITLE
PNR Fix

### DIFF
--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -741,7 +741,7 @@ class Rob(
       rob_pnr_lsb := PriorityEncoder(rob_pnr_unsafe)
     } .elsewhen (safe_to_inc && !full && !empty) {
       rob_pnr_lsb := PriorityEncoder(rob_pnr_unsafe.asUInt | ~MaskLower(rob_tail_vals.asUInt))
-    } .elsewhen (full) {
+    } .elsewhen (full && pnr_maybe_at_tail) {
       rob_pnr_lsb := 0.U
     }
 


### PR DESCRIPTION
Fixed case where PNR is in the same row as the HEAD and clears its LSB during the first cycle of exception rollback following the ROB being full.