### PR TITLE
[core] uop.ctrl.rf_wen is just an alias for uop.dst_rtype

### DIFF
--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -301,7 +301,6 @@ trait ScalarOpConstants
     val cs = Wire(new boom.common.CtrlSignals())
     cs             := DontCare // Overridden in the following lines
     cs.br_type     := BR_N
-    cs.rf_wen      := false.B
     cs.csr_cmd     := freechips.rocketchip.rocket.CSR.N
     cs.is_load     := false.B
     cs.is_sta      := false.B

--- a/src/main/scala/common/micro-op.scala
+++ b/src/main/scala/common/micro-op.scala
@@ -142,6 +142,9 @@ class MicroOp(implicit p: Parameters) extends BoomBundle
   val debug_events     = new DebugStageEvents
 
 
+  // Does this register write-back
+  def rf_wen           = dst_rtype =/= RT_X
+
   // Is it possible for this uop to misspeculate, preventing the commit of subsequent uops?
   def unsafe           = uses_ldq || (uses_stq && !is_fence) || (is_br_or_jmp && !is_jal)
 
@@ -150,12 +153,6 @@ class MicroOp(implicit p: Parameters) extends BoomBundle
 
 /**
  * Control signals within a MicroOp
- *
- * NOTE: I can't promise these signals get killed/cleared on a mispredict,
- * so I should listen to the corresponding valid bit
- * For example, on a bypassing, we listen to rf_wen to see if bypass is valid,
- * but we "could" be bypassing to a branch which kills us (a false positive combinational loop),
- * so we have to keep the rf_wen enabled, and not dependent on a branch kill signal
  *
  * TODO REFACTOR this, as this should no longer be true, as bypass occurs in stage before branch resolution
  */
@@ -167,7 +164,6 @@ class CtrlSignals extends Bundle()
   val imm_sel     = UInt(IS_X.getWidth.W)
   val op_fcn      = UInt(freechips.rocketchip.rocket.ALU.SZ_ALU_FN.W)
   val fcn_dw      = Bool()
-  val rf_wen      = Bool()
   val csr_cmd     = UInt(freechips.rocketchip.rocket.CSR.SZ.W)
   val is_load     = Bool()   // will invoke TLB address lookup
   val is_sta      = Bool()   // will invoke TLB address lookup

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -676,7 +676,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
       slow_wakeup := DontCare
 
       val resp = exe_units(i).io.iresp
-      assert(!(resp.valid && resp.bits.uop.ctrl.rf_wen && resp.bits.uop.dst_rtype =/= RT_FIX))
+      assert(!(resp.valid && resp.bits.uop.rf_wen && resp.bits.uop.dst_rtype =/= RT_FIX))
 
       // Fast Wakeup (uses just-issued uops that have known latencies)
       fast_wakeup.bits.uop := iss_uops(i)
@@ -688,7 +688,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
       // Slow Wakeup (uses write-port to register file)
       slow_wakeup.bits.uop := resp.bits.uop
       slow_wakeup.valid    := resp.valid &&
-                                resp.bits.uop.ctrl.rf_wen &&
+                                resp.bits.uop.rf_wen &&
                                 !resp.bits.uop.bypassable &&
                                 resp.bits.uop.dst_rtype === RT_FIX
 
@@ -964,7 +964,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
       val wbdata = wbresp.bits.data
 
       def wbIsValid(rtype: UInt) =
-        wbresp.valid && wbresp.bits.uop.ctrl.rf_wen && wbresp.bits.uop.dst_rtype === rtype
+        wbresp.valid && wbresp.bits.uop.rf_wen && wbresp.bits.uop.dst_rtype === rtype
       val wbReadsCSR = wbresp.bits.uop.ctrl.csr_cmd =/= freechips.rocketchip.rocket.CSR.N
 
       iregfile.io.write_ports(w_cnt).valid     := wbIsValid(RT_FIX)
@@ -979,12 +979,12 @@ class BoomCore(implicit p: Parameters) extends BoomModule
       assert (!wbIsValid(RT_FLT), "[fppipeline] An FP writeback is being attempted to the Int Regfile.")
 
       assert (!(wbresp.valid &&
-        !wbresp.bits.uop.ctrl.rf_wen &&
+        !wbresp.bits.uop.rf_wen &&
         wbresp.bits.uop.dst_rtype === RT_FIX),
         "[fppipeline] An Int writeback is being attempted with rf_wen disabled.")
 
       assert (!(wbresp.valid &&
-        wbresp.bits.uop.ctrl.rf_wen &&
+        wbresp.bits.uop.rf_wen &&
         wbresp.bits.uop.dst_rtype =/= RT_FIX),
         "[fppipeline] writeback being attempted to Int RF with dst != Int type exe_units("+i+").iresp")
       w_cnt += 1
@@ -1039,7 +1039,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
 
       rob.io.wb_resps(cnt).valid := resp.valid && !(wb_uop.uses_stq && !wb_uop.is_amo)
       rob.io.wb_resps(cnt).bits  <> resp.bits
