### PR TITLE
Update deprecated Chisel APIs

### DIFF
--- a/src/main/scala/exu/execution-units/functional-unit.scala
+++ b/src/main/scala/exu/execution-units/functional-unit.scala
@@ -346,7 +346,7 @@ class ALUUnit(isJmpUnit: Boolean = false, numStages: Int = 1, dataWidth: Int)(im
   val br_lt  = (~(rs1(xLen-1) ^ rs2(xLen-1)) & br_ltu |
                 rs1(xLen-1) & ~rs2(xLen-1)).asBool
 
-  val pc_sel = MuxLookup(uop.ctrl.br_type, PC_PLUS4,
+  val pc_sel = MuxLookup(uop.ctrl.br_type, PC_PLUS4)(
                  Seq(   BR_N   -> PC_PLUS4,
                         BR_NE  -> Mux(!br_eq,  PC_BRJMP, PC_PLUS4),
                         BR_EQ  -> Mux( br_eq,  PC_BRJMP, PC_PLUS4),

--- a/src/main/scala/ifu/bpd/ras.scala
+++ b/src/main/scala/ifu/bpd/ras.scala
@@ -7,7 +7,6 @@ package boom.ifu
 
 import chisel3._
 import chisel3.util._
-import chisel3.internal.sourceinfo.{SourceInfo}
 
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.subsystem._

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -13,7 +13,6 @@ package boom.ifu
 
 import chisel3._
 import chisel3.util._
-import chisel3.internal.sourceinfo.{SourceInfo}
 
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.subsystem._

--- a/src/main/scala/ifu/icache.scala
+++ b/src/main/scala/ifu/icache.scala
@@ -14,7 +14,6 @@ package boom.ifu
 import chisel3._
 import chisel3.util._
 import chisel3.util.random._
-import chisel3.internal.sourceinfo.{SourceInfo}
 
 import org.chipsalliance.cde.config.{Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/lsu/mshrs.scala
+++ b/src/main/scala/lsu/mshrs.scala
@@ -436,7 +436,7 @@ class BoomIOMSHR(id: Int)(implicit edge: TLEdgeOut, p: Parameters) extends BoomM
   val get      = edge.Get(a_source, a_address, a_size)._2
   val put      = edge.Put(a_source, a_address, a_size, a_data)._2
   val atomics  = if (edge.manager.anySupportLogical) {
-    MuxLookup(req.uop.mem_cmd, (0.U).asTypeOf(new TLBundleA(edge.bundle)), Array(
+    MuxLookup(req.uop.mem_cmd, (0.U).asTypeOf(new TLBundleA(edge.bundle)))(Array(
       M_XA_SWAP -> edge.Logical(a_source, a_address, a_size, a_data, TLAtomics.SWAP)._2,
       M_XA_XOR  -> edge.Logical(a_source, a_address, a_size, a_data, TLAtomics.XOR) ._2,
       M_XA_OR   -> edge.Logical(a_source, a_address, a_size, a_data, TLAtomics.OR)  ._2,


### PR DESCRIPTION
These have been deprecated since Chisel 3.6.0. The are being removed in Chisel 6, and will become compile errors at that point.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
