### PR TITLE
cleanup prints | have multicore configs show properly in collateral

### DIFF
--- a/src/main/scala/bpu/bpd-pipeline.scala
+++ b/src/main/scala/bpu/bpd-pipeline.scala
@@ -32,7 +32,7 @@ import freechips.rocketchip.util.{Str, UIntToAugmentedUInt}
 
 import boom.common._
 import boom.exu.{BranchUnitResp}
-import boom.util.{BoolToChar}
+import boom.util.{BoolToChar, AddToStringPrefix}
 
 /**
  * Give this to each instruction/uop and pass this down the pipeline to the branch unit
@@ -210,5 +210,10 @@ class BranchPredictionStage(implicit p: Parameters) extends BoomModule
     assert (!(io.f2_btb_resp.valid), "[bpd-pipeline] BTB predicted, but it's been disabled.")
   }
 
-  override def toString: String = btb.toString + "\n\n" + bpd.toString
+  override def toString: String =
+    (AddToStringPrefix("===BPD Pipeline===")
+    + "\n"
+    + btb.toString
+    + "\n"
+    + bpd.toString)
 }

--- a/src/main/scala/bpu/bpd-pipeline.scala
+++ b/src/main/scala/bpu/bpd-pipeline.scala
@@ -32,7 +32,7 @@ import freechips.rocketchip.util.{Str, UIntToAugmentedUInt}
 
 import boom.common._
 import boom.exu.{BranchUnitResp}
-import boom.util.{BoolToChar, AddToStringPrefix}
+import boom.util.{BoolToChar, BoomCoreStringPrefix}
 
 /**
  * Give this to each instruction/uop and pass this down the pipeline to the branch unit
@@ -211,9 +211,7 @@ class BranchPredictionStage(implicit p: Parameters) extends BoomModule
   }
 
   override def toString: String =
-    (AddToStringPrefix("===BPD Pipeline===")
-    + "\n"
-    + btb.toString
-    + "\n"
+    (BoomCoreStringPrefix("===BPD Pipeline===") + "\n"
+    + btb.toString + "\n"
     + bpd.toString)
 }

--- a/src/main/scala/bpu/bpd/gshare/gshare.scala
+++ b/src/main/scala/bpu/bpd/gshare/gshare.scala
@@ -25,7 +25,7 @@ import chisel3.core.withReset
 import freechips.rocketchip.config.{Parameters, Field}
 
 import boom.common._
-import boom.util.{ElasticReg, Fold, AddToStringPrefix}
+import boom.util.{ElasticReg, Fold, BoomCoreStringPrefix}
 
 /**
  * GShare configuration parameters used in configurations
@@ -240,7 +240,7 @@ class GShareBrPredictor(
     assert (com_idx === com_info.debugIdx, "[gshare] disagreement on update indices.")
   }
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==GShare BPU==",
     "(" + (nSets * fetchWidth * 2/8/1024) +
     " kB) GShare Predictor, with " + historyLength + " bits of history for (" +

--- a/src/main/scala/bpu/bpd/gshare/gshare.scala
+++ b/src/main/scala/bpu/bpd/gshare/gshare.scala
@@ -25,7 +25,7 @@ import chisel3.core.withReset
 import freechips.rocketchip.config.{Parameters, Field}
 
 import boom.common._
-import boom.util.{ElasticReg, Fold}
+import boom.util.{ElasticReg, Fold, AddToStringPrefix}
 
 /**
  * GShare configuration parameters used in configurations
@@ -240,9 +240,9 @@ class GShareBrPredictor(
     assert (com_idx === com_info.debugIdx, "[gshare] disagreement on update indices.")
   }
 
-  override def toString: String =
-    "   [Core " + hartId + "] ==GShare BPU==" +
-    "\n   [Core " + hartId + "] (" + (nSets * fetchWidth * 2/8/1024) +
+  override def toString: String = AddToStringPrefix(
+    "==GShare BPU==",
+    "(" + (nSets * fetchWidth * 2/8/1024) +
     " kB) GShare Predictor, with " + historyLength + " bits of history for (" +
-    fetchWidth + "-wide fetch) and " + nSets + " entries."
+    fetchWidth + "-wide fetch) and " + nSets + " entries")
 }

--- a/src/main/scala/bpu/bpd/simple-predictors/base-only.scala
+++ b/src/main/scala/bpu/bpd/simple-predictors/base-only.scala
@@ -26,7 +26,7 @@ import chisel3.core.withReset
 
 import freechips.rocketchip.config.{Parameters, Field}
 
-import boom.util.{ElasticReg, AddToStringPrefix}
+import boom.util.{ElasticReg, BoomCoreStringPrefix}
 
 /**
  * BaseOnly predictor configuration parameters used in configurations
@@ -89,7 +89,7 @@ class BaseOnlyBrPredictor(
 
   // Nothing to update, as the BIM is handled externally.
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==Base Only BPU==",
     "Building no predictor (just using BIM as a base predictor)")
 }

--- a/src/main/scala/bpu/bpd/simple-predictors/base-only.scala
+++ b/src/main/scala/bpu/bpd/simple-predictors/base-only.scala
@@ -26,7 +26,7 @@ import chisel3.core.withReset
 
 import freechips.rocketchip.config.{Parameters, Field}
 
-import boom.util.ElasticReg
+import boom.util.{ElasticReg, AddToStringPrefix}
 
 /**
  * BaseOnly predictor configuration parameters used in configurations
@@ -89,6 +89,7 @@ class BaseOnlyBrPredictor(
 
   // Nothing to update, as the BIM is handled externally.
 
-  override def toString: String = "   [Core " + hartId + "] ==Base Only BPU==" +
-    "\n   [Core " + hartId + "] Building no predictor (just using BIM as a base predictor)."
+  override def toString: String = AddToStringPrefix(
+    "==Base Only BPU==",
+    "Building no predictor (just using BIM as a base predictor)")
 }

--- a/src/main/scala/bpu/bpd/simple-predictors/simple-predictors.scala
+++ b/src/main/scala/bpu/bpd/simple-predictors/simple-predictors.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.rocket.{RocketCoreParams}
 import boom.common._
 import boom.exu._
 import boom.exu.{BranchUnitResp}
-import boom.util.{ElasticReg, AddToStringPrefix}
+import boom.util.{ElasticReg, BoomCoreStringPrefix}
 
 /**
  * A null branch predictor that makes no predictions
@@ -37,7 +37,7 @@ class NullBrPredictor(
 {
   io.resp.valid := false.B
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==Null BPU==",
     "Building (0 kB) Null Predictor (never predict)")
 }
@@ -81,7 +81,7 @@ class RandomBrPredictor(
   io.resp.valid := rand_val
   io.resp.bits.takens := rand(fetchWidth)
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==Random BPU==",
     "Building Random Branch Predictor")
 }

--- a/src/main/scala/bpu/bpd/simple-predictors/simple-predictors.scala
+++ b/src/main/scala/bpu/bpd/simple-predictors/simple-predictors.scala
@@ -19,12 +19,12 @@ import chisel3.core.withReset
 
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.util.{Str}
-import freechips.rocketchip.rocket.RocketCoreParams
+import freechips.rocketchip.rocket.{RocketCoreParams}
 
 import boom.common._
 import boom.exu._
-import boom.exu.BranchUnitResp
-import boom.util.ElasticReg
+import boom.exu.{BranchUnitResp}
+import boom.util.{ElasticReg, AddToStringPrefix}
 
 /**
  * A null branch predictor that makes no predictions
@@ -35,9 +35,11 @@ class NullBrPredictor(
   historyLength: Int = 12
   )(implicit p: Parameters) extends BoomBrPredictor(historyLength)
 {
-  override def toString: String = "   [Core " + hartId + "] ==Null BPU==" +
-    "\n   [Core " + hartId + "] Building (0 kB) Null Predictor (never predict)."
   io.resp.valid := false.B
+
+  override def toString: String = AddToStringPrefix(
+    "==Null BPU==",
+    "Building (0 kB) Null Predictor (never predict)")
 }
 
 /**
@@ -67,8 +69,6 @@ object RandomBrPredictor
 class RandomBrPredictor(
   )(implicit p: Parameters) extends BoomBrPredictor(historyLength = 1)
 {
-  override def toString: String = "   [Core " + hartId + "] ==Random BPU==" +
-    "\n   [Core " + hartId + "] Building Random Branch Predictor."
   private val rand_val = RegInit(false.B)
   rand_val := ~rand_val
   private var lfsr= LFSR16(true.B)
@@ -80,4 +80,8 @@ class RandomBrPredictor(
 
   io.resp.valid := rand_val
   io.resp.bits.takens := rand(fetchWidth)
+
+  override def toString: String = AddToStringPrefix(
+    "==Random BPU==",
+    "Building Random Branch Predictor")
 }

--- a/src/main/scala/bpu/bpd/tage/tage-table.scala
+++ b/src/main/scala/bpu/bpd/tage/tage-table.scala
@@ -19,7 +19,7 @@ import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.util.{Str}
 
 import boom.common._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * IO bundle to connect the TAGE table to the TAGE predictor top
@@ -287,7 +287,7 @@ class TageTable(
     assert (widx < numEntries.U, "[TageTable] out of bounds write index.")
   }
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "TageTable[" + id + "] - " +
     numEntries + " entries, " +
     historyLength + " bits of history, " +

--- a/src/main/scala/bpu/bpd/tage/tage-table.scala
+++ b/src/main/scala/bpu/bpd/tage/tage-table.scala
@@ -15,10 +15,11 @@ package boom.bpu
 import chisel3._
 import chisel3.util._
 
-import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.util.Str
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.util.{Str}
 
 import boom.common._
+import boom.util.{AddToStringPrefix}
 
 /**
  * IO bundle to connect the TAGE table to the TAGE predictor top
@@ -286,10 +287,10 @@ class TageTable(
     assert (widx < numEntries.U, "[TageTable] out of bounds write index.")
   }
 
-  override def toString: String =
-    "   [Core " + hartId + "] TageTable[" + id + "] - " +
+  override def toString: String = AddToStringPrefix(
+    "TageTable[" + id + "] - " +
     numEntries + " entries, " +
     historyLength + " bits of history, " +
     tagSz + "-bit tags, " +
-    cntrSz + "-bit counters"
+    cntrSz + "-bit counters")
 }

--- a/src/main/scala/bpu/bpd/tage/tage.scala
+++ b/src/main/scala/bpu/bpd/tage/tage.scala
@@ -34,7 +34,7 @@ import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.util.Str
 
 import boom.common._
-import boom.util.{ElasticReg, Fold}
+import boom.util.{ElasticReg, Fold, AddToStringPrefix}
 
 /**
  * TAGE parameters used in configurations
@@ -477,9 +477,9 @@ class TageBrPredictor(
     assert (r_info.provider_id < numTables.U || !r_info.provider_hit, "[Tage] provider_id is out-of-bounds.")
   }
 
-  override def toString: String =
-    "   [Core " + hartId + "] ==TAGE BPU==" +
-    "\n   [Core " + hartId + "] " + (sizeInBits/8/1024.0) + " kB TAGE Predictor (" +
+  override def toString: String = AddToStringPrefix(
+    "==TAGE BPU==",
+    "" + (sizeInBits/8/1024.0) + " kB TAGE Predictor (" +
     (sizeInBits/1024) + " Kbits) (max history length: " + historyLengths.max + " bits)\n" +
-    tables.mkString("\n")
+    tables.mkString(""))
 }

--- a/src/main/scala/bpu/bpd/tage/tage.scala
+++ b/src/main/scala/bpu/bpd/tage/tage.scala
@@ -34,7 +34,7 @@ import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.util.Str
 
 import boom.common._
-import boom.util.{ElasticReg, Fold, AddToStringPrefix}
+import boom.util.{ElasticReg, Fold, BoomCoreStringPrefix}
 
 /**
  * TAGE parameters used in configurations
@@ -477,7 +477,7 @@ class TageBrPredictor(
     assert (r_info.provider_id < numTables.U || !r_info.provider_hit, "[Tage] provider_id is out-of-bounds.")
   }
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==TAGE BPU==",
     "" + (sizeInBits/8/1024.0) + " kB TAGE Predictor (" +
     (sizeInBits/1024) + " Kbits) (max history length: " + historyLengths.max + " bits)\n" +

--- a/src/main/scala/bpu/btb/bim.scala
+++ b/src/main/scala/bpu/btb/bim.scala
@@ -31,7 +31,7 @@ import freechips.rocketchip.config.{Parameters}
 
 import boom.common._
 import boom.exu._
-import boom.util.{BoolToChar, AddToStringPrefix}
+import boom.util.{BoolToChar, BoomCoreStringPrefix}
 
 case class BimParameters(
   nSets: Int = 1024, // how many sets (conceptually) should we have?
@@ -345,7 +345,7 @@ class BimodalTable(implicit p: Parameters) extends BoomModule with HasBimParamet
   // Trust me, I just work.
 
   val size_kbits = nSets * fetchWidth * 2/1024 // assumes 2 bits / fetchWidth
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==BIM==",
     "(" + size_kbits + " Kbits = " + size_kbits/8 + " kB) Bimodal Table (" + nSets + " entries across " + nBanks + " banks)")
 }

--- a/src/main/scala/bpu/btb/bim.scala
+++ b/src/main/scala/bpu/btb/bim.scala
@@ -31,7 +31,7 @@ import freechips.rocketchip.config.{Parameters}
 
 import boom.common._
 import boom.exu._
-import boom.util.{BoolToChar}
+import boom.util.{BoolToChar, AddToStringPrefix}
 
 case class BimParameters(
   nSets: Int = 1024, // how many sets (conceptually) should we have?
@@ -345,8 +345,7 @@ class BimodalTable(implicit p: Parameters) extends BoomModule with HasBimParamet
   // Trust me, I just work.
 
   val size_kbits = nSets * fetchWidth * 2/1024 // assumes 2 bits / fetchWidth
-  override def toString: String =
-    "   [Core " + hartId + "] ==BIM==" +
-    "\n   [Core " + hartId + "] (" + size_kbits + " Kbits = " + size_kbits/8 + " kB) Bimodal Table (" +
-    nSets + " entries across " + nBanks + " banks)"
+  override def toString: String = AddToStringPrefix(
+    "==BIM==",
+    "(" + size_kbits + " Kbits = " + size_kbits/8 + " kB) Bimodal Table (" + nSets + " entries across " + nBanks + " banks)")
 }

--- a/src/main/scala/bpu/btb/btb-sa.scala
+++ b/src/main/scala/bpu/btb/btb-sa.scala
@@ -36,7 +36,7 @@ import freechips.rocketchip.config.Parameters
 
 import boom.common._
 import boom.exu._
-import boom.util.{BoolToChar, CfiTypeToChars, AddToStringPrefix}
+import boom.util.{BoolToChar, CfiTypeToChars, BoomCoreStringPrefix}
 
 /**
  * Normal set-associative branch target buffer. Checks an incoming
@@ -234,11 +234,10 @@ class BTBsa(implicit p: Parameters) extends BoomBTB
       bim.io.resp.bits.rowdata)
   }
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==BTB-SA==",
     "Sets          : " + nSets,
     "Ways          : " + nWays,
-    "Tag Size      : " + tagSz) +
-    "\n" +
+    "Tag Size      : " + tagSz) + "\n" +
     bim.toString
 }

--- a/src/main/scala/bpu/btb/btb-sa.scala
+++ b/src/main/scala/bpu/btb/btb-sa.scala
@@ -36,7 +36,7 @@ import freechips.rocketchip.config.Parameters
 
 import boom.common._
 import boom.exu._
-import boom.util.{BoolToChar, CfiTypeToChars}
+import boom.util.{BoolToChar, CfiTypeToChars, AddToStringPrefix}
 
 /**
  * Normal set-associative branch target buffer. Checks an incoming
@@ -234,11 +234,11 @@ class BTBsa(implicit p: Parameters) extends BoomBTB
       bim.io.resp.bits.rowdata)
   }
 
-  override def toString: String =
-    "   [Core " + hartId + "] ==BTB-SA==" +
-    "\n   [Core " + hartId + "] Sets          : " + nSets +
-    "\n   [Core " + hartId + "] Ways          : " + nWays +
-    "\n   [Core " + hartId + "] Tag Size      : " + tagSz +
-    "\n\n" +
+  override def toString: String = AddToStringPrefix(
+    "==BTB-SA==",
+    "Sets          : " + nSets,
+    "Ways          : " + nWays,
+    "Tag Size      : " + tagSz) +
+    "\n" +
     bim.toString
 }

--- a/src/main/scala/bpu/btb/btb.scala
+++ b/src/main/scala/bpu/btb/btb.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.config.{Parameters}
 
 import boom.common._
 import boom.exu._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 import freechips.rocketchip.util.{Str}
 
@@ -264,7 +264,7 @@ class NullBTB(implicit p: Parameters) extends BoomBTB
 {
   io.resp.valid := false.B
 
-  override def toString: String = AddToStringPrefix("==Null BTB==")
+  override def toString: String = BoomCoreStringPrefix("==Null BTB==")
 }
 
 /**

--- a/src/main/scala/bpu/btb/btb.scala
+++ b/src/main/scala/bpu/btb/btb.scala
@@ -20,12 +20,13 @@ package boom.bpu
 import chisel3._
 import chisel3.util._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Parameters}
 
 import boom.common._
 import boom.exu._
+import boom.util.{AddToStringPrefix}
 
-import freechips.rocketchip.util.Str
+import freechips.rocketchip.util.{Str}
 
 //------------------------------------------------------------------------------
 // Parameters and Traits
@@ -263,7 +264,7 @@ class NullBTB(implicit p: Parameters) extends BoomBTB
 {
   io.resp.valid := false.B
 
-  override def toString: String = "   ==Null BTB=="
+  override def toString: String = AddToStringPrefix("==Null BTB==")
 }
 
 /**

--- a/src/main/scala/bpu/btb/dense-btb.scala
+++ b/src/main/scala/bpu/btb/dense-btb.scala
@@ -39,7 +39,7 @@ import freechips.rocketchip.util._
 
 import boom.common._
 import boom.exu._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 //------------------------------------------------------------------------------
 // DenseBTB
@@ -382,14 +382,13 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
       bim.io.resp.bits.rowdata)
   }
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==Dense BTB==",
     "Sets          : " + nSets,
     "Banks         : " + nBanks,
     "Ways          : " + nWays,
     "Branch Levels : " + branchLevels,
     "Tag Size      : " + tagSz,
-    "Offset Size   : " + offsetSz)
-    "\n" +
+    "Offset Size   : " + offsetSz) + "\n" +
     bim.toString
 }

--- a/src/main/scala/bpu/btb/dense-btb.scala
+++ b/src/main/scala/bpu/btb/dense-btb.scala
@@ -39,6 +39,7 @@ import freechips.rocketchip.util._
 
 import boom.common._
 import boom.exu._
+import boom.util.{AddToStringPrefix}
 
 //------------------------------------------------------------------------------
 // DenseBTB
@@ -381,14 +382,14 @@ class DenseBTB(implicit p: Parameters) extends BoomBTB
       bim.io.resp.bits.rowdata)
   }
 
-  override def toString: String =
-    "   [Core " + hartId + "] ==Dense BTB==" +
-    "\n   [Core " + hartId + "] Sets          : " + nSets +
-    "\n   [Core " + hartId + "] Banks         : " + nBanks +
-    "\n   [Core " + hartId + "] Ways          : " + nWays +
-    "\n   [Core " + hartId + "] Branch Levels : " + branchLevels +
-    "\n   [Core " + hartId + "] Tag Size      : " + tagSz +
-    "\n   [Core " + hartId + "] Offset Size   : " + offsetSz +
-    "\n\n" +
+  override def toString: String = AddToStringPrefix(
+    "==Dense BTB==",
+    "Sets          : " + nSets,
+    "Banks         : " + nBanks,
+    "Ways          : " + nWays,
+    "Branch Levels : " + branchLevels,
+    "Tag Size      : " + tagSz,
+    "Offset Size   : " + offsetSz)
+    "\n" +
     bim.toString
 }

--- a/src/main/scala/bpu/misc/2bc-table.scala
+++ b/src/main/scala/bpu/misc/2bc-table.scala
@@ -45,7 +45,7 @@ import chisel3.util._
 
 import freechips.rocketchip.config.{Parameters}
 
-import boom.util.{SeqMem1rwTransformable}
+import boom.util.{SeqMem1rwTransformable, AddToStringPrefix}
 import boom.common.{BoomBundle, BoomModule}
 
 class UpdateEntry(val idxSz: Int)(implicit p: Parameters) extends BoomBundle
@@ -247,12 +247,12 @@ class TwobcCounterTable(
 
   //------------------------------------------------------------
 
-  override def toString: String =
-    ("  Building (" +
+  override def toString: String = AddToStringPrefix(
+    ("Building (" +
     (numEntries * fetchWidth * 2/8/1024) + " kB) 2-bit counter table for (" +
     fetchWidth + "-wide fetch) and " +
     numEntries + " p-table entries " +
     (if (dualported) "[1read/1write]" else "[1rw]" +
-    ", " + numHEntries + " h-table entries."))
+    ", " + numHEntries + " h-table entries.")))
 }
 

--- a/src/main/scala/bpu/misc/2bc-table.scala
+++ b/src/main/scala/bpu/misc/2bc-table.scala
@@ -45,7 +45,7 @@ import chisel3.util._
 
 import freechips.rocketchip.config.{Parameters}
 
-import boom.util.{SeqMem1rwTransformable, AddToStringPrefix}
+import boom.util.{SeqMem1rwTransformable, BoomCoreStringPrefix}
 import boom.common.{BoomBundle, BoomModule}
 
 class UpdateEntry(val idxSz: Int)(implicit p: Parameters) extends BoomBundle
@@ -247,7 +247,7 @@ class TwobcCounterTable(
 
   //------------------------------------------------------------
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     ("Building (" +
     (numEntries * fetchWidth * 2/8/1024) + " kB) 2-bit counter table for (" +
     fetchWidth + "-wide fetch) and " +

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.tile._
 import boom.exu._
 import boom.ifu._
 import boom.lsu._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * BOOM tile parameter class used in configurations
@@ -267,11 +267,9 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   val frontendStr = outer.frontend.module.toString
   val coreStr = core.toString
   val boomTileStr =
-    (AddToStringPrefix(s"======BOOM Tile ${p(TileKey).hartId} Params======")
-    + "\n"
+    (BoomCoreStringPrefix(s"======BOOM Tile ${p(TileKey).hartId} Params======") + "\n"
     + frontendStr
-    + coreStr
-    + "\n")
+    + coreStr + "\n")
 
   override def toString: String = boomTileStr
 

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -24,6 +24,7 @@ import freechips.rocketchip.tile._
 import boom.exu._
 import boom.ifu._
 import boom.lsu._
+import boom.util.{AddToStringPrefix}
 
 /**
  * BOOM tile parameter class used in configurations
@@ -264,9 +265,15 @@ class BoomTileModuleImp(outer: BoomTile) extends BaseTileModuleImp(outer)
   ptw.io.requestor <> ptwPorts
 
   val frontendStr = outer.frontend.module.toString
-  ElaborationArtefacts.add(
-    """core.config""",
-    frontendStr + core.toString + "\n"
-  )
-  print(outer.frontend.module.toString + core.toString + "\n")
+  val coreStr = core.toString
+  val boomTileStr =
+    (AddToStringPrefix(s"======BOOM Tile ${p(TileKey).hartId} Params======")
+    + "\n"
+    + frontendStr
+    + coreStr
+    + "\n")
+
+  override def toString: String = boomTileStr
+
+  print(boomTileStr)
 }

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -42,7 +42,7 @@ import freechips.rocketchip.util.{Str, UIntIsOneOf, CoreMonitorBundle}
 import boom.common._
 import boom.exu.FUConstants._
 import boom.system.BoomTilesKey
-import boom.util.{RobTypeToChars, BoolToChar, GetNewUopAndBrMask, Sext, WrapInc, AddToStringPrefix}
+import boom.util.{RobTypeToChars, BoolToChar, GetNewUopAndBrMask, Sext, WrapInc, BoomCoreStringPrefix}
 
 /**
  * IO bundle for the BOOM Core. Connects the external components such as
@@ -245,15 +245,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
     else ""
 
   override def toString: String =
-    (AddToStringPrefix("====Overall Core Params====")
-    + "\n"
-    + exe_units.toString
-    + "\n"
-    + fpPipelineStr
-    + "\n"
-    + rob.toString
-    + "\n"
-    + AddToStringPrefix(
+    (BoomCoreStringPrefix("====Overall Core Params====") + "\n"
+    + exe_units.toString + "\n"
+    + fpPipelineStr + "\n"
+    + rob.toString + "\n"
+    + BoomCoreStringPrefix(
         "===Other Core Params===",
         "Fetch Width           : " + fetchWidth,
         "Decode Width          : " + coreWidth,
@@ -264,18 +260,15 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
         "Num Int Phys Registers: " + numIntPhysRegs,
         "Num FP  Phys Registers: " + numFpPhysRegs,
         "Max Branch Count      : " + MAX_BR_COUNT)
-    + AddToStringPrefix(
+    + BoomCoreStringPrefix(
         "RAS Size              : " + (if (enableBTB) boomParams.btb.nRAS else 0),
-        "Rename Stage Latency  : " + renameLatency)
-    + "\n"
-    + iregfile.toString
-    + "\n"
-    + AddToStringPrefix(
+        "Rename Stage Latency  : " + renameLatency) + "\n"
+    + iregfile.toString + "\n"
+    + BoomCoreStringPrefix(
         "Num Slow Wakeup Ports : " + numIrfWritePorts,
         "Num Fast Wakeup Ports : " + exe_units.count(_.bypassable),
-        "Num Bypass Ports      : " + exe_units.numTotalBypassPorts)
-    + "\n"
-    + AddToStringPrefix(
+        "Num Bypass Ports      : " + exe_units.numTotalBypassPorts) + "\n"
+    + BoomCoreStringPrefix(
         "DCache Ways           : " + dcacheParams.nWays,
         "DCache Sets           : " + dcacheParams.nSets,
         "DCache nMSHRs         : " + dcacheParams.nMSHRs,
@@ -284,13 +277,11 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
         "D-TLB Entries         : " + dcacheParams.nTLBEntries,
         "I-TLB Entries         : " + icacheParams.nTLBEntries,
         "Paddr Bits            : " + paddrBits,
-        "Vaddr Bits            : " + vaddrBits)
-    + "\n"
-    + AddToStringPrefix(
+        "Vaddr Bits            : " + vaddrBits) + "\n"
+    + BoomCoreStringPrefix(
         "Using FPU Unit?       : " + usingFPU.toString,
         "Using FDivSqrt?       : " + usingFDivSqrt.toString,
-        "Using VM?             : " + usingVM.toString)
-    + "\n")
+        "Using VM?             : " + usingVM.toString) + "\n")
 
   //-------------------------------------------------------------
   //-------------------------------------------------------------

--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -17,19 +17,19 @@
 
 package boom.exu
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.{ArrayBuffer}
 
 import chisel3._
 import chisel3.util._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.tile.{XLen, RoCCCoreIO}
 import freechips.rocketchip.tile
 
 import FUConstants._
 import boom.common._
-import boom.ifu.GetPCFromFtqIO
-import boom.util.{ImmGen, IsKilledByBranch, BranchKillableQueue}
+import boom.ifu.{GetPCFromFtqIO}
+import boom.util.{ImmGen, IsKilledByBranch, BranchKillableQueue, AddToStringPrefix}
 
 /**
  * Response from Execution Unit. Bundles a MicroOp with data
@@ -239,14 +239,14 @@ class ALUExeUnit(
   require(!(hasMem && hasIfpu),
     "TODO. Currently do not support AluMemExeUnit with FP")
 
-  val out_str = new StringBuilder
-  out_str.append("\n   [Core " + hartId + "] ==ExeUnit==")
-  if (hasAlu)  out_str.append("\n   [Core " + hartId + "]  - ALU")
-  if (hasMul)  out_str.append("\n   [Core " + hartId + "]  - Mul")
-  if (hasDiv)  out_str.append("\n   [Core " + hartId + "]  - Div")
-  if (hasIfpu) out_str.append("\n   [Core " + hartId + "]  - IFPU")
-  if (hasMem)  out_str.append("\n   [Core " + hartId + "]  - Mem")
-  if (hasRocc) out_str.append("\n   [Core " + hartId + "]  - RoCC")
+  val out_str =
+    AddToStringPrefix("==ExeUnit==") +
+    (if (hasAlu)  AddToStringPrefix(" - ALU") else "") +
+    (if (hasMul)  AddToStringPrefix(" - Mul") else "") +
+    (if (hasDiv)  AddToStringPrefix(" - Div") else "") +
+    (if (hasIfpu) AddToStringPrefix(" - IFPU") else "") +
+    (if (hasMem)  AddToStringPrefix(" - Mem") else "") +
+    (if (hasRocc) AddToStringPrefix(" - RoCC") else "")
 
   override def toString: String = out_str.toString
 
@@ -489,11 +489,11 @@ class FPUExeUnit(
     hasFdiv = hasFdiv,
     hasFpiu = hasFpiu) with tile.HasFPUParameters
 {
-  val out_str = new StringBuilder
-  out_str.append("\n   [Core " + hartId + "] ==ExeUnit==")
-  if (hasFpu)  out_str.append("\n   [Core " + hartId + "]  - FPU (Latency: " + dfmaLatency + ")")
-  if (hasFdiv) out_str.append("\n   [Core " + hartId + "]  - FDiv/FSqrt")
-  if (hasFpiu) out_str.append("\n   [Core " + hartId + "]  - FPIU (writes to Integer RF)")
+  val out_str =
+    AddToStringPrefix("==ExeUnit==")
+    (if (hasFpu)  AddToStringPrefix("- FPU (Latency: " + dfmaLatency + ")") else "") +
+    (if (hasFdiv) AddToStringPrefix("- FDiv/FSqrt") else "") +
+    (if (hasFpiu) AddToStringPrefix("- FPIU (writes to Integer RF)") else "")
 
   val fdiv_busy = WireInit(false.B)
   val fpiu_busy = WireInit(false.B)

--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -29,7 +29,7 @@ import freechips.rocketchip.tile
 import FUConstants._
 import boom.common._
 import boom.ifu.{GetPCFromFtqIO}
-import boom.util.{ImmGen, IsKilledByBranch, BranchKillableQueue, AddToStringPrefix}
+import boom.util.{ImmGen, IsKilledByBranch, BranchKillableQueue, BoomCoreStringPrefix}
 
 /**
  * Response from Execution Unit. Bundles a MicroOp with data
@@ -240,13 +240,13 @@ class ALUExeUnit(
     "TODO. Currently do not support AluMemExeUnit with FP")
 
   val out_str =
-    AddToStringPrefix("==ExeUnit==") +
-    (if (hasAlu)  AddToStringPrefix(" - ALU") else "") +
-    (if (hasMul)  AddToStringPrefix(" - Mul") else "") +
-    (if (hasDiv)  AddToStringPrefix(" - Div") else "") +
-    (if (hasIfpu) AddToStringPrefix(" - IFPU") else "") +
-    (if (hasMem)  AddToStringPrefix(" - Mem") else "") +
-    (if (hasRocc) AddToStringPrefix(" - RoCC") else "")
+    BoomCoreStringPrefix("==ExeUnit==") +
+    (if (hasAlu)  BoomCoreStringPrefix(" - ALU") else "") +
+    (if (hasMul)  BoomCoreStringPrefix(" - Mul") else "") +
+    (if (hasDiv)  BoomCoreStringPrefix(" - Div") else "") +
+    (if (hasIfpu) BoomCoreStringPrefix(" - IFPU") else "") +
+    (if (hasMem)  BoomCoreStringPrefix(" - Mem") else "") +
+    (if (hasRocc) BoomCoreStringPrefix(" - RoCC") else "")
 
   override def toString: String = out_str.toString
 
@@ -490,10 +490,10 @@ class FPUExeUnit(
     hasFpiu = hasFpiu) with tile.HasFPUParameters
 {
   val out_str =
-    AddToStringPrefix("==ExeUnit==")
-    (if (hasFpu)  AddToStringPrefix("- FPU (Latency: " + dfmaLatency + ")") else "") +
-    (if (hasFdiv) AddToStringPrefix("- FDiv/FSqrt") else "") +
-    (if (hasFpiu) AddToStringPrefix("- FPIU (writes to Integer RF)") else "")
+    BoomCoreStringPrefix("==ExeUnit==")
+    (if (hasFpu)  BoomCoreStringPrefix("- FPU (Latency: " + dfmaLatency + ")") else "") +
+    (if (hasFdiv) BoomCoreStringPrefix("- FDiv/FSqrt") else "") +
+    (if (hasFpiu) BoomCoreStringPrefix("- FPIU (writes to Integer RF)") else "")
 
   val fdiv_busy = WireInit(false.B)
   val fpiu_busy = WireInit(false.B)

--- a/src/main/scala/exu/execution-units/execution-units.scala
+++ b/src/main/scala/exu/execution-units/execution-units.scala
@@ -13,13 +13,14 @@
 
 package boom.exu
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.{ArrayBuffer}
 
 import chisel3._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Parameters}
 
 import boom.common._
+import boom.util.{AddToStringPrefix}
 
 /**
  * Top level class to wrap all execution units together into a "collection"
@@ -145,16 +146,22 @@ class ExecutionUnits(val fpu: Boolean)(implicit val p: Parameters) extends HasBo
   }
 
   val exeUnitsStr = new StringBuilder
-  if (!fpu) {
-    exeUnitsStr.append(
-      ( "\n   [Core " + hartId + "] ==" + Seq("One","Two","Three","Four")(coreWidth-1) + "-wide Machine=="
-      + "\n   [Core " + hartId + "] ==" + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue==\n"))
-  }
-
   for (exe_unit <- exe_units) {
     exeUnitsStr.append(exe_unit.toString)
   }
-  override def toString: String =  exeUnitsStr.toString
+
+  override def toString: String =
+    (AddToStringPrefix("===ExecutionUnits===")
+    + "\n"
+    + (if (!fpu) {
+      AddToStringPrefix(
+        "==" + Seq("One","Two","Three","Four")(coreWidth-1) + "-wide Machine==",
+        "==" + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue==")
+    } else {
+      ""
+    })
+    + "\n"
+    + exeUnitsStr.toString)
 
   require (exe_units.length != 0)
   if (!fpu) {

--- a/src/main/scala/exu/execution-units/execution-units.scala
+++ b/src/main/scala/exu/execution-units/execution-units.scala
@@ -20,7 +20,7 @@ import chisel3._
 import freechips.rocketchip.config.{Parameters}
 
 import boom.common._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * Top level class to wrap all execution units together into a "collection"
@@ -151,16 +151,14 @@ class ExecutionUnits(val fpu: Boolean)(implicit val p: Parameters) extends HasBo
   }
 
   override def toString: String =
-    (AddToStringPrefix("===ExecutionUnits===")
-    + "\n"
+    (BoomCoreStringPrefix("===ExecutionUnits===") + "\n"
     + (if (!fpu) {
-      AddToStringPrefix(
+      BoomCoreStringPrefix(
         "==" + Seq("One","Two","Three","Four")(coreWidth-1) + "-wide Machine==",
         "==" + Seq("Single","Dual","Triple","Quad","Five","Six")(totalIssueWidth-1) + " Issue==")
     } else {
       ""
-    })
-    + "\n"
+    }) + "\n"
     + exeUnitsStr.toString)
 
   require (exe_units.length != 0)

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -22,7 +22,7 @@ import freechips.rocketchip.tile
 
 import boom.exu.FUConstants._
 import boom.common._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * Top level datapath that wraps the floating point issue window, regfile, and arithmetic units.
@@ -247,10 +247,9 @@ class FpPipeline(implicit p: Parameters) extends BoomModule with tile.HasFPUPara
   }
 
   override def toString: String =
-    (AddToStringPrefix("===FP Pipeline===")
-    + "\n"
+    (BoomCoreStringPrefix("===FP Pipeline===") + "\n"
     + fregfile.toString
-    + AddToStringPrefix(
+    + BoomCoreStringPrefix(
       "Num Wakeup Ports      : " + numWakeupPorts,
       "Num Bypass Ports      : " + exe_units.numTotalBypassPorts))
 }

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -16,12 +16,13 @@ package boom.exu
 import chisel3._
 import chisel3.util._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.rocket
 import freechips.rocketchip.tile
 
 import boom.exu.FUConstants._
 import boom.common._
+import boom.util.{AddToStringPrefix}
 
 /**
  * Top level datapath that wraps the floating point issue window, regfile, and arithmetic units.
@@ -245,9 +246,11 @@ class FpPipeline(implicit p: Parameters) extends BoomModule with tile.HasFPUPara
     exe_units(w).io.req.bits.kill := io.flush_pipeline
   }
 
-  val fpString = exe_units.toString
   override def toString: String =
-    fregfile.toString +
-    "\n   [Core " + hartId + "] Num Wakeup Ports      : " + numWakeupPorts +
-    "\n   [Core " + hartId + "] Num Bypass Ports      : " + exe_units.numTotalBypassPorts + "\n"
+    (AddToStringPrefix("===FP Pipeline===")
+    + "\n"
+    + fregfile.toString
+    + AddToStringPrefix(
+      "Num Wakeup Ports      : " + numWakeupPorts,
+      "Num Bypass Ports      : " + exe_units.numTotalBypassPorts))
 }

--- a/src/main/scala/exu/register-read/regfile.scala
+++ b/src/main/scala/exu/register-read/regfile.scala
@@ -21,7 +21,7 @@ import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 import boom.common._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * IO bundle for a register read port
@@ -88,7 +88,7 @@ abstract class RegisterFile(
 
   private val rf_cost = (numReadPorts + numWritePorts) * (numReadPorts + 2*numWritePorts)
   private val type_str = if (registerWidth == fLen+1) "Floating Point" else "Integer"
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==" + type_str + " Regfile==",
     "Num RF Read Ports     : " + numReadPorts,
     "Num RF Write Ports    : " + numWritePorts,

--- a/src/main/scala/exu/register-read/regfile.scala
+++ b/src/main/scala/exu/register-read/regfile.scala
@@ -21,6 +21,7 @@ import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 import boom.common._
+import boom.util.{AddToStringPrefix}
 
 /**
  * IO bundle for a register read port
@@ -87,12 +88,12 @@ abstract class RegisterFile(
 
   private val rf_cost = (numReadPorts + numWritePorts) * (numReadPorts + 2*numWritePorts)
   private val type_str = if (registerWidth == fLen+1) "Floating Point" else "Integer"
-  override def toString: String =
-    "\n   [Core " + hartId + "] ==" + type_str + " Regfile==" +
-    "\n   [Core " + hartId + "] Num RF Read Ports     : " + numReadPorts +
-    "\n   [Core " + hartId + "] Num RF Write Ports    : " + numWritePorts +
-    "\n   [Core " + hartId + "] RF Cost (R+W)*(R+2W)  : " + rf_cost +
-    "\n   [Core " + hartId + "] Bypassable Units      : " + bypassableArray
+  override def toString: String = AddToStringPrefix(
+    "==" + type_str + " Regfile==",
+    "Num RF Read Ports     : " + numReadPorts,
+    "Num RF Write Ports    : " + numWritePorts,
+    "RF Cost (R+W)*(R+2W)  : " + rf_cost,
+    "Bypassable Units      : " + bypassableArray)
 }
 
 /**

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -990,7 +990,7 @@ class Rob(
     // scalastyle:off
   }
 
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==ROB==",
     "Machine Width      : " + coreWidth,
     "Rob Entries        : " + numRobEntries,

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -990,12 +990,12 @@ class Rob(
     // scalastyle:off
   }
 
-  override def toString: String =
-    "\n   [Core " + hartId + "] ==ROB==" +
-    "\n   [Core " + hartId + "] Machine Width      : " + coreWidth +
-    "\n   [Core " + hartId + "] Rob Entries        : " + numRobEntries +
-    "\n   [Core " + hartId + "] Rob Rows           : " + numRobRows +
-    "\n   [Core " + hartId + "] Rob Row size       : " + log2Ceil(numRobRows) +
-    "\n   [Core " + hartId + "] log2Ceil(coreWidth): " + log2Ceil(coreWidth) +
-    "\n   [Core " + hartId + "] FPU FFlag Ports    : " + numFpuPorts
+  override def toString: String = AddToStringPrefix(
+    "==ROB==",
+    "Machine Width      : " + coreWidth,
+    "Rob Entries        : " + numRobEntries,
+    "Rob Rows           : " + numRobRows,
+    "Rob Row size       : " + log2Ceil(numRobRows),
+    "log2Ceil(coreWidth): " + log2Ceil(coreWidth),
+    "FPU FFlag Ports    : " + numFpuPorts)
 }

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -32,7 +32,7 @@ import boom.bpu._
 import boom.common._
 import boom.exu.{BranchUnitResp, CommitExceptionSignals}
 import boom.lsu.{CanHaveBoomPTW, CanHaveBoomPTWModule}
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * Parameters to manage a L1 Banked ICache
@@ -322,10 +322,8 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
     cover(cond, s"FRONTEND_$label", "Rocket;;" + desc)
 
   override def toString: String =
-    (AddToStringPrefix("====Overall Frontend Params====")
-    + "\n"
-    + bpdpipeline.toString
-    + "\n"
+    (BoomCoreStringPrefix("====Overall Frontend Params====") + "\n"
+    + bpdpipeline.toString + "\n"
     + icache.toString)
 }
 

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -32,6 +32,7 @@ import boom.bpu._
 import boom.common._
 import boom.exu.{BranchUnitResp, CommitExceptionSignals}
 import boom.lsu.{CanHaveBoomPTW, CanHaveBoomPTWModule}
+import boom.util.{AddToStringPrefix}
 
 /**
  * Parameters to manage a L1 Banked ICache
@@ -320,7 +321,12 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
     cover(cond, s"FRONTEND_$label", "Rocket;;" + desc)
 
-  override def toString: String = bpdpipeline.toString + "\n" + icache.toString
+  override def toString: String =
+    (AddToStringPrefix("====Overall Frontend Params====")
+    + "\n"
+    + bpdpipeline.toString
+    + "\n"
+    + icache.toString)
 }
 
 /**

--- a/src/main/scala/ifu/icache.scala
+++ b/src/main/scala/ifu/icache.scala
@@ -29,6 +29,7 @@ import freechips.rocketchip.util.property._
 import freechips.rocketchip.rocket.{HasL1ICacheParameters, ICacheParams, ICacheErrors, ICacheReq}
 
 import boom.common._
+import boom.util.{AddToStringPrefix}
 
 /**
  * ICache module
@@ -630,18 +631,18 @@ class ICacheModule(outer: ICache) extends ICacheBaseModule(outer)
   cover(error_cross_covers)
 
   val ramWidth = dECC.width(wordBits/nBanks)
-  override def toString: String =
-    "\n   [Core " + hartId + "] ==L1-ICache==" +
-    "\n   [Core " + hartId + "] Fetch bytes   : " + cacheParams.fetchBytes +
-    "\n   [Core " + hartId + "] Block bytes   : " + (1 << blockOffBits) +
-    "\n   [Core " + hartId + "] Row bytes     : " + rowBytes +
-    "\n   [Core " + hartId + "] Word bits     : " + wordBits +
-    "\n   [Core " + hartId + "] Sets          : " + nSets +
-    "\n   [Core " + hartId + "] Ways          : " + nWays +
-    "\n   [Core " + hartId + "] Refill cycles : " + refillCycles +
-    "\n   [Core " + hartId + "] RAMs          : (" +  ramWidth + " x " + nSets*refillCycles + ") using " + nBanks + " banks"  +
-    "\n   [Core " + hartId + "] " + (if (nBanks == 2) "Dual-banked" else "Single-banked") +
-    "\n   [Core " + hartId + "] I-TLB entries : " + cacheParams.nTLBEntries + "\n"
+  override def toString: String = AddToStringPrefix(
+    "==L1-ICache==",
+    "Fetch bytes   : " + cacheParams.fetchBytes,
+    "Block bytes   : " + (1 << blockOffBits),
+    "Row bytes     : " + rowBytes,
+    "Word bits     : " + wordBits,
+    "Sets          : " + nSets,
+    "Ways          : " + nWays,
+    "Refill cycles : " + refillCycles,
+    "RAMs          : (" +  ramWidth + " x " + nSets*refillCycles + ") using " + nBanks + " banks",
+    "" + (if (nBanks == 2) "Dual-banked" else "Single-banked"),
+    "I-TLB entries : " + cacheParams.nTLBEntries + "\n")
 }
 
 /**

--- a/src/main/scala/ifu/icache.scala
+++ b/src/main/scala/ifu/icache.scala
@@ -29,7 +29,7 @@ import freechips.rocketchip.util.property._
 import freechips.rocketchip.rocket.{HasL1ICacheParameters, ICacheParams, ICacheErrors, ICacheReq}
 
 import boom.common._
-import boom.util.{AddToStringPrefix}
+import boom.util.{BoomCoreStringPrefix}
 
 /**
  * ICache module
@@ -631,7 +631,7 @@ class ICacheModule(outer: ICache) extends ICacheBaseModule(outer)
   cover(error_cross_covers)
 
   val ramWidth = dECC.width(wordBits/nBanks)
-  override def toString: String = AddToStringPrefix(
+  override def toString: String = BoomCoreStringPrefix(
     "==L1-ICache==",
     "Fetch bytes   : " + cacheParams.fetchBytes,
     "Block bytes   : " + (1 << blockOffBits),

--- a/src/main/scala/system/BoomRocketSubsystem.scala
+++ b/src/main/scala/system/BoomRocketSubsystem.scala
@@ -106,4 +106,7 @@ class BoomRocketSubsystemModuleImp[+L <: BoomRocketSubsystem](_outer: L) extends
     wire.hartid := i.U
     wire.reset_vector := global_reset_vector
   }
+
+  // create file with boom params
+  ElaborationArtefacts.add("""core.config""", outer.tiles.map(x => x.module.toString).mkString("\n"))
 }

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -19,6 +19,8 @@ import chisel3.util._
 import freechips.rocketchip.rocket.Instructions._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.util.{Str}
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.tile.{TileKey}
 
 import boom.common.{MicroOp}
 import boom.exu.{BrResolutionInfo}
@@ -72,7 +74,7 @@ object IsKilledByBranch
 object GetNewUopAndBrMask
 {
   def apply(uop: MicroOp, brinfo: BrResolutionInfo)
-    (implicit p: freechips.rocketchip.config.Parameters): MicroOp = {
+    (implicit p: Parameters): MicroOp = {
     val newuop = WireInit(uop)
     newuop.br_mask := Mux(brinfo.valid,
                           (uop.br_mask & ~brinfo.mask),
@@ -379,7 +381,7 @@ object MaskUpper
  * Assumption: enq.valid only high if not killed by branch (so don't check IsKilled on io.enq).
  */
 class BranchKillableQueue[T <: boom.common.HasBoomUOP](gen: T, entries: Int)
