### PR TITLE
Rename config mixins to fragments

### DIFF
--- a/docs/sections/boom-ecosystem.rst
+++ b/docs/sections/boom-ecosystem.rst
@@ -15,7 +15,7 @@ The core code structure is shown below:
 * ``src/main/scala/``
 
   * ``bpu/`` - branch predictor unit
-  * ``common/`` - configs mixins, constants, bundles, tile definitions
+  * ``common/`` - configs fragments, constants, bundles, tile definitions
   * ``exu/`` - execute/core unit
   * ``ifu/`` - instruction fetch unit
   * ``lsu/`` - load/store/memory unit

--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -24,7 +24,7 @@ case object BoomTilesKey extends Field[Seq[BoomTileParams]](Nil)
 case object BoomCrossingKey extends Field[Seq[RocketCrossingParams]](List(RocketCrossingParams()))
 
 // ---------------------
-// BOOM Configs
+// BOOM Config Fragments
 // ---------------------
 
 /**
@@ -90,7 +90,7 @@ class WithTrace extends Config((site, here, up) => {
 
 /**
  * Create multiple copies of a BOOM tile (and thus a core).
- * Override with the default mixins to control all params of the tiles.
+ * Override with the default fragments to control all params of the tiles.
  * Default adds small BOOMs.
  *
  * @param n amount of tiles to duplicate
@@ -106,7 +106,7 @@ class WithNBoomCores(n: Int) extends Config(
 
 /**
  * Class to renumber BOOM + Rocket harts so that there are no overlapped harts
- * This mixin assumes Rocket tiles are numbered before BOOM tiles
+ * This fragment assumes Rocket tiles are numbered before BOOM tiles
  * Also makes support for multiple harts depend on Rocket + BOOM
  * Note: Must come after all harts are assigned for it to apply
  */


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
This follows the naming convention stated in Chipyard for config fragments.
