### PR TITLE
`DontCare` Prefetcher `is_hella` signal

### DIFF
--- a/src/main/scala/lsu/prefetcher.scala
+++ b/src/main/scala/lsu/prefetcher.scala
@@ -47,7 +47,6 @@ class NullPrefetcher(implicit edge: TLEdgeOut, p: Parameters) extends DataPrefet
   */
 class NLPrefetcher(implicit edge: TLEdgeOut, p: Parameters) extends DataPrefetcher
 {
-
   val req_valid = RegInit(false.B)
   val req_addr  = Reg(UInt(coreMaxAddrBits.W))
   val req_cmd   = Reg(UInt(M_SZ.W))
@@ -63,12 +62,9 @@ class NLPrefetcher(implicit edge: TLEdgeOut, p: Parameters) extends DataPrefetch
   }
 
   io.prefetch.valid            := req_valid && io.mshr_avail
+  io.prefetch.bits             := DontCare
   io.prefetch.bits.addr        := req_addr
   io.prefetch.bits.uop         := NullMicroOp
   io.prefetch.bits.uop.mem_cmd := req_cmd
   io.prefetch.bits.data        := DontCare
-
-
 }
-
-


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Prefetcher `is_hella` signal is unconnected in the prefetcher. This adds a `DontCare` to avoid errors.

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
