### PR TITLE
Put terminology in alphabetical order

### DIFF
--- a/docs/sections/terminology.rst
+++ b/docs/sections/terminology.rst
@@ -6,6 +6,42 @@ out-of-order terminology.
 
 .. glossary::
 
+    Back-end
+        The stages starting from Dispatch to Writeback. Here instructions
+        are executed, dependencies resolved, branches resolved, etc.
+
+    Backing predictor (BPD)
+        Slower but more complicated predictor used to track longer
+        histories. In BOOM you can have multiple different types of
+        a Backing predictor (TAGE, GShare...).
+
+    Bi-Modal Table (BIM)
+        A counter table.
+
+    Branch Rename Snapshot
+        Metadata and prediction snapshots that are used to fix the branch predictor after
+        mispredictions.
+
+    Branch Target Buffer (BTB)
+        Tagged entry table in which a PC is used to find a matching
+        target. Thus, if there is a hit, the specified target is used
+        to redirect the pipeline.
+
+    Branch Unit
+        The functional unit that resolves a branch in the Execute Pipeline.
+
+    Execution Unit
+        A module that wraps multiple Functional Units within it.
+        It is attached to one issue port only.
+
+    Fetch Boundary
+        The bytes at the end of a i-cache response that might be half of an instruction
+        used in RVC.
+
+    Fetch Buffer
+        Buffer that holds Fetch Packets that are sent to the
+        Back-end.
+
     Fetch Packet
         A bundle returned by the Front-end which contains
         some set of consecutive instructions with a mask
@@ -20,84 +56,48 @@ out-of-order terminology.
         The PC corresponding to the head of a
         Fetch Packet instruction group.
 
-    Fetch Buffer
-        Buffer that holds Fetch Packets that are sent to the
-        Back-end.
-
-    TAGE Predictor
-        A high performance branch predictor. For more information
-        read the paper "A case for (partially) tagged geometric history length predictors".
-
-    GShare Predictor
-        A simpler branch predictor that uses a global history to index into a set of
-        counters.
-
-    Bi-Modal Table (BIM)
-        A counter table.
-
-    Micro-Op (UOP)
-        Element sent throughout the pipeline holding information about the type of
-        Micro-Op, its PC, pointers to the FTQ, ROB, LDQ, STQs, and more.
-
-    Front-end
-        The Fetch and Branch Prediction portions of the pipeline that fetch instructions
-        from the i-cache.
-
-    Back-end
-        The stages starting from Dispatch to Writeback. Here instructions
-        are executed, dependencies resolved, branches resolved, etc.
-
-    Fetch Boundary
-        The bytes at the end of a i-cache response that might be half of an instruction
-        used in RVC.
-
     Fetch Target Queue (FTQ)
         Queue used to track the branch prediction information for inflight Micro-Ops.
         This is dequeued once all instructions in its Fetch Packet entry are
         committed.
 
-    Next-Line Predictor (NLP)
-        Consists of a Branch Target Buffer (BTB),
-        Return Address Stack (RAS) and Bi-Modal Table (BIM).
-        This is used to make quick predictions to redirect the Front-end
-
-    Backing predictor (BPD)
-        Slower but more complicated predictor used to track longer
-        histories. In BOOM you can have multiple different types of
-        a Backing predictor (TAGE, GShare...).
-
-    Branch Target Buffer (BTB)
-        Tagged entry table in which a PC is used to find a matching
-        target. Thus, if there is a hit, the specified target is used
-        to redirect the pipeline.
-
-    Return Address Stack (RAS)
-        Stack used to track function calls. It is pushed with a PC
-        on a JAL or JALR and popped during a RET.
-
     Fetch Width
         The amount of instructions retrieved from the i-cache from the
         Front-end of the processor.
+
+    Front-end
+        The Fetch and Branch Prediction portions of the pipeline that fetch instructions
+        from the i-cache.
+
+    Functional Unit
+        A specific hardware module to compute some function (i.e. ALU, FPU, etc).
 
     Global History Register (GHR)
         A register holding the last N taken/not taken results of branches
         in the processor. However, in BOOM, each bit does not correspond to a
         bit of history. Instead this is a hashed history.
 
+    GShare Predictor
+        A simpler branch predictor that uses a global history to index into a set of
+        counters.
+
+    Micro-Op (UOP)
+        Element sent throughout the pipeline holding information about the type of
+        Micro-Op, its PC, pointers to the FTQ, ROB, LDQ, STQs, and more.
+
+    Next-Line Predictor (NLP)
+        Consists of a Branch Target Buffer (BTB),
+        Return Address Stack (RAS) and Bi-Modal Table (BIM).
+        This is used to make quick predictions to redirect the Front-end
+
     Rename Snapshots
         Saved state used to reset the pipeline to a correct state after a
         misspeculation or other redirecting event.
 
-    Branch Unit
-        The functional unit that resolves a branch in the Execute Pipeline.
+    Return Address Stack (RAS)
+        Stack used to track function calls. It is pushed with a PC
+        on a JAL or JALR and popped during a RET.
 
-    Branch Rename Snapshot
-        Metadata and prediction snapshots that are used to fix the branch predictor after
-        mispredictions.
-
-    Execution Unit
-        A module that wraps multiple Functional Units within it.
-        It is attached to one issue port only.
-
-    Functional Unit
-        A specific hardware module to compute some function (i.e. ALU, FPU, etc).
+    TAGE Predictor
+        A high performance branch predictor. For more information
+        read the paper "A case for (partially) tagged geometric history length predictors".


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement (documentation)

<!-- choose one -->
**Impact**: no rtl change 

<!-- choose one -->
**Development Phase**: N/A

Since there's more than a small handful of terms in the terminolgoy, I think it'd be helpful to put them in alphabetical order. I know that it's sometimes convenient to have relevant terms next to each other (e.g. front-and and back-end), but since there's more than 20 items in the list, it starts becoming more easily searchable if they're in order.

There's a joke in here somewhere about putting things in order for the out-of-order machine, but I can't think of a punchline.