### PR TITLE
Early Out Divider

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -77,7 +77,7 @@ case class BoomCoreParams(
   mtvecInit: Option[BigInt] = Some(BigInt(0)),
   mtvecWritable: Boolean = true,
   haveCFlush: Boolean = false,
-  mulDiv: Option[freechips.rocketchip.rocket.MulDivParams] = Some(MulDivParams()),
+  mulDiv: Option[freechips.rocketchip.rocket.MulDivParams] = Some(MulDivParams(divEarlyOut=true)),
   nBreakpoints: Int = 1,
   nL2TLBEntries: Int = 512,
   nLocalInterrupts: Int = 0,


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Configure BOOM to have an early-out divider by default. This has very low hardware cost, and boosted dhrystone scores for a particular config by 20%.
