### PR TITLE
Bugfix: take static rounding mode into account in FDivSqrtUnit

### DIFF
--- a/src/main/scala/exu/execution-units/fdiv.scala
+++ b/src/main/scala/exu/execution-units/fdiv.scala
@@ -122,7 +122,7 @@ class FDivSqrtUnit(implicit p: Parameters)
     r_buffer_req.uop.br_mask := GetNewBrMask(io.brupdate, io.req.bits.uop)
     r_buffer_fin <> fdiv_decoder.io.sigs
 
-    r_buffer_fin.rm := io.fcsr_rm
+    r_buffer_fin.rm := Mux(ImmGenRm(io.req.bits.uop.imm_packed) === 7.U, io.fcsr_rm, ImmGenRm(io.req.bits.uop.imm_packed))
     r_buffer_fin.typ := 0.U // unused for fdivsqrt
     val tag = fdiv_decoder.io.sigs.typeTagIn
     r_buffer_fin.in1 := unbox(io.req.bits.rs1_data, tag, Some(tile.FType.D))


### PR DESCRIPTION
Hi there!

**Related issue**: #628 

**Type of change**: bug fix

**Impact**: rtl refactoring

**Development Phase**: implementation

**Release Notes**
Take static rounding mode into account in FDivSqrtUnit

**Testing**
I tested the fix with many inputs and all rounding errors disappear.
