### PR TITLE
[ren] Handle MV instructions in rename

### DIFF
--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -278,6 +278,7 @@ trait ScalarOpConstants
   val uopSFENCE    = 107.U(UOPC_SZ.W)
 
   val uopROCC      = 108.U(UOPC_SZ.W)
+  val uopMV        = 109.U(UOPC_SZ.W)
 
   // The Bubble Instruction (Machine generated NOP)
   // Insert (XOR x0,x0,x0) which is different from software compiler

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -535,7 +535,7 @@ class BoomCore(implicit p: Parameters, edge: freechips.rocketchip.tilelink.TLEdg
 
   // Get uops from rename2
   for (w <- 0 until coreWidth) {
-    dispatcher.io.ren_uops(w).valid := dis_fire(w)
+    dispatcher.io.ren_uops(w).valid := dis_fire(w) && dis_uops(w).uopc =/= uopMV
     dispatcher.io.ren_uops(w).bits  := dis_uops(w)
   }
 

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -523,9 +523,6 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule
   }
   uop.fu_code    := cs.fu_code
 
-  // x-registers placed in 0-31, f-registers placed in 32-63.
-  // This allows us to straight-up compare register specifiers and not need to
-  // verify the rtypes (e.g., bypassing in rename).
   uop.ldst       := inst(RD_MSB,RD_LSB)
   uop.lrs1       := inst(RS1_MSB,RS1_LSB)
   uop.lrs2       := inst(RS2_MSB,RS2_LSB)

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -573,6 +573,13 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule
   uop.is_call        := (uop.uopc === uopJALR || uop.uopc === uopJAL) &&
                         (uop.ldst === RA)
 
+
+  //------------------------------------------------------------
+  when (cs.uopc === uopADDI && uop.imm_packed === 0.U) {
+    // This is a move
+    uop.uopc := uopMV
+  }
+
   //-------------------------------------------------------------
 
   io.deq.uop := uop

--- a/src/main/scala/exu/issue-units/issue-unit.scala
+++ b/src/main/scala/exu/issue-units/issue-unit.scala
@@ -141,6 +141,7 @@ abstract class IssueUnit(
         dis_uops(w).prs1_busy  := false.B
       }
     }
+    assert(!(io.dis_uops(w).valid && io.dis_uops(w).bits.uopc === uopMV))
   }
 
   //-------------------------------------------------------------

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -304,7 +304,8 @@ class Rob(
     when (io.enq_valids(w)) {
       rob_val(rob_tail)       := true.B
       rob_bsy(rob_tail)       := !(io.enq_uops(w).is_fence ||
-                                   io.enq_uops(w).is_fencei)
+                                   io.enq_uops(w).is_fencei ||
+                                   io.enq_uops(w).uopc === uopMV)
       rob_unsafe(rob_tail)    := io.enq_uops(w).unsafe
       rob_uop(rob_tail)       := io.enq_uops(w)
       rob_exception(rob_tail) := io.enq_uops(w).exception


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature 

<!-- choose one -->
**Impact**: new rtl 

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

`mv` instructions can be handled by just changing the map-table entry for the destination register, without sending the instruction through to dispatch.

The additional complexity here is reading the intermediate map tables to determine what the new physical destination is (since we don't allocate a new pdst from the freelist). There's a way to do this that is cheaper, but its more complex to implement. 

This conflicts with #317 due to changes to the rename interfaces. I'll rebase this when that is done, since this PR still needs some work.