-      rob.io.debug_wb_valids(cnt) := resp.valid && wb_uop.ctrl.rf_wen && wb_uop.dst_rtype === RT_FIX
+      rob.io.debug_wb_valids(cnt) := resp.valid && wb_uop.rf_wen && wb_uop.dst_rtype === RT_FIX
       if (eu.hasFFlags) {
         rob.io.fflags(f_cnt) <> resp.bits.fflags
         f_cnt += 1

--- a/src/main/scala/exu/fp-pipeline.scala
+++ b/src/main/scala/exu/fp-pipeline.scala
@@ -178,7 +178,7 @@ class FpPipeline(implicit p: Parameters) extends BoomModule with tile.HasFPUPara
   fregfile.io.write_ports(0) := RegNext(WritePort(ll_wbarb.io.out, fpregSz, fLen+1, RT_FLT))
 
   assert (ll_wbarb.io.in(0).ready) // never backpressure the memory unit.
-  when (ifpu_resp.valid) { assert (ifpu_resp.bits.uop.ctrl.rf_wen && ifpu_resp.bits.uop.dst_rtype === RT_FLT) }
+  when (ifpu_resp.valid) { assert (ifpu_resp.bits.uop.rf_wen && ifpu_resp.bits.uop.dst_rtype === RT_FLT) }
 
   var w_cnt = 1
   for (i <- 1 until memWidth) {
@@ -189,13 +189,13 @@ class FpPipeline(implicit p: Parameters) extends BoomModule with tile.HasFPUPara
   }
   for (eu <- exe_units) {
     if (eu.writesFrf) {
-      fregfile.io.write_ports(w_cnt).valid     := eu.io.fresp.valid && eu.io.fresp.bits.uop.ctrl.rf_wen
+      fregfile.io.write_ports(w_cnt).valid     := eu.io.fresp.valid && eu.io.fresp.bits.uop.rf_wen
       fregfile.io.write_ports(w_cnt).bits.addr := eu.io.fresp.bits.uop.pdst
       fregfile.io.write_ports(w_cnt).bits.data := eu.io.fresp.bits.data
       eu.io.fresp.ready                        := true.B
       when (eu.io.fresp.valid) {
         assert(eu.io.fresp.ready, "No backpressuring the FPU")
-        assert(eu.io.fresp.bits.uop.ctrl.rf_wen, "rf_wen must be high here")
+        assert(eu.io.fresp.bits.uop.rf_wen, "rf_wen must be high here")
         assert(eu.io.fresp.bits.uop.dst_rtype === RT_FLT, "wb type must be FLT for fpu")
       }
       w_cnt += 1

--- a/src/main/scala/exu/register-read/func-unit-decode.scala
+++ b/src/main/scala/exu/register-read/func-unit-decode.scala
@@ -333,7 +333,6 @@ class RegisterReadDecode(supportedUnits: SupportedFuncUnits)(implicit p: Paramet
 
   // rrd_use_alupipe is unused
   io.rrd_uop.ctrl.br_type := rrd_cs.br_type
-  io.rrd_uop.ctrl.rf_wen  := rrd_cs.rf_wen
   io.rrd_uop.ctrl.op1_sel := rrd_cs.op1_sel
   io.rrd_uop.ctrl.op2_sel := rrd_cs.op2_sel
   io.rrd_uop.ctrl.imm_sel := rrd_cs.imm_sel

--- a/src/main/scala/exu/register-read/register-read.scala
+++ b/src/main/scala/exu/register-read/register-read.scala
@@ -172,9 +172,9 @@ class RegisterRead(
     for (b <- 0 until io.bypass.getNumPorts)
     {
       // can't use "io.bypass.valid(b) since it would create a combinational loop on branch kills"
-      rs1_cases ++= Array((io.bypass.valid(b) && (prs1 === io.bypass.uop(b).pdst) && io.bypass.uop(b).ctrl.rf_wen
+      rs1_cases ++= Array((io.bypass.valid(b) && (prs1 === io.bypass.uop(b).pdst) && io.bypass.uop(b).rf_wen
         && io.bypass.uop(b).dst_rtype === RT_FIX && lrs1_rtype === RT_FIX && (prs1 =/= 0.U), io.bypass.data(b)))
-      rs2_cases ++= Array((io.bypass.valid(b) && (prs2 === io.bypass.uop(b).pdst) && io.bypass.uop(b).ctrl.rf_wen
+      rs2_cases ++= Array((io.bypass.valid(b) && (prs2 === io.bypass.uop(b).pdst) && io.bypass.uop(b).rf_wen
         && io.bypass.uop(b).dst_rtype === RT_FIX && lrs2_rtype === RT_FIX && (prs2 =/= 0.U), io.bypass.data(b)))
     }
 


### PR DESCRIPTION
Just check dst_rtype instead of keeping around a separate signal.