### PR TITLE
4-stage fetch

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -61,7 +61,7 @@ case class BoomCoreParams(
   bpdRandom: Option[RandomBpdParameters] = None,
   intToFpLatency: Int = 2,
   imulLatency: Int = 3,
-  fetchLatency: Int = 3,
+  fetchLatency: Int = 4,
   renameLatency: Int = 2,
   nPerfCounters: Int = 0,
   numRXQEntries: Int = 4,

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -174,7 +174,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val intToFpLatency = boomParams.intToFpLatency
 
   val fetchLatency = boomParams.fetchLatency // how many cycles does fetch occupy?
-  require (fetchLatency == 3) // do not currently support changing this
+  require (Seq(3, 4).contains(fetchLatency)) // 3 and 4 cycle fetch supported
   val renameLatency = boomParams.renameLatency // how many cycles does rename occupy?
 
   val enableBrResolutionRegister = boomParams.enableBrResolutionRegister

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -641,7 +641,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
                         + (cfi_idx << log2Ceil(coreInstBytes).U)
                         - Mux(f3_fetch_bundle.edge_inst && cfi_idx === 0.U, 2.U, 0.U))
 
-  when (fb.io.enq.fire() &&
+  when (f4_fire &&
         !f3_fetch_bundle.replay_if &&
         !f3_fetch_bundle.xcpt_pf_if &&
         !f3_fetch_bundle.xcpt_ae_if) {
@@ -695,12 +695,12 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   }
 
   when (io.clear_fetchbuffer ||
-        (fb.io.enq.fire() &&
+        (f4_fire &&
     (f3_fetch_bundle.replay_if || f3_fetch_bundle.xcpt_pf_if || f3_fetch_bundle.xcpt_ae_if))) {
     last_valid := false.B
   }
 
-  when (fb.io.enq.fire() &&
+  when (f4_fire &&
         !f3_fetch_bundle.replay_if &&
         !f3_fetch_bundle.xcpt_pf_if &&
         !f3_fetch_bundle.xcpt_ae_if) {

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -135,7 +135,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   val r_f4_valid = RegInit(false.B)
 
   // Can the F3 stage proceed?
-  val f4_ready = fb.io.enq.ready && ftq.io.enq.ready
+  val f4_ready = (!r_f4_valid || fb.io.enq.ready) && ftq.io.enq.ready
   val f4_fire = f3_valid && f4_ready
 
   // F4 Redirection path.
@@ -538,8 +538,8 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
 
   // Fetch Buffer
-  fb.io.enq.valid := f3_valid && !r_f4_req.valid && f4_ready && f3_fetch_bundle.mask =/= 0.U
-  fb.io.enq.bits  := f3_fetch_bundle
+  fb.io.enq.valid := r_f4_valid && r_f4_fetch_bundle.mask =/= 0.U
+  fb.io.enq.bits  := r_f4_fetch_bundle
   fb.io.clear := io.clear_fetchbuffer
 
   for (i <- 0 until fetchWidth) {

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -143,8 +143,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   val r_f4_fetchpc = Reg(UInt())
 
   // F3 is invalidated by redirects.
-  val f3_valid_masked = f3_valid && !r_f4_req.valid
-  val f3_fire = f3_valid_masked && f4_ready
+  val f3_fire = f3_valid && f4_ready && !clear_f3
 
   // F4 Instruction path.
   val r_f4_fetch_bundle = RegEnable(f3_fetch_bundle, f3_fire)
@@ -528,7 +527,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   } .otherwise {
     r_f4_req.valid := false.B
   }
-  r_f4_valid := (r_f4_valid && !fb.io.enq.ready || f3_fire) && !io.clear_fetchbuffer
+  r_f4_valid := r_f4_valid && !fb.io.enq.ready && !io.clear_fetchbuffer || f3_fire
 
   assert (!(r_f4_req.valid && !r_f4_valid),
     "[fetch] f4-request is high but f4_valid is not.")

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -519,7 +519,6 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
 
   when (io.clear_fetchbuffer || r_f4_req.valid) {
-    r_f4_valid := false.B
     r_f4_req.valid := false.B
   } .elsewhen (f4_ready) {
     r_f4_valid := f3_valid && !(r_f4_valid && r_f4_req.valid)

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -143,7 +143,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   val r_f4_fetchpc = Reg(UInt())
 
   // F3 is invalidated by redirects.
-  val f3_fire = f3_valid && f4_ready && !clear_f3
+  val f3_fire = f3_valid && f4_ready && !clear_f3 && (f3_fetch_bundle.mask =/= 0.U)
 
   // F4 Instruction path.
   val r_f4_fetch_bundle = RegEnable(f3_fetch_bundle, f3_fire)
@@ -539,7 +539,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
 
   // Fetch Buffer
-  fb.io.enq.valid := r_f4_valid && r_f4_fetch_bundle.mask =/= 0.U
+  fb.io.enq.valid := r_f4_valid
   fb.io.enq.bits  := r_f4_fetch_bundle
   fb.io.clear := io.clear_fetchbuffer
 

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -603,9 +603,9 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
 
   if (O3PIPEVIEW_PRINTF) {
-    when (fb.io.enq.fire()) {
-      fseq_reg := fseq_reg + PopCount(fb.io.enq.bits.mask)
-      val bundle = fb.io.enq.bits
+    when (f4_fire) {
+      fseq_reg := fseq_reg + PopCount(f3_fetch_bundle.mask)
+      val bundle = f3_fetch_bundle
       for (i <- 0 until fetchWidth) {
         when (bundle.mask(i)) {
           // TODO for now, manually set the fetch_tsc to point to when the fetch
@@ -621,6 +621,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
       }
     }
   }
+  // TODO Add pipeview output for f4 stage.
 
   //-------------------------------------------------------------
   // **** Assertions ****

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -357,7 +357,8 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   val f3_btb_mask = Wire(UInt(fetchWidth.W))
   val f3_bpd_mask = Wire(UInt(fetchWidth.W))
 
-  when (f3_fire) {
+  // Don't use f3_fire here -- this needs to happen even if all instructions are invalid!
+  when (f3_valid && f4_ready) {
     val last_idx  = Mux(inLastChunk(f3_fetch_bundle.pc) && icIsBanked.B,
                       (fetchWidth/2-1).U, (fetchWidth-1).U)
     prev_is_half := (usingCompressed.B

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -557,7 +557,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   // **** FetchTargetQueue ****
   //-------------------------------------------------------------
 
-  ftq.io.enq.valid := f3_valid_masked
+  ftq.io.enq.valid := f4_fire
   ftq.io.enq.bits.fetch_pc := f3_imemresp.pc
   ftq.io.enq.bits.history := io.f3_bpd_resp.bits.history
   ftq.io.enq.bits.bpd_info := io.f3_bpd_resp.bits.info

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -135,7 +135,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   val r_f4_valid = RegInit(false.B)
 
   // Can the F3 stage proceed?
-  val f4_ready = (!r_f4_valid || fb.io.enq.ready) && ftq.io.enq.ready
+  val f4_ready = ((!r_f4_valid && (fetchLatency == 4).B) || fb.io.enq.ready) && ftq.io.enq.ready
 
   // F4 Redirection path.
   val r_f4_req = Reg(Valid(new PCReq()))
@@ -144,6 +144,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
 
   // F3 is invalidated by redirects.
   val f3_fire = f3_valid && f4_ready && !clear_f3
+
   // F4 Instruction path.
   val r_f4_fetch_bundle = RegEnable(f3_fetch_bundle, f3_fire)
 
@@ -526,7 +527,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   } .otherwise {
     r_f4_req.valid := false.B
   }
-  r_f4_valid := r_f4_valid && !fb.io.enq.ready && !io.clear_fetchbuffer || f3_fire
+  r_f4_valid := r_f4_valid && !fb.io.enq.ready && !io.clear_fetchbuffer && (fetchLatency == 4).B || f3_fire
 
   assert (!(r_f4_req.valid && !r_f4_valid),
     "[fetch] f4-request is high but f4_valid is not.")
@@ -538,8 +539,11 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
 
   // Fetch Buffer
-  fb.io.enq.valid := r_f4_valid && (r_f4_fetch_bundle.mask =/= 0.U)
-  fb.io.enq.bits  := r_f4_fetch_bundle
+  if (fetchLatency == 3) fb.io.enq.valid := f3_fire && (f3_fetch_bundle.mask =/= 0.U)
+  else                   fb.io.enq.valid := r_f4_valid && (r_f4_fetch_bundle.mask =/= 0.U)
+
+  if (fetchLatency == 3) fb.io.enq.bits := f3_fetch_bundle
+  else                   fb.io.enq.bits := r_f4_fetch_bundle
   fb.io.clear := io.clear_fetchbuffer
 
   for (i <- 0 until fetchWidth) {


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Added another stage to instruction fetch. The fetch bundle path is split by an f4 register prior to enqueueing to the fetch buffer. The ftq still enqueues fetch targets in f3, as it is not the endpoint of any long paths.
