### PR TITLE
Make BIM have cleaner name

### DIFF
--- a/src/main/scala/bpu/btb/bim.scala
+++ b/src/main/scala/bpu/btb/bim.scala
@@ -217,7 +217,7 @@ class BimodalTable(val bankBytes: Int)(implicit p: Parameters) extends BoomModul
 
   for (w <- 0 until nBanks) {
     val ram = SyncReadMem(nSets/nBanks, Vec(rowSz, Bool()))
-    ram.suggestName("bim_data_array")
+    ram.suggestName(s"bim_data_array_$w")
 
     val ren = Wire(Bool())
     val s2_rmw_valid = Wire(Bool())


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
Cleans up the name of the BIM table so that it doesn't have an instance name with a `_` at the end.
