### PR TITLE
Connect local clock and reset to each element in trace port

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -1332,6 +1332,8 @@ class BoomCore(implicit p: Parameters) extends BoomModule
   //io.trace := csr.io.trace unused
   if (p(BoomTilesKey)(0).trace) {
     for (w <- 0 until coreWidth) {
+      io.trace(w).clock      := clock
+      io.trace(w).reset      := reset
       io.trace(w).valid      := rob.io.commit.valids(w)
       io.trace(w).iaddr      := Sext(rob.io.commit.uops(w).debug_pc(vaddrBits-1,0), xLen)
       io.trace(w).insn       := rob.io.commit.uops(w).debug_inst


### PR DESCRIPTION
**Related issue**: 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: new rtl

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Copy of #433 that should pass CI. The issue was that the CI would run on the #433 PR and would have an older version of Chipyard that is incompatible with the current version of CI.
