### PR TITLE
icache: switch dataArrays' size to ramDepth

### DIFF
--- a/src/main/scala/ifu/icache.scala
+++ b/src/main/scala/ifu/icache.scala
@@ -196,7 +196,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
       DescribedSRAM(
         name = s"dataArrayWay_${x}",
         desc = "ICache Data Array",
-        size = nSets * refillCycles,
+        size = ramDepth,
         data = UInt((wordBits).W)
       )
     }
@@ -206,14 +206,14 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
       DescribedSRAM(
         name = s"dataArrayB0Way_${x}",
         desc = "ICache Data Array",
-        size = nSets * refillCycles,
+        size = ramDepth,
         data = UInt((wordBits/nBanks).W)
       )} ++
     (0 until nWays).map { x =>
       DescribedSRAM(
         name = s"dataArrayB1Way_${x}",
         desc = "ICache Data Array",
-        size = nSets * refillCycles,
+        size = ramDepth,
         data = UInt((wordBits/nBanks).W)
       )}
   }


### PR DESCRIPTION
**Related issue**: #618

**Type of change**: bug fix

**Impact**: rtl refactoring

**Development Phase**: proposal

**Release Notes**
In icache.scala, the dataArrays' size was nSets * refillCycles. But in the case of (refillsToOneBank && nBanks == 2), it should be nSets * refillCycles / 2, otherwise only half of the capacity is used.
