### PR TITLE
Remove automatic upstreaming for fork PRs + Small updates to PR template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,39 +483,9 @@ jobs:
                             .circleci/firesim-run-finished.sh largefireboom spec17-intspeed-test-600 << pipeline.parameters.launchrunfarm_passed >> << pipeline.parameters.infrasetup_passed >> << pipeline.parameters.runworkload_passed >>
                         no_output_timeout: 30m
 
-    ###########################################################################################
-
-    push-fork-upstream:
-        executor: main-env
-        steps:
-            - run:
-                name: Install Git Push Script
-                command: |
-                    curl -sL https://raw.githubusercontent.com/jklukas/git-push-fork-to-upstream-branch/master/git-push-fork-to-upstream-branch > /usr/local/bin/git-push-fork-to-upstream-branch
-                    chmod 755 /usr/local/bin/git-push-fork-to-upstream-branch
-
-            - ssh-checkout
-
-            - run:
-                name: Checkout upstream
-                command: |
-                    git remote add upstream https://github.com/riscv-boom/riscv-boom.git
-                    git fetch --all
-
-            - run:
-                name: Configure and push fork branch
-                command: |
-                    git-push-fork-to-upstream-branch upstream $CIRCLE_PR_USERNAME:$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.head.ref')
-
 # Order and dependencies of jobs to run
 workflows:
     version: 2
-    checkstyle-workflow:
-        when: << pipeline.parameters.build-and-test-boom-configs-run >>
-        jobs:
-            # Run generic syntax checking
-            - run-scala-checkstyle
-
     build-and-test-boom-configs:
         when: << pipeline.parameters.build-and-test-boom-configs-run >>
         jobs:
@@ -531,6 +501,11 @@ workflows:
 
             # Setup build environment
             - prepare-build-environment:
+                filters:
+                    <<: *ignore_fork
+
+            # Run generic syntax checking
+            - run-scala-checkstyle:
                 filters:
                     <<: *ignore_fork
 
@@ -662,18 +637,3 @@ workflows:
         when: << pipeline.parameters.finish-firesim-workload-run >>
         jobs:
             - largefireboom-workload-finished
-
-    push-fork-upstream-workload:
-        jobs:
-            # comment
-            - push-approval:
-                filters: &only_fork
-                    branches:
-                        only: /pull\/[0-9]+/
-                type: approval
-
-            - push-fork-upstream:
-                filters:
-                    <<: *only_fork
-                requires:
-                    - push-approval

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!-- ******************************************************* -->
+<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
+<!-- ******************************************************* -->
+
 **Related issue**: <!-- if applicable -->
 
 <!-- choose one -->
@@ -11,3 +15,9 @@
 
 **Release Notes**
 <!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
+
+<!-- Uncomment for forked PRs -->
+<!--
+**DEVS ONLY: FORKED PR**
+Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
+-->


### PR DESCRIPTION
**Related issue**: #511 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
This removes the automatic upstreaming of a fork PR branch to the main repository to trigger CI. Currently, there is no nice way to write to `riscv-boom/riscv-boom` without exposing secrets. We could enable passing secrets to fork PR builds with an approval button to ensure anything run is checked by BOOM devs... but nothing prevents forked PRs from changing the `config.yml` file and getting rid of the approval button. Additionally, if we don't pass secrets and have automatic upstreaming, we need an SSH key to write the fork PR branch to the main repo... this can leak since fork PR's can run the CI with SSH enabled and access the key. Maybe CircleCI improves this in the future or has a bypass mechanism? Maybe we have to have a GH bot that only devs can call which does this upstreaming separately?

I think the best most secure solution, for now, is to have a BOOM developer push the fork PR branch to the main repository using something like https://github.com/jklukas/git-push-fork-to-upstream-branch (the commit of the local branch should match the commit of the fork PR branch). This is basically doing the same thing as before but doesn't require opening a new PR with the local branch.
