### PR TITLE
[rob] FP stores don't dirty FP regs

### DIFF
--- a/src/main/scala/exu/rob.scala
+++ b/src/main/scala/exu/rob.scala
@@ -596,7 +596,8 @@ class Rob(
   for (w <- 0 until coreWidth) {
     fflags_val(w) :=
       io.commit.valids(w) &&
-      io.commit.uops(w).fp_val
+      io.commit.uops(w).fp_val &&
+      !io.commit.uops(w).uses_stq
 
     fflags(w) := Mux(fflags_val(w), rob_head_fflags(w), 0.U)
 


### PR DESCRIPTION
Not a functional bug. We just want to match the behavior of ISA simulators.