### PR TITLE
[TLB] Check `do_refill` before generating access faults for the special entry

### DIFF
--- a/src/main/scala/lsu/tlb.scala
+++ b/src/main/scala/lsu/tlb.scala
@@ -253,7 +253,8 @@ class NBDTLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge
   val ae_array = widthMap(w =>
     Mux(misaligned(w), eff_array(w), 0.U) |
     Mux(cmd_lrsc(w)  , ~lrscAllowed(w), 0.U))
-  val ae_valid_array = widthMap(w => Cat(true.B, !do_refill, Fill(normal_entries(w).size, true.B)))
+  val ae_valid_array = widthMap(w => Cat(if (special_entry.isEmpty) true.B else Cat(true.B, Fill(special_entry.size, !do_refill)),
+                                         Fill(normal_entries(w).size, true.B)))
   val ae_ld_array = widthMap(w => Mux(cmd_read(w), ae_array(w) | ~pr_array(w), 0.U))
   val ae_st_array = widthMap(w =>
     Mux(cmd_write_perms(w)   , ae_array(w) | ~pw_array(w), 0.U) |


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

If the current memory operation hits the special entry (`special_entry`), it expects to use the PPN stored in the special entry and the page offset to perform the PMP check. However, when doing a refill (`do_refill`) at the same time, the TLB will use the refilled PPN (`refill_ppn`) to perform the PMP check. In this situation, the PPN used for the special entry is wrong and the TLB may generate unexpected access faults. This PR suppresses these unexpected access faults by checking `do_refill` before generating access faults for the special entry.

I have also tried ANDing `!dtlb.io.resp(w).miss` to `pf_ld`, `pf_st`, `ae_ld`, and `ae_st` in the LSU, but it seems to have worse timing results.

To reproduce:
1. Withdraw RWX permissions for the S mode for 0~2MiB using a PMP region. These addresses will be used as `refill_ppn` when doing a refill for some speculatively executed instructions.
2. Set up another PMP region whose granularity is smaller than the page size (e.g., < 2MiB for the Linux kernel).
3. Run complex software like the Linux kernel.

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: new rtl

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

* Fixed a bug when handling non-homogeneous pages.

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