-  (implicit p: freechips.rocketchip.config.Parameters)
+  (implicit p: Parameters)
   extends boom.common.BoomModule()(p)
   with boom.common.HasBoomCoreParameters
 {
@@ -570,5 +572,19 @@ object FPRegToChars
                       " ft8", " ft9", "ft10", "ft11")
     val multiVec = VecInit(for(string <- strings) yield { VecInit(for (c <- string) yield { Str(c) }) })
     multiVec(fpreg)
+  }
+}
+
+object AddToStringPrefix
+{
+  /**
+  * Add prefix to BOOM toString strings
+  *
+  * @param strs list of strings
+  * @return String combining the list with the prefix per line
+  */
+  def apply(strs: String*)(implicit p: Parameters) = {
+    val prefix = "[C" + s"${p(TileKey).hartId}" + "] "
+    strs.map(str => prefix + str + "\n").mkString("")
   }
 }

--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -575,10 +575,10 @@ object FPRegToChars
   }
 }
 
-object AddToStringPrefix
+object BoomCoreStringPrefix
 {
   /**
-  * Add prefix to BOOM toString strings
+  * Add prefix to BOOM strings (currently only adds the hartId)
   *
   * @param strs list of strings
   * @return String combining the list with the prefix per line


### PR DESCRIPTION
**Type of change**: bug fix + other enhancement

**Impact**: no rtl change

**Development Phase**: implementation

**Release Notes**
This adds a new function called `AddToStringPrefix` that makes it so that the prefix for all the BOOM prints is in one location. Additionally, there is a couple of new print headers and spaces to make things a bit clearer. Finally, the `*.core.config` file that is generated is made in the subsystem level so that it can include all tiles in the system rather than just the first.
