### PR TITLE
[DO NOT MERGE DRAFT] [util] Use Mem() for uops instead of Reg(Vec())

### DIFF
--- a/src/main/scala/util/util.scala
+++ b/src/main/scala/util/util.scala
@@ -463,7 +463,7 @@ class BranchKillableQueue[T <: boom.common.HasBoomUOP](gen: T, entries: Int, flu
 
   val ram     = Mem(entries, gen)
   val valids  = RegInit(VecInit(Seq.fill(entries) {false.B}))
-  val uops    = Reg(Vec(entries, new MicroOp))
+  val uops    = Mem(entries, new MicroOp)
 
   val enq_ptr = Counter(entries)
   val deq_ptr = Counter(entries)


### PR DESCRIPTION
Easier to leave to backend to decide what sort of implementation to use flops or SRAM.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix | new feature | other enhancement

other enhancement

<!-- choose one -->
**Impact**: no rtl change | rtl refactoring | new rtl | unknown

rtl refactoring

<!-- choose one -->
**Development Phase**: proposal |  implementation

proposal

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
