### PR TITLE
[core] Always enable fast wakeups to rename stage

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -40,7 +40,6 @@ case class BoomCoreParams(
   enableFastLoadUse: Boolean = true,
   enableCommitMapTable: Boolean = false,
   enableFastPNR: Boolean = false,
-  enableFastWakeupsToRename: Boolean = true,
   enableBTBContainsBranches: Boolean = true,
   enableBranchPredictor: Boolean = true,
   enableBTB: Boolean = true,
@@ -246,7 +245,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val enableCommitMapTable = boomParams.enableCommitMapTable
   require(!enableCommitMapTable) // TODO Fix the commit map table.
   val enableFastPNR = boomParams.enableFastPNR
-  val enableFastWakeupsToRename = boomParams.enableFastWakeupsToRename
 
   //************************************
   // Implicitly calculated constants


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->
Always enable fast wakeups to rename. One less configuration option to maintain.

<!-- choose one -->
**Impact**: no rtl change 

