### PR TITLE
[rocc] Remove debug_inst

### DIFF
--- a/src/main/scala/exu/execution-units/rocc.scala
+++ b/src/main/scala/exu/execution-units/rocc.scala
@@ -107,7 +107,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule
     rxq_op_val   (rxq_tail) := false.B
     rxq_committed(rxq_tail) := false.B
     rxq_uop      (rxq_tail) := io.core.dis_uops(rocc_idx)
-    rxq_inst     (rxq_tail) := io.core.dis_uops(rocc_idx).debug_inst
+    rxq_inst     (rxq_tail) := io.core.dis_uops(rocc_idx).inst
     rxq_tail                := WrapInc(rxq_tail, numRxqEntries)
   }
 


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Use inst instead of debug_inst to get the RoCC instruction. Should prevent debug_inst from being propagated through the fetch buffer post synthesis.