### PR TITLE
Decode QoR

### DIFF
--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -37,6 +37,7 @@ class MicroOp(implicit p: Parameters) extends BoomBundle
   with freechips.rocketchip.rocket.constants.ScalarOpConstants
 {
   val uopc             = UInt(UOPC_SZ.W)       // micro-op code
+  val inst             = UInt(32.W)
   val debug_inst       = UInt(32.W)
   val is_rvc           = Bool()
   val pc               = UInt(coreMaxAddrBits.W) // TODO remove -- use FTQ to get PC. Change to debug_pc.

--- a/src/main/scala/exu/decode.scala
+++ b/src/main/scala/exu/decode.scala
@@ -473,10 +473,7 @@ class DecodeUnit(implicit p: Parameters) extends BoomModule
   if (usingRoCC) decode_table ++= RoCCDecode.table
   decode_table ++= (if (xLen == 64) X64Decode.table else X32Decode.table)
 
-  val rvc_exp    = Module(new RVCExpander)
-  rvc_exp.io.in := io.enq.uop.debug_inst
-  uop.is_rvc    := rvc_exp.io.rvc
-  val inst       = Mux(rvc_exp.io.rvc, rvc_exp.io.out.bits, io.enq.uop.debug_inst)
+  val inst = uop.inst
 
   val cs = Wire(new CtrlSigs()).decode(inst, decode_table)
 

--- a/src/main/scala/ifu/fetch-buffer.scala
+++ b/src/main/scala/ifu/fetch-buffer.scala
@@ -106,6 +106,7 @@ class FetchBuffer(numEntries: Int)(implicit p: Parameters) extends BoomModule
       }
     }
     in_uops(i).ftq_idx        := io.enq.bits.ftq_idx
+    in_uops(i).inst           := io.enq.bits.exp_insts(i)
     in_uops(i).debug_inst     := io.enq.bits.insts(i)
     in_uops(i).is_rvc         := io.enq.bits.insts(i)(1,0) =/= 3.U && usingCompressed.B
     in_uops(i).xcpt_pf_if     := io.enq.bits.xcpt_pf_if

--- a/src/main/scala/ifu/old-fetch-buffer.scala
+++ b/src/main/scala/ifu/old-fetch-buffer.scala
@@ -102,6 +102,7 @@ class OldFetchBuffer(numEntries: Int)(implicit p: Parameters) extends BoomModule
       }
     }
     in_uops(i).ftq_idx        := io.enq.bits.ftq_idx
+    in_uops(i).inst           := io.enq.bits.exp_insts(i)
     in_uops(i).debug_inst     := io.enq.bits.insts(i)
     in_uops(i).is_rvc         := io.enq.bits.insts(i)(1,0) =/= 3.U && usingCompressed.B
     in_uops(i).xcpt_pf_if     := io.enq.bits.xcpt_pf_if


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Have the fetchbuffer store instruction bits which were expanded in F3, rather than compressed instructions. Decode won't need to re-expand them, saving 50~100ps of delay.
