### PR TITLE
Fix decode from rocket-chip new opcode

### DIFF
--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -202,9 +202,9 @@ trait ScalarOpConstants
   //               =  66.U(UOPC_SZ.W)
   val uopAMO_AG    =  67.U(UOPC_SZ.W) // AMO-address gen (use normal STD for datagen)
 
-  val uopFMV_S_X   =  68.U(UOPC_SZ.W)
+  val uopFMV_W_X   =  68.U(UOPC_SZ.W)
   val uopFMV_D_X   =  69.U(UOPC_SZ.W)
-  val uopFMV_X_S   =  70.U(UOPC_SZ.W)
+  val uopFMV_X_W   =  70.U(UOPC_SZ.W)
   val uopFMV_X_D   =  71.U(UOPC_SZ.W)
 
   val uopFSGNJ_S   =  72.U(UOPC_SZ.W)

--- a/src/main/scala/exu/execution-units/fpu.scala
+++ b/src/main/scala/exu/execution-units/fpu.scala
@@ -51,8 +51,8 @@ class UOPCodeFPUDecoder(implicit p: Parameters) extends BoomModule with HasFPUPa
     //                          | | | | |  | | | | | | |  | | | |
     Array(
     BitPat(uopFCLASS_S) -> List(X,X,Y,N,N, N,X,S,S,N,Y,N, N,N,N,N),
-    BitPat(uopFMV_S_X)  -> List(X,X,N,N,N, X,X,S,D,Y,N,N, N,N,N,N),
-    BitPat(uopFMV_X_S)  -> List(X,X,Y,N,N, N,X,D,S,N,Y,N, N,N,N,N),
+    BitPat(uopFMV_W_X)  -> List(X,X,N,N,N, X,X,S,D,Y,N,N, N,N,N,N),
+    BitPat(uopFMV_X_W)  -> List(X,X,Y,N,N, N,X,D,S,N,Y,N, N,N,N,N),
 
     BitPat(uopFCVT_S_X) -> List(X,X,N,N,N, X,X,S,S,Y,N,N, N,N,N,Y),
 
@@ -192,7 +192,7 @@ class FPU(implicit p: Parameters) extends BoomModule with tile.HasFPUParameters
     when (fp_ctrl.swap23) { req.in3 := req.in2 }
     req.typ := ImmGenTyp(io_req.uop.imm_packed)
     req.fmt := Mux(tag === S, 0.U, 1.U) // TODO support Zfh and avoid special-case below
-    when (io_req.uop.uopc === uopFMV_X_S) {
+    when (io_req.uop.uopc === uopFMV_X_W) {
       req.fmt := 0.U
     }
 

--- a/src/main/scala/exu/register-read/func-unit-decode.scala
+++ b/src/main/scala/exu/register-read/func-unit-decode.scala
@@ -220,9 +220,9 @@ object FpuRRdDecode extends RRdDecodeConstants
          BitPat(uopFCLASS_S)->List(BR_N, Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
          BitPat(uopFCLASS_D)->List(BR_N, Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
 
-//         BitPat(uopFMV_S_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
+//         BitPat(uopFMV_W_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
 //         BitPat(uopFMV_D_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
-         BitPat(uopFMV_X_S)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
+         BitPat(uopFMV_X_W)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
          BitPat(uopFMV_X_D)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
          BitPat(uopFSGNJ_S)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
          BitPat(uopFSGNJ_D)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
@@ -273,7 +273,7 @@ object IfmvRRdDecode extends RRdDecodeConstants
                                // |      |  |  use mem pipe        |         |         |     rf wen |
                                // |      |  |  |  alu fcn  wd/word?|         |         |     |      |
                                // |      |  |  |  |        |       |         |         |     |      |
-         BitPat(uopFMV_S_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
+         BitPat(uopFMV_W_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
          BitPat(uopFMV_D_X)->List(BR_N , Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),
 
          BitPat(uopFCVT_S_X) ->List(BR_N,Y, N, N, FN_X   , DW_X  , OP1_X   , OP2_X   , IS_X, REN_1, CSR.N),


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: https://github.com/chipsalliance/rocket-chip/pull/2972

<!-- choose one -->
**Type of change**: bug fix

Since https://github.com/riscv/riscv-opcodes/pull/106 the API of riscv-opcodes has changed, especially on `SLLI_RV32` and RoCC custom instructions. Rocket Chip has bumped to new API, BOOM here also needs to bump them.

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

Fixed rocketchip Instructions API since https://github.com/chipsalliance/rocket-chip/pull/2972

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
