### PR TITLE
fdiv: adjust for RC typeTag implementation

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -80,7 +80,9 @@ case class BoomCoreParams(
   mulDiv: Option[freechips.rocketchip.rocket.MulDivParams] = Some(MulDivParams(divEarlyOut=true)),
   nBreakpoints: Int = 0, // TODO Fix with better frontend breakpoint unit
   nL2TLBEntries: Int = 512,
+  nL2TLBWays: Int = 1,
   nLocalInterrupts: Int = 0,
+  useNMI: Boolean = false,
   useAtomics: Boolean = true,
   useDebug: Boolean = true,
   useUser: Boolean = true,

--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -28,6 +28,7 @@ import boom.exu._
 import boom.ifu._
 import boom.lsu._
 import boom.util.{BoomCoreStringPrefix}
+import freechips.rocketchip.prci.ClockSinkParameters
 
 
 case class BoomTileAttachParams(
@@ -61,6 +62,7 @@ case class BoomTileParams(
   val beuAddr: Option[BigInt] = None
   val blockerCtrlAddr: Option[BigInt] = None
   val boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
+  val clockSinkParams: ClockSinkParameters = ClockSinkParameters()
 }
 
 /**

--- a/src/main/scala/exu/execution-units/fdiv.scala
+++ b/src/main/scala/exu/execution-units/fdiv.scala
@@ -19,11 +19,13 @@ import freechips.rocketchip.tile
 import boom.common._
 import boom.util._
 import freechips.rocketchip.tile.HasFPUParameters
+import freechips.rocketchip.util.uintToBitPat
 
 /**
  * Decoder for FPU divide and square root signals
  */
-class UOPCodeFDivDecoder extends Module with HasFPUParameters
+class UOPCodeFDivDecoder(implicit p: Parameters) extends BoomModule
+  with HasFPUParameters
 {
   val io = IO(new Bundle {
     val uopc = Input(Bits(UOPC_SZ.W))
@@ -52,7 +54,7 @@ class UOPCodeFDivDecoder extends Module with HasFPUParameters
       BitPat(uopFDIV_D)  -> List(X,X,Y,Y,X, X,X,D,D,X,X,X, X,Y,N,Y),
       BitPat(uopFSQRT_S) -> List(X,X,Y,N,X, X,X,S,S,X,X,X, X,N,Y,Y),
       BitPat(uopFSQRT_D) -> List(X,X,Y,N,X, X,X,D,D,X,X,X, X,N,Y,Y)
-    ))
+    ): Array[(BitPat, List[BitPat])])
 
   val s = io.sigs
   val sigs = Seq(s.ldst, s.wen, s.ren1, s.ren2, s.ren3, s.swap12,

--- a/src/main/scala/exu/execution-units/fdiv.scala
+++ b/src/main/scala/exu/execution-units/fdiv.scala
@@ -14,16 +14,16 @@ package boom.exu
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.config.Parameters
-
 import freechips.rocketchip.tile.FPConstants._
 import freechips.rocketchip.tile
 import boom.common._
 import boom.util._
+import freechips.rocketchip.tile.HasFPUParameters
 
 /**
  * Decoder for FPU divide and square root signals
  */
-class UOPCodeFDivDecoder extends Module
+class UOPCodeFDivDecoder extends Module with HasFPUParameters
 {
   val io = IO(new Bundle {
     val uopc = Input(Bits(UOPC_SZ.W))
@@ -37,26 +37,26 @@ class UOPCodeFDivDecoder extends Module
   val decoder = freechips.rocketchip.rocket.DecodeLogic(io.uopc,
     // Note: not all of these signals are used or necessary, but we're
     // constrained by the need to fit the rocket.FPU units' ctrl signals.
-    //                                       swap12         fma
-    //                                       | swap32       | div
-    //                                       | | singleIn   | | sqrt
-    //                            ldst       | | | singleOut| | | wflags
-    //                            | wen      | | | | from_int | | |
-    //                            | | ren1   | | | | | to_int | | |
-    //                            | | | ren2 | | | | | | fast | | |
-    //                            | | | | ren3 | | | | | |  | | | |
-    //                            | | | | |  | | | | | | |  | | | |
-    /* Default */            List(X,X,X,X,X, X,X,X,X,X,X,X, X,X,X,X),
+    //                                      swap12         fma
+    //                                      | swap32       | div
+    //                                      | | typeTagIn  | | sqrt
+    //                           ldst       | | | typeTagOut | | wflags
+    //                           | wen      | | | | from_int | | |
+    //                           | | ren1   | | | | | to_int | | |
+    //                           | | | ren2 | | | | | | fast | | |
+    //                           | | | | ren3 | | | | | |  | | | |
+    //                           | | | | |  | | | | | | |  | | | |
+    /* Default */           List(X,X,X,X,X, X,X,X,X,X,X,X, X,X,X,X),
     Array(
-      BitPat(uopFDIV_S)  -> List(X,X,Y,Y,X, X,X,Y,Y,X,X,X, X,Y,N,Y),
-      BitPat(uopFDIV_D)  -> List(X,X,Y,Y,X, X,X,N,N,X,X,X, X,Y,N,Y),
-      BitPat(uopFSQRT_S) -> List(X,X,Y,N,X, X,X,Y,Y,X,X,X, X,N,Y,Y),
-      BitPat(uopFSQRT_D) -> List(X,X,Y,N,X, X,X,N,N,X,X,X, X,N,Y,Y)
+      BitPat(uopFDIV_S)  -> List(X,X,Y,Y,X, X,X,S,S,X,X,X, X,Y,N,Y),
+      BitPat(uopFDIV_D)  -> List(X,X,Y,Y,X, X,X,D,D,X,X,X, X,Y,N,Y),
+      BitPat(uopFSQRT_S) -> List(X,X,Y,N,X, X,X,S,S,X,X,X, X,N,Y,Y),
+      BitPat(uopFSQRT_D) -> List(X,X,Y,N,X, X,X,D,D,X,X,X, X,N,Y,Y)
     ))
 
   val s = io.sigs
   val sigs = Seq(s.ldst, s.wen, s.ren1, s.ren2, s.ren3, s.swap12,
-                 s.swap23, s.singleIn, s.singleOut, s.fromint, s.toint, s.fastpipe, s.fma,
+                 s.swap23, s.typeTagIn, s.typeTagOut, s.fromint, s.toint, s.fastpipe, s.fma,
                  s.div, s.sqrt, s.wflags)
   sigs zip decoder map {case(s,d) => s := d}
 }
@@ -122,10 +122,10 @@ class FDivSqrtUnit(implicit p: Parameters)
 
     r_buffer_fin.rm := io.fcsr_rm
     r_buffer_fin.typ := 0.U // unused for fdivsqrt
-    val tag = !fdiv_decoder.io.sigs.singleIn
+    val tag = fdiv_decoder.io.sigs.typeTagIn
     r_buffer_fin.in1 := unbox(io.req.bits.rs1_data, tag, Some(tile.FType.D))
     r_buffer_fin.in2 := unbox(io.req.bits.rs2_data, tag, Some(tile.FType.D))
-    when (fdiv_decoder.io.sigs.singleIn) {
+    when (tag === S) {
       r_buffer_fin.in1 := in1_upconvert
       r_buffer_fin.in2 := in2_upconvert
     }
@@ -209,12 +209,12 @@ class FDivSqrtUnit(implicit p: Parameters)
   downvert_d2s.io.in := r_out_wdata_double
   downvert_d2s.io.roundingMode := r_divsqrt_fin.rm
   downvert_d2s.io.detectTininess := DontCare
-  val out_flags = r_out_flags_double | Mux(r_divsqrt_fin.singleIn, downvert_d2s.io.exceptionFlags, 0.U)
+  val out_flags = r_out_flags_double | Mux(r_divsqrt_fin.typeTagIn === S, downvert_d2s.io.exceptionFlags, 0.U)
 
   io.resp.valid := r_out_val && !IsKilledByBranch(io.brupdate, r_out_uop)
   io.resp.bits.uop := r_out_uop
   io.resp.bits.data :=
-    Mux(r_divsqrt_fin.singleIn,
+    Mux(r_divsqrt_fin.typeTagIn === S,
       box(downvert_d2s.io.out, false.B),
       box(r_out_wdata_double, true.B))
   io.resp.bits.fflags.valid := io.resp.valid

--- a/src/main/scala/exu/execution-units/fpu.scala
+++ b/src/main/scala/exu/execution-units/fpu.scala
@@ -191,7 +191,10 @@ class FPU(implicit p: Parameters) extends BoomModule with tile.HasFPUParameters
     req.in3 := unbox(io_req.rs3_data, tag, minT)
     when (fp_ctrl.swap23) { req.in3 := req.in2 }
     req.typ := ImmGenTyp(io_req.uop.imm_packed)
-    req.fmt := DontCare //FIXME: this probably should be a new ImmGenFmt() utility?
+    req.fmt := Mux(tag === S, 0.U, 1.U) // TODO support Zfh and avoid special-case below
+    when (io_req.uop.uopc === uopFMV_X_S) {
+      req.fmt := 0.U
+    }
 
     val fma_decoder = Module(new FMADecoder)
     fma_decoder.io.uopc := io_req.uop.uopc

--- a/src/main/scala/exu/execution-units/fpu.scala
+++ b/src/main/scala/exu/execution-units/fpu.scala
@@ -191,6 +191,7 @@ class FPU(implicit p: Parameters) extends BoomModule with tile.HasFPUParameters
     req.in3 := unbox(io_req.rs3_data, tag, minT)
     when (fp_ctrl.swap23) { req.in3 := req.in2 }
     req.typ := ImmGenTyp(io_req.uop.imm_packed)
+    req.fmt := DontCare //FIXME: this probably should be a new ImmGenFmt() utility?
 
     val fma_decoder = Module(new FMADecoder)
     fma_decoder.io.uopc := io_req.uop.uopc

--- a/src/main/scala/exu/execution-units/fpu.scala
+++ b/src/main/scala/exu/execution-units/fpu.scala
@@ -7,14 +7,12 @@ package boom.exu
 
 import chisel3._
 import chisel3.util._
-
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile.FPConstants._
-import freechips.rocketchip.tile.FPUCtrlSigs
+import freechips.rocketchip.tile.{FPUCtrlSigs, HasFPUParameters}
 import freechips.rocketchip.tile
 import freechips.rocketchip.rocket
 import freechips.rocketchip.util.uintToBitPat
-
 import boom.common._
 import boom.util.{ImmGenRm, ImmGenTyp}
 
@@ -25,7 +23,7 @@ import boom.util.{ImmGenRm, ImmGenTyp}
  * most of these signals are already created, just need to be translated
  * to the Rocket FPU-speak
  */
-class UOPCodeFPUDecoder extends Module
+class UOPCodeFPUDecoder extends Module with HasFPUParameters
 {
   val io = IO(new Bundle {
     val uopc = Input(Bits(UOPC_SZ.W))
@@ -44,63 +42,63 @@ class UOPCodeFPUDecoder extends Module
     // constrained by the need to fit the rocket.FPU units' ctrl signals.
     //                                     swap12         fma
     //                                     | swap32       | div
-    //                                     | | singleIn   | | sqrt
-    //                          ldst       | | | singleOut| | | wflags
+    //                                     | | typeTagIn  | | sqrt
+    //                          ldst       | | | typeTagOut | | wflags
     //                          | wen      | | | | from_int | | |
     //                          | | ren1   | | | | | to_int | | |
     //                          | | | ren2 | | | | | | fastpipe |
     //                          | | | | ren3 | | | | | |  | | | |
     //                          | | | | |  | | | | | | |  | | | |
     Array(
-    BitPat(uopFCLASS_S) -> List(X,X,Y,N,N, N,X,Y,Y,N,Y,N, N,N,N,N),
-    BitPat(uopFMV_S_X)  -> List(X,X,N,N,N, X,X,Y,N,Y,N,N, N,N,N,N),
-    BitPat(uopFMV_X_S)  -> List(X,X,Y,N,N, N,X,N,Y,N,Y,N, N,N,N,N),
+    BitPat(uopFCLASS_S) -> List(X,X,Y,N,N, N,X,S,S,N,Y,N, N,N,N,N),
+    BitPat(uopFMV_S_X)  -> List(X,X,N,N,N, X,X,S,D,Y,N,N, N,N,N,N),
+    BitPat(uopFMV_X_S)  -> List(X,X,Y,N,N, N,X,D,S,N,Y,N, N,N,N,N),
 
-    BitPat(uopFCVT_S_X) -> List(X,X,N,N,N, X,X,Y,Y,Y,N,N, N,N,N,Y),
+    BitPat(uopFCVT_S_X) -> List(X,X,N,N,N, X,X,S,S,Y,N,N, N,N,N,Y),
 
-    BitPat(uopFCVT_X_S) -> List(X,X,Y,N,N, N,X,Y,Y,N,Y,N, N,N,N,Y),
+    BitPat(uopFCVT_X_S) -> List(X,X,Y,N,N, N,X,S,S,N,Y,N, N,N,N,Y),
 
-    BitPat(uopCMPR_S)   -> List(X,X,Y,Y,N, N,N,Y,Y,N,Y,N, N,N,N,Y),
+    BitPat(uopCMPR_S)   -> List(X,X,Y,Y,N, N,N,S,S,N,Y,N, N,N,N,Y),
 
-    BitPat(uopFSGNJ_S)  -> List(X,X,Y,Y,N, N,N,Y,Y,N,N,Y, N,N,N,N),
+    BitPat(uopFSGNJ_S)  -> List(X,X,Y,Y,N, N,N,S,S,N,N,Y, N,N,N,N),
 
-    BitPat(uopFMINMAX_S)-> List(X,X,Y,Y,N, N,N,Y,Y,N,N,Y, N,N,N,Y),
+    BitPat(uopFMINMAX_S)-> List(X,X,Y,Y,N, N,N,S,S,N,N,Y, N,N,N,Y),
 
-    BitPat(uopFADD_S)   -> List(X,X,Y,Y,N, N,Y,Y,Y,N,N,N, Y,N,N,Y),
-    BitPat(uopFSUB_S)   -> List(X,X,Y,Y,N, N,Y,Y,Y,N,N,N, Y,N,N,Y),
-    BitPat(uopFMUL_S)   -> List(X,X,Y,Y,N, N,N,Y,Y,N,N,N, Y,N,N,Y),
-    BitPat(uopFMADD_S)  -> List(X,X,Y,Y,Y, N,N,Y,Y,N,N,N, Y,N,N,Y),
-    BitPat(uopFMSUB_S)  -> List(X,X,Y,Y,Y, N,N,Y,Y,N,N,N, Y,N,N,Y),
-    BitPat(uopFNMADD_S) -> List(X,X,Y,Y,Y, N,N,Y,Y,N,N,N, Y,N,N,Y),
-    BitPat(uopFNMSUB_S) -> List(X,X,Y,Y,Y, N,N,Y,Y,N,N,N, Y,N,N,Y)
+    BitPat(uopFADD_S)   -> List(X,X,Y,Y,N, N,Y,S,S,N,N,N, Y,N,N,Y),
+    BitPat(uopFSUB_S)   -> List(X,X,Y,Y,N, N,Y,S,S,N,N,N, Y,N,N,Y),
+    BitPat(uopFMUL_S)   -> List(X,X,Y,Y,N, N,N,S,S,N,N,N, Y,N,N,Y),
+    BitPat(uopFMADD_S)  -> List(X,X,Y,Y,Y, N,N,S,S,N,N,N, Y,N,N,Y),
+    BitPat(uopFMSUB_S)  -> List(X,X,Y,Y,Y, N,N,S,S,N,N,N, Y,N,N,Y),
+    BitPat(uopFNMADD_S) -> List(X,X,Y,Y,Y, N,N,S,S,N,N,N, Y,N,N,Y),
+    BitPat(uopFNMSUB_S) -> List(X,X,Y,Y,Y, N,N,S,S,N,N,N, Y,N,N,Y)
     )
 
   val d_table: Array[(BitPat, List[BitPat])] =
     Array(
-    BitPat(uopFCLASS_D) -> List(X,X,Y,N,N, N,X,N,N,N,Y,N, N,N,N,N),
-    BitPat(uopFMV_D_X)  -> List(X,X,N,N,N, X,X,N,N,Y,N,N, N,N,N,N),
-    BitPat(uopFMV_X_D)  -> List(X,X,Y,N,N, N,X,N,N,N,Y,N, N,N,N,N),
-    BitPat(uopFCVT_S_D) -> List(X,X,Y,N,N, N,X,N,Y,N,N,Y, N,N,N,Y),
-    BitPat(uopFCVT_D_S) -> List(X,X,Y,N,N, N,X,Y,N,N,N,Y, N,N,N,Y),
+    BitPat(uopFCLASS_D) -> List(X,X,Y,N,N, N,X,D,D,N,Y,N, N,N,N,N),
+    BitPat(uopFMV_D_X)  -> List(X,X,N,N,N, X,X,D,D,Y,N,N, N,N,N,N),
+    BitPat(uopFMV_X_D)  -> List(X,X,Y,N,N, N,X,D,D,N,Y,N, N,N,N,N),
+    BitPat(uopFCVT_S_D) -> List(X,X,Y,N,N, N,X,D,S,N,N,Y, N,N,N,Y),
+    BitPat(uopFCVT_D_S) -> List(X,X,Y,N,N, N,X,S,D,N,N,Y, N,N,N,Y),
 
-    BitPat(uopFCVT_D_X) -> List(X,X,N,N,N, X,X,N,N,Y,N,N, N,N,N,Y),
+    BitPat(uopFCVT_D_X) -> List(X,X,N,N,N, X,X,D,D,Y,N,N, N,N,N,Y),
 
-    BitPat(uopFCVT_X_D) -> List(X,X,Y,N,N, N,X,N,N,N,Y,N, N,N,N,Y),
+    BitPat(uopFCVT_X_D) -> List(X,X,Y,N,N, N,X,D,D,N,Y,N, N,N,N,Y),
 
-    BitPat(uopCMPR_D)   -> List(X,X,Y,Y,N, N,N,N,N,N,Y,N, N,N,N,Y),
+    BitPat(uopCMPR_D)   -> List(X,X,Y,Y,N, N,N,D,D,N,Y,N, N,N,N,Y),
 
-    BitPat(uopFSGNJ_D)  -> List(X,X,Y,Y,N, N,N,N,N,N,N,Y, N,N,N,N),
+    BitPat(uopFSGNJ_D)  -> List(X,X,Y,Y,N, N,N,D,D,N,N,Y, N,N,N,N),
 
-    BitPat(uopFMINMAX_D)-> List(X,X,Y,Y,N, N,N,N,N,N,N,Y, N,N,N,Y),
+    BitPat(uopFMINMAX_D)-> List(X,X,Y,Y,N, N,N,D,D,N,N,Y, N,N,N,Y),
 
-    BitPat(uopFADD_D)   -> List(X,X,Y,Y,N, N,Y,N,N,N,N,N, Y,N,N,Y),
-    BitPat(uopFSUB_D)   -> List(X,X,Y,Y,N, N,Y,N,N,N,N,N, Y,N,N,Y),
-    BitPat(uopFMUL_D)   -> List(X,X,Y,Y,N, N,N,N,N,N,N,N, Y,N,N,Y),
+    BitPat(uopFADD_D)   -> List(X,X,Y,Y,N, N,Y,D,D,N,N,N, Y,N,N,Y),
+    BitPat(uopFSUB_D)   -> List(X,X,Y,Y,N, N,Y,D,D,N,N,N, Y,N,N,Y),
+    BitPat(uopFMUL_D)   -> List(X,X,Y,Y,N, N,N,D,D,N,N,N, Y,N,N,Y),
 
-    BitPat(uopFMADD_D)  -> List(X,X,Y,Y,Y, N,N,N,N,N,N,N, Y,N,N,Y),
-    BitPat(uopFMSUB_D)  -> List(X,X,Y,Y,Y, N,N,N,N,N,N,N, Y,N,N,Y),
-    BitPat(uopFNMADD_D) -> List(X,X,Y,Y,Y, N,N,N,N,N,N,N, Y,N,N,Y),
-    BitPat(uopFNMSUB_D) -> List(X,X,Y,Y,Y, N,N,N,N,N,N,N, Y,N,N,Y)
+    BitPat(uopFMADD_D)  -> List(X,X,Y,Y,Y, N,N,D,D,N,N,N, Y,N,N,Y),
+    BitPat(uopFMSUB_D)  -> List(X,X,Y,Y,Y, N,N,D,D,N,N,N, Y,N,N,Y),
+    BitPat(uopFNMADD_D) -> List(X,X,Y,Y,Y, N,N,D,D,N,N,N, Y,N,N,Y),
+    BitPat(uopFNMSUB_D) -> List(X,X,Y,Y,Y, N,N,D,D,N,N,N, Y,N,N,Y)
     )
 
 //   val insns = fLen match {
@@ -112,7 +110,7 @@ class UOPCodeFPUDecoder extends Module
 
   val s = io.sigs
   val sigs = Seq(s.ldst, s.wen, s.ren1, s.ren2, s.ren3, s.swap12,
-                 s.swap23, s.singleIn, s.singleOut, s.fromint, s.toint, s.fastpipe, s.fma,
+                 s.swap23, s.typeTagIn, s.typeTagOut, s.fromint, s.toint, s.fastpipe, s.fma,
                  s.div, s.sqrt, s.wflags)
   sigs zip decoder map {case(s,d) => s := d}
 }
@@ -185,7 +183,7 @@ class FPU(implicit p: Parameters) extends BoomModule with tile.HasFPUParameters
 
   def fuInput(minT: Option[tile.FType]): tile.FPInput = {
     val req = Wire(new tile.FPInput)
-    val tag = !fp_ctrl.singleIn
+    val tag = fp_ctrl.typeTagIn
     req <> fp_ctrl
     req.rm := fp_rm
     req.in1 := unbox(io_req.rs1_data, tag, minT)
@@ -201,11 +199,11 @@ class FPU(implicit p: Parameters) extends BoomModule with tile.HasFPUParameters
   }
 
   val dfma = Module(new tile.FPUFMAPipe(latency = fpu_latency, t = tile.FType.D))
-  dfma.io.in.valid := io.req.valid && fp_ctrl.fma && !fp_ctrl.singleOut
+  dfma.io.in.valid := io.req.valid && fp_ctrl.fma && (fp_ctrl.typeTagOut === D)
   dfma.io.in.bits := fuInput(Some(dfma.t))
 
   val sfma = Module(new tile.FPUFMAPipe(latency = fpu_latency, t = tile.FType.S))
-  sfma.io.in.valid := io.req.valid && fp_ctrl.fma && fp_ctrl.singleOut
+  sfma.io.in.valid := io.req.valid && fp_ctrl.fma && (fp_ctrl.typeTagOut === S)
   sfma.io.in.bits := fuInput(Some(sfma.t))
 
   val fpiu = Module(new tile.FPToInt)
@@ -221,7 +219,7 @@ class FPU(implicit p: Parameters) extends BoomModule with tile.HasFPUParameters
   fpmu.io.in.valid := io.req.valid && fp_ctrl.fastpipe
   fpmu.io.in.bits := fpiu.io.in.bits
   fpmu.io.lt := fpiu.io.out.bits.lt
-  val fpmu_double = Pipe(io.req.valid && fp_ctrl.fastpipe, !fp_ctrl.singleOut, fpu_latency).bits
+  val fpmu_double = Pipe(io.req.valid && fp_ctrl.fastpipe, fp_ctrl.typeTagOut === D, fpu_latency).bits
 
   // Response (all FP units have been padded out to the same latency)
   io.resp.valid := fpiu_out.valid ||

--- a/src/main/scala/exu/execution-units/fpu.scala
+++ b/src/main/scala/exu/execution-units/fpu.scala
@@ -23,7 +23,7 @@ import boom.util.{ImmGenRm, ImmGenTyp}
  * most of these signals are already created, just need to be translated
  * to the Rocket FPU-speak
  */
-class UOPCodeFPUDecoder extends Module with HasFPUParameters
+class UOPCodeFPUDecoder(implicit p: Parameters) extends BoomModule with HasFPUParameters
 {
   val io = IO(new Bundle {
     val uopc = Input(Bits(UOPC_SZ.W))

--- a/src/main/scala/exu/execution-units/functional-unit.scala
+++ b/src/main/scala/exu/execution-units/functional-unit.scala
@@ -605,6 +605,7 @@ class IntToFPUnit(latency: Int)(implicit p: Parameters)
   req.in2 := unbox(io_req.rs2_data, tag, None)
   req.in3 := DontCare
   req.typ := ImmGenTyp(io_req.uop.imm_packed)
+  req.fmt := DontCare // FIXME: this may not be the right thing to do here
   req.fmaCmd := DontCare
 
   assert (!(io.req.valid && fp_ctrl.fromint && req.in1(xLen).asBool),

--- a/src/main/scala/exu/execution-units/functional-unit.scala
+++ b/src/main/scala/exu/execution-units/functional-unit.scala
@@ -596,7 +596,7 @@ class IntToFPUnit(latency: Int)(implicit p: Parameters)
   val fp_ctrl = fp_decoder.io.sigs
   val fp_rm = Mux(ImmGenRm(io_req.uop.imm_packed) === 7.U, io.fcsr_rm, ImmGenRm(io_req.uop.imm_packed))
   val req = Wire(new tile.FPInput)
-  val tag = !fp_ctrl.singleIn
+  val tag = fp_ctrl.typeTagIn
 
   req <> fp_ctrl
 
@@ -617,7 +617,7 @@ class IntToFPUnit(latency: Int)(implicit p: Parameters)
   ifpu.io.in.valid := io.req.valid
   ifpu.io.in.bits := req
   ifpu.io.in.bits.in1 := io_req.rs1_data
-  val out_double = Pipe(io.req.valid, !fp_ctrl.singleOut, intToFpLatency).bits
+  val out_double = Pipe(io.req.valid, fp_ctrl.typeTagOut === D, intToFpLatency).bits
 
 //io.resp.bits.data              := box(ifpu.io.out.bits.data, !io.resp.bits.uop.fp_single)
   io.resp.bits.data              := box(ifpu.io.out.bits.data, out_double)


### PR DESCRIPTION
chipsalliance/rocket-chip#2723 implemented typeTag in rocket.FPU
control signals.  Update fdiv accordingly

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature 

<!-- choose one -->
**Impact**: new rtl 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
