### PR TITLE
alwaysBypassable fix

### DIFF
--- a/src/main/scala/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/exu/execution-units/execution-unit.scala
@@ -221,7 +221,7 @@ class ALUExeUnit(
       else if (hasAlu) 1 else 0,
     dataWidth        = p(tile.XLen) + 1,
     bypassable       = hasAlu,
-    alwaysBypassable = hasAlu && !hasMul && !hasDiv,
+    alwaysBypassable = hasAlu && !(hasMem || hasBrUnit || hasMul || hasDiv || hasCSR || hasIfpu || hasRocc),
     hasCSR           = hasCSR,
     hasBrUnit        = hasBrUnit,
     hasAlu           = hasAlu,


### PR DESCRIPTION
Fixed the alwaysBypassable execution unit property to work with the new execution-units generator. It was causing the generation of buggy cores (missing some wakeup ports) for pipeline widths > 2.