### PR TITLE
lsu,mshr: fix not fully initialized issue for atomics

### DIFF
--- a/src/main/scala/lsu/mshrs.scala
+++ b/src/main/scala/lsu/mshrs.scala
@@ -438,7 +438,7 @@ class BoomIOMSHR(id: Int)(implicit edge: TLEdgeOut, p: Parameters) extends BoomM
   } else {
     // If no managers support atomics, assert fail if processor asks for them
     assert(state === s_idle || !isAMO(req.uop.mem_cmd))
-    Wire(new TLBundleA(edge.bundle))
+    (0.U).asTypeOf(new TLBundleA(edge.bundle))
   }
   assert(state === s_idle || req.uop.mem_cmd =/= M_XSC)
 


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

In chisel3, we should use `0.U.asTypeOf(...)` to initialize the signal.

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
