### PR TITLE
Fixed false btb clear

### DIFF
--- a/src/main/scala/bpu/btb/btb-sa.scala
+++ b/src/main/scala/bpu/btb/btb-sa.scala
@@ -110,7 +110,7 @@ class BTBsa(val bankBytes: Int)(implicit p: Parameters) extends BoomBTB
     tags.suggestName("btb_tag_array")
     data.suggestName("btb_data_array")
 
-    val is_valid = (valids >> s1_idx)(0) && RegNext(!wen)
+    val is_valid = (valids >> s1_idx)(0) && RegNext(!wen && !stall)
     val rout     = data.read(s0_idx, !wen)
     val rtag     = tags.read(s0_idx, !wen)
     hits_oh(w)   := is_valid && (rtag === s1_req_tag)


### PR DESCRIPTION
When there was stall (!req_valid), then is_valid remained in the last state.
However, rtag continued to change.
As a result there could be false hits_oh and clear_valid.

**Type of change**: bug fix

**Impact**: new rtl

**Development Phase**: proposal

**Release Notes**