### PR TITLE
[lsu] Fix logic to prevent forwarding from AMO instructions

### DIFF
--- a/src/main/scala/lsu/lsu.scala
+++ b/src/main/scala/lsu/lsu.scala
@@ -1148,7 +1148,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
     val write_mask = GenByteMask(s_addr, s_uop.mem_size)
     for (w <- 0 until memWidth) {
       when (do_ld_search(w) && stq(i).valid && lcam_st_dep_mask(w)(i)) {
-        when (((lcam_mask(w) & write_mask) === lcam_mask(w)) && !s_uop.is_fence && dword_addr_matches(w) && can_forward(w))
+        when (((lcam_mask(w) & write_mask) === lcam_mask(w)) && !s_uop.is_fence && !s_uop.is_amo && dword_addr_matches(w) && can_forward(w))
         {
           ldst_addr_matches(w)(i)            := true.B
           ldst_forward_matches(w)(i)         := true.B


### PR DESCRIPTION
fix control logic to prevent forwarding from AMOs

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
When executing load instructions, the store queue is searched for forwarding candidates. This search should account for possible address overlapping AMO instructions only to terminate memory accesses, not to use their data for forwarding. To implement this behavior, it suffices to change the store queue search implementation at the second **_when_** statement s.t. for store queue entries containing AMOs its second condition triggers instead of the first.

<!-- Uncomment for forked PRs -->
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
