### PR TITLE
[exu] Size the badvaddr reg properly to make sign-extending work.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,21 +66,21 @@ jobs:
             - checkout
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Build Verilator and checkout submodules
                 command: |
                     .circleci/prepare-for-rtl-build.sh
                 no_output_timeout: 120m
             - save_cache:
-                key: chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                key: chipyard-v13-{{ checksum "CHIPYARD.hash" }}
                 paths:
                     - "/home/riscvuser/chipyard"
             - save_cache:
-                key: verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                key: verilator-v13-{{ checksum "CHIPYARD.hash" }}
                 paths:
                     - "/home/riscvuser/verilator"
     run-scala-checkstyle:
@@ -114,10 +114,10 @@ jobs:
                     - riscv-tools-installed-v4-{{ checksum "../riscv-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building SmallBoomConfig using Verilator
                 command: .circleci/do-rtl-build.sh smallboom
@@ -146,10 +146,10 @@ jobs:
                     - riscv-tools-installed-v4-{{ checksum "../riscv-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building MediumBoomConfig using Verilator
                 command: .circleci/do-rtl-build.sh mediumboom
@@ -178,10 +178,10 @@ jobs:
                     - riscv-tools-installed-v4-{{ checksum "../riscv-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building LargeBoomConfig using Verilator
                 command: .circleci/do-rtl-build.sh largeboom
@@ -210,10 +210,10 @@ jobs:
                     - riscv-tools-installed-v4-{{ checksum "../riscv-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building MegaBoomConfig using Verilator
                 command: .circleci/do-rtl-build.sh megaboom
@@ -242,10 +242,10 @@ jobs:
                     - riscv-tools-installed-v4-{{ checksum "../riscv-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building SmallBoomAndRocketConfig using Verilator
                 command: .circleci/do-rtl-build.sh boomandrocket
@@ -274,10 +274,10 @@ jobs:
                     - riscv-tools-installed-v4-{{ checksum "../riscv-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building SmallRV32BoomConfig using Verilator
                 command: .circleci/do-rtl-build.sh rv32boom
@@ -306,10 +306,10 @@ jobs:
                     - esp-tools-installed-v4-{{ checksum "../esp-tools.hash" }}
             - restore_cache:
                 keys:
-                    - chipyard-v12-{{ checksum "CHIPYARD.hash" }}
+                    - chipyard-v13-{{ checksum "CHIPYARD.hash" }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Building HwachaBoomConfig using Verilator
                 command: .circleci/do-rtl-build.sh hwachaboom
@@ -338,7 +338,7 @@ jobs:
                     - smallboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run SmallBoomConfig csmith tests
                 command: .circleci/build-run-csmith-tests.sh smallboom 50
@@ -363,7 +363,7 @@ jobs:
                     - smallboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run SmallBoomConfig riscv tests
                 command: .circleci/run-tests.sh smallboom
@@ -387,7 +387,7 @@ jobs:
                     - mediumboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run MediumBoomConfig csmith tests
                 command: .circleci/build-run-csmith-tests.sh mediumboom 50
@@ -412,7 +412,7 @@ jobs:
                     - mediumboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run MediumBoomConfig riscv tests
                 command: .circleci/run-tests.sh mediumboom
@@ -436,7 +436,7 @@ jobs:
                     - largeboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run LargeBoomConfig csmith tests
                 command: .circleci/build-run-csmith-tests.sh largeboom 40
@@ -461,7 +461,7 @@ jobs:
                     - largeboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run LargeBoomConfig riscv tests
                 command: .circleci/run-tests.sh largeboom
@@ -485,7 +485,7 @@ jobs:
                     - megaboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run MegaBoomConfig csmith tests
                 command: .circleci/build-run-csmith-tests.sh megaboom 40
@@ -510,7 +510,7 @@ jobs:
                     - megaboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run MegaBoomConfig riscv tests
                 command: .circleci/run-tests.sh megaboom
@@ -535,7 +535,7 @@ jobs:
                     - smallboomandrocketconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run SmallBoomAndRocketConfig csmith tests
                 command: .circleci/build-run-csmith-tests.sh boomandrocket 50
@@ -560,7 +560,7 @@ jobs:
                     - smallboomandrocketconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run SmallBoomAndRocketConfig riscv tests
                 command: .circleci/run-tests.sh boomandrocket
@@ -584,7 +584,7 @@ jobs:
                     - smallrv32boomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run SmallRV32BoomConfig csmith tests
                 command: .circleci/build-run-csmith-tests.sh rv32boom 50
@@ -609,7 +609,7 @@ jobs:
                     - smallrv32boomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run SmallRV32BoomConfig riscv tests
                 command: .circleci/run-tests.sh rv32boom
@@ -633,7 +633,7 @@ jobs:
                     - hwachaboomconfig-{{ .Branch }}-{{ .Revision }}
             - restore_cache:
                 keys:
-                    - verilator-v12-{{ checksum "CHIPYARD.hash" }}
+                    - verilator-v13-{{ checksum "CHIPYARD.hash" }}
             - run:
                 name: Run HwachaBoomConfig riscv tests
                 command: .circleci/run-tests.sh hwachaboom

--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -248,7 +248,7 @@ class Rob(
   // TODO compress xcpt cause size. Most bits in the middle are zero.
   val r_xcpt_val       = RegInit(false.B)
   val r_xcpt_uop       = Reg(new MicroOp())
-  val r_xcpt_badvaddr  = Reg(UInt(xLen.W))
+  val r_xcpt_badvaddr  = Reg(UInt(coreMaxAddrBits.W))
 
   //--------------------------------------------------
   // Utility


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->
Fixes Linux 5.3 with RVC kernels on FireSim. 

<!-- choose one -->
**Type of change**: bug fix 


