### PR TITLE
Fix issue when building WithoutFPU

### DIFF
--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -98,9 +98,9 @@ class BoomCore(usingTrace: Boolean)(implicit p: Parameters) extends BoomModule
   val decode_units     = for (w <- 0 until decodeWidth) yield { val d = Module(new DecodeUnit); d }
   val dec_brmask_logic = Module(new BranchMaskGenerationLogic(coreWidth))
   val rename_stage     = Module(new RenameStage(coreWidth, numIntPhysRegs, numIntRenameWakeupPorts, false))
-  val fp_rename_stage  = Module(new RenameStage(coreWidth, numFpPhysRegs, numFpWakeupPorts, true))
+  val fp_rename_stage  = if (usingFPU) Module(new RenameStage(coreWidth, numFpPhysRegs, numFpWakeupPorts, true)) else null
   val pred_rename_stage = Module(new PredRenameStage(coreWidth, ftqSz, 1))
-  val rename_stages    = Seq(rename_stage, fp_rename_stage, pred_rename_stage)
+  val rename_stages    = if (usingFPU) Seq(rename_stage, fp_rename_stage, pred_rename_stage) else Seq(rename_stage, pred_rename_stage)
 
   val mem_iss_unit     = Module(new IssueUnitCollapsing(memIssueParam, numIntIssueWakeupPorts))
   mem_iss_unit.suggestName("mem_issue_unit")
@@ -885,8 +885,6 @@ class BoomCore(usingTrace: Boolean)(implicit p: Parameters) extends BoomModule
     for ((renport, fpport) <- fp_rename_stage.io.wakeups zip fp_pipeline.io.wakeups) {
        renport <> fpport
     }
