### PR TITLE
remove objectmodule

### DIFF
--- a/src/main/scala/common/tile.scala
+++ b/src/main/scala/common/tile.scala
@@ -14,7 +14,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalTreeNode }
+
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/ifu/bpd/ras.scala
+++ b/src/main/scala/ifu/bpd/ras.scala
@@ -17,7 +17,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{ICacheLogicalTreeNode}
+
 
 import boom.common._
 import boom.exu.{CommitExceptionSignals, BranchDecode, BrUpdateInfo}

--- a/src/main/scala/lsu/dcache.scala
+++ b/src/main/scala/lsu/dcache.scala
@@ -284,7 +284,7 @@ class BoomDuplicatedDataArray(implicit p: Parameters) extends AbstractBoomDataAr
 
     val raddr = io.read(j).bits.addr >> rowOffBits
     for (w <- 0 until nWays) {
-      val (array, omSRAM) = DescribedSRAM(
+      val array = DescribedSRAM(
         name = s"array_${w}_${j}",
         desc = "Non-blocking DCache Data Array",
         size = nSets * refillCycles,
@@ -347,7 +347,7 @@ class BoomBankedDataArray(implicit p: Parameters) extends AbstractBoomDataArray 
     val s2_bank_reads = Reg(Vec(nBanks, Bits(encRowBits.W)))
 
     for (b <- 0 until nBanks) {
-      val (array, omSRAM) = DescribedSRAM(
+      val array = DescribedSRAM(
         name = s"array_${w}_${b}",
         desc = "Non-blocking DCache Data Array",
         size = bankSize,


### PR DESCRIPTION
This is needed for RC bumping after chipsalliance/rocket-chip#2967 get merged. 