### PR TITLE
[lsu] Fix logic for avoiding deadlock by blocking load wakeup

### DIFF
--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -1207,7 +1207,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
     when (will_fire_store_commit(0) || !can_fire_store_commit(0)) {
       store_blocked_counter := 0.U
     } .elsewhen (can_fire_store_commit(0) && !will_fire_store_commit(0)) {
-      store_blocked_counter := Mux(store_blocked_counter === 15.U, store_blocked_counter + 1.U, 15.U)
+      store_blocked_counter := Mux(store_blocked_counter === 15.U, 15.U, store_blocked_counter + 1.U)
     }
     when (store_blocked_counter === 15.U) {
       block_load_wakeup := true.B


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

For avoiding deadlocks in lsu.scala, load wakeups are blocked using the ``block_load_wakeup`` bit. It seems this bit should be set when stores remain blocked for 15 cycles, and stay set until the unfairness is resolved. To implement the indented behavior, the order of operands to MUX controlling increments of ``store_blocked_counter`` should change to be the opposite: ``15.U`` if the MUX condition is true (a store remains blocked for at least 15 cycles) and ``store_blocked_counter + 1.U`` otherwise. 

<!-- Uncomment for forked PRs -->
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