-  } else {
-    fp_rename_stage.io.wakeups := DontCare
   }
   if (enableSFBOpt) {
     pred_rename_stage.io.wakeups(0) := pred_wakeup


### PR DESCRIPTION
**Related issue**: When I'm trying to do the RV64IMAC, the following problem happened:
```
[error] java.lang.UnsupportedOperationException: empty.reduceLeft
[error]         ...
[error]         at boom.exu.RenameBusyTable.<init>(rename-busytable.scala:51)
[error]         at boom.exu.RenameStage.$anonfun$busytable$1(rename-stage.scala:221)
[error]         at chisel3.Module$.do_apply(Module.scala:52)
[error] eehardwaat boom.exu.RenameStage.<init>(rename-stage.scala:221)
[error] 	at boom.exu.BoomCore.$anonfun$fp_rename_stage$1(core.scala:102)
[error] 	at chisel3.Module$.do_apply(Module.scala:52)
[error] 	at boom.exu.BoomCore.<init>(core.scala:102)
[error] 	at boom.common.BoomTileModuleImp.$anonfun$core$1(tile.scala:160)
[error] 	at chisel3.Module$.do_apply(Module.scala:52)
[error] 	at boom.common.BoomTileModuleImp.<init>(tile.scala:160)
[error] 	at boom.common.BoomTile.module$lzycompute(tile.scala:133)
[error] 	at boom.common.BoomTile.module(tile.scala:133)
[error] 	at boom.common.BoomTile.module(tile.scala:70)
[error] 	at freechips.rocketchip.diplomacy.LazyModuleImpLike.$anonfun$instantiate$2(LazyModule.scala:166)
[error] 	at chisel3.Module$.do_apply(Module.scala:52)
[error] 	at freechips.rocketchip.diplomacy.LazyModuleImpLike.$anonfun$instantiate$1(LazyModule.scala:166)
[error] 	at scala.collection.immutable.List.flatMap(List.scala:338)
[error] 	at freechips.rocketchip.diplomacy.LazyModuleImpLike.instantiate(LazyModule.scala:164)
[error] 	at freechips.rocketchip.diplomacy.LazyModuleImpLike.instantiate$(LazyModule.scala:163)
[error] 	at freechips.rocketchip.diplomacy.LazyModuleImp.instantiate(LazyModule.scala:193)
[error] 	at freechips.rocketchip.diplomacy.LazyModuleImp.<init>(LazyModule.scala:194)
[error] 	at freechips.rocketchip.subsystem.BareSubsystemModuleImp.<init>(BaseSubsystem.scala:31)
[error] 	at freechips.rocketchip.subsystem.BaseSubsystemModuleImp.<init>(BaseSubsystem.scala:130)
[error] 	at chipyard.SubsystemModuleImp.<init>(Subsystem.scala:98)
[error] 	at uec.teehardware.TEEHWSystemModule.<init>(TEEHWplatform.scala:176)
[error] 	at uec.teehardware.TEEHWSystem.module$lzycompute(TEEHWplatform.scala:171)
[error] 	at uec.teehardware.TEEHWSystem.module(TEEHWplatform.scala:171)
[error] 	at uec.teehardware.TEEHWPlatform.$anonfun$sys$1(TEEHWplatform.scala:274)
[error] 	at chisel3.Module$.do_apply(Module.scala:52)
[error] 	at uec.teehardware.TEEHWPlatform.<init>(TEEHWplatform.scala:274)
[error] 	at uec.teehardware.TEEHWbase.$anonfun$new$25(TEEHWwrapper.scala:203)
[error] 	at chisel3.Module$.do_apply(Module.scala:52)
[error] 	at uec.teehardware.TEEHWbase.$anonfun$new$24(TEEHWwrapper.scala:203)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at chisel3.withClockAndReset$.apply(MultiClock.scala:25)
[error] 	at uec.teehardware.TEEHWbase.<init>(TEEHWwrapper.scala:201)
[error] 	at uec.teehardware.TEEHWSoC.<init>(TEEHWwrapper.scala:267)
[error] 	at uec.teehardware.FPGADE4.$anonfun$new$35(TEEHWwrapper.scala:631)
[error] 	at chisel3.Module$.do_apply(Module.scala:52)
[error] 	at uec.teehardware.FPGADE4.$anonfun$new$34(TEEHWwrapper.scala:631)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at chisel3.withClockAndReset$.apply(MultiClock.scala:25)
[error] 	at uec.teehardware.FPGADE4.<init>(TEEHWwrapper.scala:629)
[error] 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[error] 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[error] 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[error] 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
[error] 	at freechips.rocketchip.stage.phases.PreElaboration.$anonfun$transform$1(PreElaboration.scala:31)
[error] 	... (Stack trace trimmed to user code only, rerun with --full-stacktrace if you wish to see the full stack trace)

Exception: sbt.TrapExitSecurityException thrown from the UncaughtExceptionHandler in thread "run-main-0"
[error] Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1
[error] Total time: 66 s (01:06), completed Jun 25, 2020 4:14:47 PM
/home/ubuntu/Projects/TEE-HW/tee-hardware-vlsi-2/common.mk:70: recipe for target 'generator_temp' failed
make: *** [generator_temp] Error 1
```

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: unknown

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
After those modifications, I was able to run the RV64IMAC of BOOM:
```
L12: cpu@1 {
	clock-frequency = <0>;
	compatible = "ucb-bar,boom0", "riscv";
	d-cache-block-size = <64>;
	d-cache-sets = <16>;
	d-cache-size = <1024>;
	d-tlb-sets = <1>;
	d-tlb-size = <8>;
	device_type = "cpu";
	hardware-exec-breakpoint-count = <0>;
	i-cache-block-size = <64>;
	i-cache-sets = <16>;
	i-cache-size = <1024>;
	i-tlb-sets = <1>;
	i-tlb-size = <32>;
	mmu-type = "riscv,sv39";
	next-level-cache = <&L0 &L3>;
	reg = <0x1>;
	riscv,isa = "rv64imac";
	riscv,pmpregions = <8>;
	status = "okay";
	timebase-frequency = <1000000>;
	tlb-split;
	L11: interrupt-controller {
		#interrupt-cells = <1>;
		compatible = "riscv,cpu-intc";
		interrupt-controller;
	};
};
```
