### PR TITLE
[exu] Add chicken bit to kill performance (AKA "Single stage in order pipeline support in a superscalar out-of-order core")

### DIFF
--- a/docs/sections/debugging.rst
+++ b/docs/sections/debugging.rst
@@ -14,7 +14,8 @@ Chicken Bits
 BOOM supports a chicken-bit to delay all instructions from issue until the
 pipeline clears. This effectively turns BOOM into a unpipelined in-order
 core. The chicken bit is controlled by the third bit of the CSR at 0x7c1.
-`csrwi 0x7c1, 0x8` will turn off all out-of-orderiness in the core.
+Writing this CSR with `csrwi 0x7c1, 0x8` will turn off all out-of-orderiness
+in the core. High-performance can be re-enabled with `csrwi 0x7c1, 0x0`.
 
 Pipeline Visualization
 ----------------------

--- a/docs/sections/debugging.rst
+++ b/docs/sections/debugging.rst
@@ -9,6 +9,13 @@ the FireSim tool to debug faster using an FPGA. This tools comes out of the
 UC Berkeley Architecture Research group and is still a work in progress. You
 can find the documentation and website at https://fires.im/.
 
+Chicken Bits
+------------
+BOOM supports a chicken-bit to delay all instructions from issue until the
+pipeline clears. This effectively turns BOOM into a unpipelined in-order
+core. The chicken bit is controlled by the third bit of the CSR at 0x7c1.
+`csrwi 0x7c1, 0x8` will turn off all out-of-orderiness in the core.
+
 Pipeline Visualization
 ----------------------
 

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -113,10 +113,18 @@ class BoomCustomCSRs(implicit p: Parameters) extends freechips.rocketchip.tile.C
     val mask = BigInt(
       tileParams.dcache.get.clockGate.toInt << 0 |
       params.clockGate.toInt << 1 |
-      params.clockGate.toInt << 2
+      params.clockGate.toInt << 2 |
+      1 << 3 // Disable OOO when this bit is high
     )
-    Some(CustomCSR(chickenCSRId, mask, Some(mask)))
+    val init = BigInt(
+      tileParams.dcache.get.clockGate.toInt << 0 |
+      params.clockGate.toInt << 1 |
+      params.clockGate.toInt << 2 |
+      0 << 3 // Enable OOO at init
+    )
+    Some(CustomCSR(chickenCSRId, mask, Some(init)))
   }
+  def disableOOO = getOrElse(chickenCSR, _.value(3), true.B)
 }
 
 /**


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: new rtl

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
`csrwi 0x7c1, 0x8` will disable out-of-orderiness in BOOM. All instructions will wait for pipeline to drain before issue.
