### PR TITLE
Interrupt/exception behavior changes

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -391,8 +391,8 @@ class BoomCore(implicit p: Parameters) extends BoomModule
   val branch_mask_full = Wire(Vec(coreWidth, Bool()))
 
   for (w <- 0 until coreWidth) {
-    dec_valids(w)                      := io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid &&
-                                          !dec_finished_mask(w)
+    dec_valids(w)                      := !dec_finished_mask(w) &&
+                                          ((io.ifu.fetchpacket.valid && dec_fbundle.uops(w).valid) || csr.io.interrupt)
     decode_units(w).io.enq.uop         := dec_fbundle.uops(w).bits
     decode_units(w).io.status          := csr.io.status
     decode_units(w).io.csr_decode      <> csr.io.decode(w)

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -797,7 +797,7 @@ class Rob(
   io.rob_tail_idx := rob_tail_idx
   io.rob_pnr_idx  := rob_pnr_idx
   io.empty        := empty
-  io.ready        := (rob_state === s_normal) && !full
+  io.ready        := (rob_state === s_normal) && !full && !r_xcpt_val
 
   //-----------------------------------------------
   //-----------------------------------------------


### PR DESCRIPTION
- Interrupts do not need to wait for frontend to provide a valid instruction. Interrupts should always immediately enter ROB
- Interrupts/exceptions should block dispatch of younger instructions