### PR TITLE
Delayed Dispatch

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -402,6 +402,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
   val dec_hazards = (0 until coreWidth).map(w =>
                       dec_valids(w) &&
                       (  !dis_ready
+                      || rob.io.commit.rollback
                       || branch_mask_full(w)
                       || !rename_stage.io.inst_can_proceed(w)
                       || flush_ifu))
@@ -444,7 +445,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
   rename_stage.io.kill := flush_ifu
   rename_stage.io.brinfo := br_unit.brinfo
 
-  rename_stage.io.flush_pipeline := rob.io.flush.valid
+  rename_stage.io.flush := rob.io.flush.valid
   rename_stage.io.debug_rob_empty := rob.io.empty
 
   rename_stage.io.dec_fire := dec_fire

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -378,10 +378,6 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
   //-------------------------------------------------------------
   // Decoders
 
-  // send only 1 RoCC instructions at a time
-  var dec_rocc_found = if (usingRoCC) exe_units.rocc_unit.io.rocc.rxq_full else false.B
-  val rocc_shim_busy = if (usingRoCC) !exe_units.rocc_unit.io.rocc.rxq_empty else false.B
-
   // stall fetch/dcode because we ran out of branch tags
   val branch_mask_full = Wire(Vec(coreWidth, Bool()))
 
@@ -467,6 +463,8 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
   // **** Dispatch Stage ****
   //-------------------------------------------------------------
   //-------------------------------------------------------------
+
+  val rocc_shim_busy = if (usingRoCC) !exe_units.rocc_unit.io.rocc.rxq_empty else false.B
 
   // Rename2/Dispatch pipeline logic
 
@@ -1274,16 +1272,16 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
   io.rocc.exception := csr.io.exception && csr.io.status.xs.orR
   if (usingRoCC) {
     exe_units.rocc_unit.io.rocc.rocc         <> io.rocc
-    exe_units.rocc_unit.io.rocc.dec_uops     := dec_uops
+    exe_units.rocc_unit.io.rocc.dis_uops     := dis_uops
     exe_units.rocc_unit.io.rocc.rob_head_idx := rob.io.rob_head_idx
     exe_units.rocc_unit.io.rocc.rob_pnr_idx  := rob.io.rob_pnr_idx
     exe_units.rocc_unit.io.com_exception     := rob.io.com_xcpt.valid
     exe_units.rocc_unit.io.status            := csr.io.status
 
     for (w <- 0 until coreWidth) {
-       exe_units.rocc_unit.io.rocc.dec_rocc_vals(w) := (
-         dec_fire(w) &&
-         dec_uops(w).uopc === uopROCC)
+       exe_units.rocc_unit.io.rocc.dis_rocc_vals(w) := (
+         dis_fire(w) &&
+         dis_uops(w).uopc === uopROCC)
     }
   }
 

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -445,7 +445,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
   rename_stage.io.kill := flush_ifu
   rename_stage.io.brinfo := br_unit.brinfo
 
-  rename_stage.io.flush := rob.io.flush.valid
+  rename_stage.io.flush := rob.io.flush.valid || io.ifu.sfence_take_pc
   rename_stage.io.debug_rob_empty := rob.io.empty
 
   rename_stage.io.dec_fire := dec_fire

