### PR TITLE
Change linebuffer arbiters to RRarbiters

### DIFF
--- a/src/main/scala/lsu/mshrs.scala
+++ b/src/main/scala/lsu/mshrs.scala
@@ -566,8 +566,8 @@ class BoomMSHRFile(implicit edge: TLEdgeOut, p: Parameters) extends BoomModule()
   // The LineBuffer Data
   // Holds refilling lines, prefetched lines
   val lb = Mem(nLBEntries * cacheDataBeats, UInt(encRowBits.W))
-  val lb_read_arb  = Module(new Arbiter(new LineBufferReadReq, cfg.nMSHRs))
-  val lb_write_arb = Module(new Arbiter(new LineBufferWriteReq, cfg.nMSHRs))
+  val lb_read_arb  = Module(new RRArbiter(new LineBufferReadReq, cfg.nMSHRs))
+  val lb_write_arb = Module(new RRArbiter(new LineBufferWriteReq, cfg.nMSHRs))
 
   lb_read_arb.io.out.ready  := false.B
   lb_write_arb.io.out.ready := true.B


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable --> N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Changed the linebuffer arbiters in BoomMSHR to be RRArbiters which use round robin scheduling instead of arbiters, which use priority scheduling. 
**Note**: This currently impacts performance by around ~10% (according to the read test with N=65536 in https://github.com/ucb-bar/chipyard/pull/1478). 
Benchmarking should be done to figure out what is causing the performance difference. Abe and Jerry's suggestion was to figure out the occupancy of each MSHR state in the RRArbiter implementation in comparison to the Arbiter implementation. Summary slides are linked here: https://docs.google.com/presentation/d/1E6beSmXTvA7i3Fidx7r5adM6YJHAKcfKDLTG5HufCzM/edit?usp=sharing