### PR TITLE
Back nPMPs

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -97,7 +97,7 @@ case class BoomCoreParams(
   val lrscCycles: Int = 80 // worst case is 14 mispredicted branches + slop
   val retireWidth = decodeWidth
   val jumpInFrontend: Boolean = false // unused in boom
-  val nPMPs: Int = 0 // TODO Fix this!!!!!
+  val nPMPs: Int = 8
 
   override def customCSRs(implicit p: Parameters) = new BoomCustomCSRs
 }


### PR DESCRIPTION
I did not understand why PMP were excluded. If enabled, the pmp test (from riscv-tests) works.