### PR TITLE
Connect local clock and reset to each element in trace port

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1365,6 +1365,8 @@ class BoomCore(implicit p: Parameters) extends BoomModule
   //io.trace := csr.io.trace unused
   if (p(BoomTilesKey)(0).trace) {
     for (w <- 0 until coreWidth) {
+      io.trace(w).clock      := clock
+      io.trace(w).reset      := reset
       io.trace(w).valid      := rob.io.commit.valids(w)
       io.trace(w).iaddr      := Sext(rob.io.commit.uops(w).debug_pc(vaddrBits-1,0), xLen)
       io.trace(w).insn       := rob.io.commit.uops(w).debug_inst


### PR DESCRIPTION
**Related issue**:  None

**Type of change**: bug fix 

**Impact**: new rtl

**Development Phase**:  implementation

This brings BOOM's trace port connections into compliance with recent changes in Rocket Chip. Useful in multi-clock systems with trace enabled.