### PR TITLE
[ifu] Deprecate support for 3-cycle fetch pipeline

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -183,7 +183,7 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val intToFpLatency = boomParams.intToFpLatency
 
   val fetchLatency = boomParams.fetchLatency // how many cycles does fetch occupy?
-  require (Seq(3, 4).contains(fetchLatency)) // 3 and 4 cycle fetch supported
+  require (fetchLatency == 4) // Only 4-cycle fetch is supported
   val renameLatency = boomParams.renameLatency // how many cycles does rename occupy?
 
   val enableBrResolutionRegister = boomParams.enableBrResolutionRegister

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -137,7 +137,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   val r_f4_valid = RegInit(false.B)
 
   // Can the F3 stage proceed?
-  val f4_ready = ((!r_f4_valid && (fetchLatency == 4).B) || fb.io.enq.ready) && ftq.io.enq.ready
+  val f4_ready = (!r_f4_valid || fb.io.enq.ready) && ftq.io.enq.ready
 
   // F4 Redirection path.
   val r_f4_req = Reg(Valid(new PCReq()))
@@ -537,7 +537,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   } .otherwise {
     r_f4_req.valid := false.B
   }
-  r_f4_valid := r_f4_valid && !fb.io.enq.ready && !io.clear_fetchbuffer && (fetchLatency == 4).B || f3_fire
+  r_f4_valid := r_f4_valid && !fb.io.enq.ready && !io.clear_fetchbuffer || f3_fire
 
   assert (!(r_f4_req.valid && !r_f4_valid),
     "[fetch] f4-request is high but f4_valid is not.")
@@ -549,11 +549,8 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
 
   // Fetch Buffer
-  if (fetchLatency == 3) fb.io.enq.valid := f3_fire && (f3_fetch_bundle.mask =/= 0.U)
-  else                   fb.io.enq.valid := r_f4_valid && (r_f4_fetch_bundle.mask =/= 0.U)
-
-  if (fetchLatency == 3) fb.io.enq.bits := f3_fetch_bundle
-  else                   fb.io.enq.bits := r_f4_fetch_bundle
+  fb.io.enq.valid := r_f4_valid && (r_f4_fetch_bundle.mask =/= 0.U)
+  fb.io.enq.bits := r_f4_fetch_bundle
   fb.io.clear := io.clear_fetchbuffer
 
   for (i <- 0 until fetchWidth) {


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
A 4-stage fetch pipeline has proved crucial for QoR now that BOOM is employing wide, RVC-enabled fetch pipelines. IPC degradation has been minimal.