--- a/src/main/scala/exu/execution-units/rocc.scala
+++ b/src/main/scala/exu/execution-units/rocc.scala
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 // The RoCC shim unit. Similar to the LSU, in that we need to allocate entries
-// for instruction bits at decode, and send commands strictly in order.
+// for instruction bits at dispatch, and send commands strictly in order.
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 
@@ -31,8 +31,8 @@ import boom.util._
 class RoCCShimCoreIO(implicit p: Parameters) extends BoomBundle
 {
   // Decode Stage
-  val dec_rocc_vals    = Input(Vec(coreWidth, Bool()))
-  val dec_uops         = Input(Vec(coreWidth, new MicroOp))
+  val dis_rocc_vals    = Input(Vec(coreWidth, Bool()))
+  val dis_uops         = Input(Vec(coreWidth, new MicroOp))
   val rxq_full         = Output(Bool())
   val rxq_empty        = Output(Bool())
   val rxq_idx          = Output(UInt(log2Ceil(numRxqEntries).W))
@@ -95,8 +95,8 @@ class RoCCShim(implicit p: Parameters) extends BoomModule
   val br_mask = WireInit(0.U(maxBrCount.W))
 
   for (w <- 0 until coreWidth) {
-    when (io.core.dec_rocc_vals(w)
-       && io.core.dec_uops(w).uopc === uopROCC) {
+    when (io.core.dis_rocc_vals(w)
+       && io.core.dis_uops(w).uopc === uopROCC) {
       enq_val      := true.B
       rocc_idx     := w.U
     }
@@ -106,8 +106,8 @@ class RoCCShim(implicit p: Parameters) extends BoomModule
     rxq_val      (rxq_tail) := true.B
     rxq_op_val   (rxq_tail) := false.B
     rxq_committed(rxq_tail) := false.B
-    rxq_uop      (rxq_tail) := io.core.dec_uops(rocc_idx)
-    rxq_inst     (rxq_tail) := io.core.dec_uops(rocc_idx).debug_inst
+    rxq_uop      (rxq_tail) := io.core.dis_uops(rocc_idx)
+    rxq_inst     (rxq_tail) := io.core.dis_uops(rocc_idx).debug_inst
     rxq_tail                := WrapInc(rxq_tail, numRxqEntries)
   }
 

--- a/src/main/scala/exu/rename/rename-freelist.scala
+++ b/src/main/scala/exu/rename/rename-freelist.scala
@@ -30,16 +30,12 @@ class RenameFreeList(
   val io = IO(new BoomBundle()(p) {
     // Physical register requests.
     val reqs = Input(Vec(plWidth, Bool()))
-    val can_allocate = Output(Vec(plWidth, Bool()))
-    val alloc_pregs = Output(Vec(plWidth, UInt(pregSz.W)))
+    val alloc_pregs = Output(Vec(plWidth, Valid(UInt(pregSz.W))))
 
     // Pregs returned by the ROB.
     // They come from the "stale" field of committed uops during normal operation,
     // or the pdst field of uops at the tail during exception rollback.
-    val rob_uops = Input(Vec(plWidth, new MicroOp))
-    val com_valids = Input(Vec(plWidth, Bool()))
-    val rbk_valids = Input(Vec(plWidth, Bool()))
-    val rollback = Input(Bool())
+    val dealloc_pregs = Input(Vec(plWidth, Valid(UInt(pregSz.W))))
 
     // Branch info for starting new allocation lists.
     val ren_br_tags = Input(Vec(plWidth, Valid(UInt(brTagSz.W))))
@@ -60,15 +56,13 @@ class RenameFreeList(
 
   // Select pregs from the free list.
   val preg_sels = SelectFirstN(free_list, plWidth)
-  io.can_allocate := preg_sels.map(_.orR)
 
   // Allocations seen by branches in each pipeline slot.
   val alloc_masks = (preg_sels zip io.reqs).scanRight(0.U(numPregs.W)) {case ((preg, req), mask) => Mux(req, mask | preg, mask)}
 
   // Pregs returned by the ROB via commit or rollback.
-  val ret_valids = io.rbk_valids zip io.com_valids map {case (r,c) => r || c}
-  val ret_pregs = io.rob_uops.map(uop => Mux(io.rollback, uop.pdst, uop.stale_pdst))
-  val ret_mask = (ret_pregs zip ret_valids).map {case (preg, valid) => UIntToOH(preg)(numPregs-1,0) & Cat(Fill(numPregs-1, valid.asUInt), 0.U(1.W))}.reduce(_|_)
+  val dealloc_mask = io.dealloc_pregs.map(d =>
+                       UIntToOH(d.bits)(numPregs-1,0) & Cat(Fill(numPregs-1, d.valid.asUInt), 0.U(1.W))).reduce(_|_)
 
   val br_slots = VecInit(io.ren_br_tags.map(tag => tag.valid)).asUInt
   // Create branch allocation lists.
@@ -80,19 +74,20 @@ class RenameFreeList(
 
   when (io.brinfo.mispredict) {
     // Recover pregs allocated past a mispredicted branch.
-    free_list := free_list | br_alloc_lists(io.brinfo.tag) | ret_mask
+    free_list := free_list | br_alloc_lists(io.brinfo.tag) | dealloc_mask
   } .otherwise {
     // Update the free list.
-    free_list := free_list & ~alloc_masks(0) | ret_mask
+    free_list := free_list & ~alloc_masks(0) | dealloc_mask
   }
 
   // Encode outputs.
-  io.alloc_pregs := VecInit(preg_sels.map(s => OHToUInt(s)))
+  io.alloc_pregs zip preg_sels map {case (p,s) => p.bits  := OHToUInt(s)}
+  io.alloc_pregs zip preg_sels map {case (p,s) => p.valid := s.orR}
 
   io.debug.freelist := free_list
   io.debug.isprlist := 0.U  // TODO track commit free list.
 
-  assert (!(free_list & ret_mask).orR, "[freelist] Returning a free physical register.")
+  assert (!(free_list & dealloc_mask).orR, "[freelist] Returning a free physical register.")
 
   val numLregs = if(float) 32 else 31
   assert (!io.debug.pipeline_empty || PopCount(free_list) >= (numPregs - numLregs - 1).U,

--- a/src/main/scala/exu/rename/rename-freelist.scala
+++ b/src/main/scala/exu/rename/rename-freelist.scala
@@ -48,7 +48,7 @@ class RenameFreeList(
     val brinfo = Input(new BrResolutionInfo)
 
     val debug = new Bundle {
-      val rob_empty = Input(Bool())
+      val pipeline_empty = Input(Bool())
       val freelist = Output(Bits(numPregs.W))
       val isprlist = Output(Bits(numPregs.W))
     }
@@ -95,6 +95,6 @@ class RenameFreeList(
   assert (!(free_list & ret_mask).orR, "[freelist] Returning a free physical register.")
 
   val numLregs = if(float) 32 else 31
-  assert (!io.debug.rob_empty || PopCount(free_list) >= (numPregs - numLregs - 1).U,
+  assert (!io.debug.pipeline_empty || PopCount(free_list) >= (numPregs - numLregs - 1).U,
     "[freelist] Leaking physical registers.")
 }

--- a/src/main/scala/exu/rename/rename-freelist.scala
+++ b/src/main/scala/exu/rename/rename-freelist.scala
@@ -61,7 +61,7 @@ class RenameFreeList(
 
   // Pregs returned by the ROB via commit or rollback.
   val dealloc_mask = io.dealloc_pregs.map(d =>
-                       UIntToOH(d.bits)(numPregs-1,0) & Cat(Fill(numPregs-1, d.valid.asUInt), 0.U(1.W))).reduce(_|_)
+                       UIntToOH(d.bits)(numPregs-1,0) & Fill(numPregs, d.valid.asUInt)).reduce(_|_)
 
   val br_slots = VecInit(io.ren_br_tags.map(tag => tag.valid)).asUInt
   // Create branch allocation lists.
@@ -74,10 +74,10 @@ class RenameFreeList(
 
   when (io.brinfo.mispredict) {
     // Recover pregs allocated past a mispredicted branch.
-    free_list := free_list | br_alloc_lists(io.brinfo.tag) | dealloc_mask
+    free_list := (free_list | br_alloc_lists(io.brinfo.tag) | dealloc_mask) & ~(1.U(numPregs.W))
   } .otherwise {
     // Update the free list.
-    free_list := free_list & ~alloc_masks(0) | dealloc_mask
+    free_list := (free_list & ~alloc_masks(0) | dealloc_mask) & ~(1.U(numPregs.W))
   }
 
   // Encode outputs.

--- a/src/main/scala/exu/rename/rename-maptable.scala
+++ b/src/main/scala/exu/rename/rename-maptable.scala
@@ -53,18 +53,18 @@ class RenameMapTable(
 
   val io = IO(new BoomBundle()(p) {
     // Logical sources -> physical sources.
-    val map_reqs = Input(Vec(plWidth, new MapReq(lregSz)))
-    val map_resps = Output(Vec(plWidth, new MapResp(pregSz)))
+    val map_reqs    = Input(Vec(plWidth, new MapReq(lregSz)))
+    val map_resps   = Output(Vec(plWidth, new MapResp(pregSz)))
 
     // Remapping an ldst to a newly allocated pdst?
-    val remap_reqs = Input(Vec(plWidth, new RemapReq(lregSz, pregSz)))
+    val remap_reqs  = Input(Vec(plWidth, new RemapReq(lregSz, pregSz)))
 
     // Dispatching branches: need to take snapshots of table state.
     val ren_br_tags = Input(Vec(plWidth, Valid(UInt(brTagSz.W))))
 
     // Signals for restoring state following misspeculation.
-    val brinfo = Input(new BrResolutionInfo)
-    val rollback = Input(Bool())
+    val brinfo      = Input(new BrResolutionInfo)
+    val rollback    = Input(Bool())
   })
 
   // The map table register array and its branch snapshots.

--- a/src/main/scala/exu/rename/rename-maptable.scala
+++ b/src/main/scala/exu/rename/rename-maptable.scala
@@ -19,12 +19,27 @@ import boom.common._
 import boom.util._
 import freechips.rocketchip.config.Parameters
 
+class MapReq(val lregSz: Int) extends Bundle
+{
+  val lrs1 = UInt(lregSz.W)
+  val lrs2 = UInt(lregSz.W)
+  val lrs3 = UInt(lregSz.W)
+  val ldst = UInt(lregSz.W)
+}
+
 class MapResp(val pregSz: Int) extends Bundle
 {
   val prs1 = UInt(pregSz.W)
   val prs2 = UInt(pregSz.W)
   val prs3 = UInt(pregSz.W)
   val stale_pdst = UInt(pregSz.W)
+}
+
+class RemapReq(val lregSz: Int, val pregSz: Int) extends Bundle
+{
+  val ldst = UInt(lregSz.W)
+  val pdst = UInt(pregSz.W)
+  val valid = Bool()
 }
 
 class RenameMapTable(
@@ -34,6 +49,7 @@ class RenameMapTable(
   val float: Boolean)
   (implicit p: Parameters) extends BoomModule
 {
+  val lregSz = log2Ceil(numLregs)
   val pregSz = log2Ceil(numPregs)
 
   val io = IO(new BoomBundle()(p) {

--- a/src/main/scala/exu/rename/rename-maptable.scala
+++ b/src/main/scala/exu/rename/rename-maptable.scala
@@ -49,16 +49,15 @@ class RenameMapTable(
   val float: Boolean)
   (implicit p: Parameters) extends BoomModule
 {
-  val lregSz = log2Ceil(numLregs)
   val pregSz = log2Ceil(numPregs)
 
   val io = IO(new BoomBundle()(p) {
     // Logical sources -> physical sources.
-    val ren_uops = Input(Vec(plWidth, new MicroOp))
+    val map_reqs = Input(Vec(plWidth, new MapReq(lregSz)))
     val map_resps = Output(Vec(plWidth, new MapResp(pregSz)))
 
     // Remapping an ldst to a newly allocated pdst?
-    val ren_remap_reqs = Input(Vec(plWidth, Bool()))
+    val remap_reqs = Input(Vec(plWidth, new RemapReq(lregSz, pregSz)))
 
     // Dispatching branches: need to take snapshots of table state.
     val ren_br_tags = Input(Vec(plWidth, Valid(UInt(brTagSz.W))))
@@ -66,8 +65,6 @@ class RenameMapTable(
     // Signals for restoring state following misspeculation.
     val brinfo = Input(new BrResolutionInfo)
     val rollback = Input(Bool())
-    val rbk_uops = Input(Vec(plWidth, new MicroOp))
-    val rbk_valids = Input(Vec(plWidth, Bool()))
   })
 
   // The map table register array and its branch snapshots.
@@ -78,10 +75,8 @@ class RenameMapTable(
   val remap_table = Wire(Vec(plWidth+1, Vec(numLregs, UInt(pregSz.W))))
 
   // Uops requesting changes to the map table.
-  val remap_reqs = Mux(io.rollback, VecInit(io.rbk_valids.reverse), io.ren_remap_reqs)
-  val remap_ldsts = io.ren_uops zip io.rbk_uops.reverse map {case (ren, rbk) => Mux(io.rollback, rbk.ldst, ren.ldst)}
-  val remap_pdsts = io.ren_uops zip io.rbk_uops.reverse map {case (ren, rbk) => Mux(io.rollback, rbk.stale_pdst, ren.pdst)}
-  val remap_ldst_reqs = (remap_ldsts zip remap_reqs) map {case (ldst, req) => UIntToOH(ldst) & Fill(numLregs, req.asUInt)}
+  val remap_pdsts = io.remap_reqs map (_.pdst)
+  val remap_ldsts_oh = io.remap_reqs map (req => UIntToOH(req.ldst) & Fill(numLregs, req.valid.asUInt))
 
   // Figure out the new mappings seen by each pipeline slot.
   for (i <- 0 until numLregs) {
@@ -90,7 +85,7 @@ class RenameMapTable(
         remap_table(j)(i) := 0.U
       }
     } else {
-      val remapped_row = (remap_ldst_reqs.map(ldst => ldst(i)) zip remap_pdsts)
+      val remapped_row = (remap_ldsts_oh.map(ldst => ldst(i)) zip remap_pdsts)
         .scanLeft(map_table(i)) {case (pdst, (ldst, new_pdst)) => Mux(ldst, new_pdst, pdst)}
 
       for (j <- 0 until plWidth+1) {
@@ -117,14 +112,14 @@ class RenameMapTable(
   // Read out mappings.
   for (i <- 0 until plWidth) {
     val remapped_col = remap_table(i)
-    io.map_resps(i).prs1 := remapped_col(io.ren_uops(i).lrs1)
-    io.map_resps(i).prs2 := remapped_col(io.ren_uops(i).lrs2)
-    if (float) io.map_resps(i).prs3 := remapped_col(io.ren_uops(i).lrs3) else io.map_resps(i).prs3 := 0.U(pregSz.W)
-    io.map_resps(i).stale_pdst := remapped_col(io.ren_uops(i).ldst)
+    io.map_resps(i).prs1 := remapped_col(io.map_reqs(i).lrs1)
+    io.map_resps(i).prs2 := remapped_col(io.map_reqs(i).lrs2)
+    if (float) io.map_resps(i).prs3 := remapped_col(io.map_reqs(i).lrs3) else io.map_resps(i).prs3 := 0.U(pregSz.W)
+    io.map_resps(i).stale_pdst := remapped_col(io.map_reqs(i).ldst)
   }
 
   // Don't flag the creation of duplicate 'p0' mappings during rollback.
   // These cases may occur soon after reset, as all maptable entries are initialized to 'p0'.
-  remap_pdsts zip remap_reqs foreach {case (p,r) =>
+  io.remap_reqs map (req => (req.pdst, req.valid)) foreach {case (p,r) =>
     assert (!r || !map_table.contains(p) || p === 0.U && io.rollback, "[maptable] Trying to write a duplicate mapping.")}
 }

--- a/src/main/scala/exu/rename/rename-stage.scala
+++ b/src/main/scala/exu/rename/rename-stage.scala
@@ -221,7 +221,7 @@ class RenameStage(
     list.io.com_valids := com_valids(i)
     list.io.rbk_valids := rbk_valids(i) zip ren2_rbk_valids(i) map {case (r1,r2) => r1 || r2}
     list.io.rollback := io.flush || io.rollback
-    list.io.debug.rob_empty := io.debug_rob_empty
+    list.io.debug.pipeline_empty := io.debug_rob_empty && !ren2_valids.reduce(_||_)
   }
 
   // Freelist outputs.

--- a/src/main/scala/exu/rename/rename-stage.scala
+++ b/src/main/scala/exu/rename/rename-stage.scala
@@ -222,6 +222,9 @@ class RenameStage(
     list.io.ren_br_tags := ren1_br_tags
     list.io.brinfo := io.brinfo
     list.io.debug.pipeline_empty := io.debug_rob_empty && !ren2_valids.reduce(_||_)
+
+    assert (ren1_alloc_reqs(i) zip list.io.alloc_pregs map {case (r,p) => !r || p.bits =/= 0.U} reduce (_&&_),
+             "[rename-stage] A uop is trying to allocate the zero physical register.")
   }
 
   // Freelist outputs.

--- a/src/main/scala/exu/rename/rename-stage.scala
+++ b/src/main/scala/exu/rename/rename-stage.scala
@@ -49,10 +49,6 @@ class RenameStageIO(
   val dec_fire  = Input(Vec(plWidth, Bool())) // will commit state updates
   val dec_uops  = Input(Vec(plWidth, new MicroOp()))
 
-  // physical specifiers now available (but not the busy/ready status of the operands).
-  val ren1_mask = Vec(plWidth, Output(Bool()))
-  val ren1_uops = Vec(plWidth, Output(new MicroOp()))
-
   // physical specifiers available AND busy/ready status available.
   val ren2_mask = Vec(plWidth, Output(Bool())) // mask of valid instructions
   val ren2_uops = Vec(plWidth, Output(new MicroOp()))
@@ -351,9 +347,6 @@ class RenameStage(
 
   //-------------------------------------------------------------
   // Outputs
-
-  io.ren1_mask := ren1_fire
-  io.ren1_uops := ren1_uops
 
   io.ren2_mask := ren2_valids
   io.ren2_uops := ren2_uops map {u => GetNewUopAndBrMask(u, io.brinfo)}


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Dispatch into ROB, LSU queues, etc. is delayed until the second stage of rename. This removes any paths which go through decode, the maptable, dispatch hazard-checker, and broadcast into the ROB, which should be good for QoR. This requires the second stage of rename be "rolled back" during pipeline flushes.

The interfaces of the rename structures were also refactored in the process: MicroOps were removed from the interfaces of the maptable and freelist, and their behavior was "simplified". It's not immediately clear that this will result in cleaner code overall, but it should make some planned future features/refactors a bit easier and cleaner.