### PR TITLE
Update deprecated Chisel APIs

### DIFF
--- a/src/main/scala/v4/exu/execution-units/fdiv.scala
+++ b/src/main/scala/v4/exu/execution-units/fdiv.scala
@@ -101,7 +101,7 @@ class FDivSqrtUnit2(implicit p: Parameters)
   fpiu.io.in.bits.typ := io.req.bits.uop.fp_typ
   fpiu.io.in.bits.fmaCmd := 0.U
 
-  when (io.req.fire()) {
+  when (io.req.fire) {
     r_req.valid := !IsKilledByBranch(io.brupdate, io.kill, io.req.bits.uop.br_mask)
     r_req.bits  := UpdateBrMask(io.brupdate, io.req.bits)
     r_sigs := fdiv_decoder.io.sigs
@@ -129,7 +129,7 @@ class FDivSqrtUnit2(implicit p: Parameters)
   io.resp.bits.data := r_out_wdata
   io.resp.bits.fflags.valid := io.resp.valid
   io.resp.bits.fflags.bits  := r_out_flags
-  when (io.resp.fire() || reset.asBool) {
+  when (io.resp.fire || reset.asBool) {
     r_req.valid := false.B
     r_out_valid := false.B
   }

--- a/src/main/scala/v4/exu/execution-units/functional-unit.scala
+++ b/src/main/scala/v4/exu/execution-units/functional-unit.scala
@@ -175,7 +175,7 @@ class ALUUnit(dataWidth: Int)(implicit p: Parameters)
   val br_lt  = (~(rs1(xLen-1) ^ rs2(xLen-1)) & br_ltu |
                 rs1(xLen-1) & ~rs2(xLen-1)).asBool
 
-  val pc_sel = MuxLookup(uop.br_type, PC_PLUS4,
+  val pc_sel = MuxLookup(uop.br_type, PC_PLUS4)(
                  Seq(   B_N   -> PC_PLUS4,
                         B_NE  -> Mux(!br_eq,  PC_BRJMP, PC_PLUS4),
                         B_EQ  -> Mux( br_eq,  PC_BRJMP, PC_PLUS4),
@@ -391,7 +391,7 @@ class DivUnit(dataWidth: Int)(implicit p: Parameters)
 
   val req = Reg(Valid(new MicroOp()))
 
-  when (io.req.fire()) {
+  when (io.req.fire) {
     req.valid := !IsKilledByBranch(io.brupdate, io.kill, io.req.bits)
     req.bits  := UpdateBrMask(io.brupdate, io.req.bits.uop)
   } .otherwise {
@@ -420,7 +420,7 @@ class DivUnit(dataWidth: Int)(implicit p: Parameters)
   io.resp.valid       := div.io.resp.valid && req.valid
   io.resp.bits.data   := div.io.resp.bits.data
   io.resp.bits.uop    := req.bits
-  when (io.resp.fire()) {
+  when (io.resp.fire) {
     req.valid := false.B
   }
 }

--- a/src/main/scala/v4/exu/execution-units/rocc.scala
+++ b/src/main/scala/v4/exu/execution-units/rocc.scala
@@ -263,7 +263,7 @@ class RoCCShim(implicit p: Parameters) extends BoomModule
   io.core.rocc.resp.ready := resp_arb.io.in(1).ready
   io.resp <> resp_arb.io.out
 
-  when (io.core.rocc.resp.fire()) {
+  when (io.core.rocc.resp.fire) {
     assert(rcq(rcq_head).valid && rcq(rcq_head).bits.uop.ldst === io.core.rocc.resp.bits.rd)
     rcq(rcq_head).valid := false.B
     rcq_head := WrapInc(rcq_head, numRcqEntries)

--- a/src/main/scala/v4/exu/register-read/regfile.scala
+++ b/src/main/scala/v4/exu/register-read/regfile.scala
@@ -165,7 +165,7 @@ class PartiallyPortedRF[T <: Data](
       read_issued = issue_read || read_issued
     }
     io.arb_read_reqs(i).ready := PopCount(io.arb_read_reqs.take(i).map(_.valid)) < numPhysicalReadPorts.U
-    assert(!(io.arb_read_reqs(i).fire() && !read_issued))
+    assert(!(io.arb_read_reqs(i).fire && !read_issued))
   }
 
   for (j <- 0 until numPhysicalReadPorts) {

--- a/src/main/scala/v4/ifu/bpd/ras.scala
+++ b/src/main/scala/v4/ifu/bpd/ras.scala
@@ -7,7 +7,6 @@ package boom.v4.ifu
 
 import chisel3._
 import chisel3.util._
-import chisel3.internal.sourceinfo.{SourceInfo}
 
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.subsystem._

--- a/src/main/scala/v4/ifu/fetch-target-queue.scala
+++ b/src/main/scala/v4/ifu/fetch-target-queue.scala
@@ -330,7 +330,7 @@ class FetchTargetQueue(implicit p: Parameters) extends BoomModule
 
   for (i <- 0 until 3) {
     val idx = Mux(reset.asBool, 0.U(log2Ceil(ftqSz).W), io.arb_ftq_reqs(i))
-    val is_enq = (idx === enq_ptr) && io.enq.fire()
+    val is_enq = (idx === enq_ptr) && io.enq.fire
     val get_entry = ram(idx)
 
     io.rrd_ftq_resps(i).entry     := RegNext(get_entry)

--- a/src/main/scala/v4/ifu/frontend.scala
+++ b/src/main/scala/v4/ifu/frontend.scala
@@ -607,7 +607,7 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
   // The BPD resp comes in f3
   f3_bpd_queue.io.enq.valid := f3.io.deq.valid && RegNext(f3.io.enq.ready)
   f3_bpd_queue.io.enq.bits  := bpd.io.resp.f3
-  when (f3_bpd_queue.io.enq.fire()) {
+  when (f3_bpd_queue.io.enq.fire) {
     bpd.io.f3_fire := true.B
   }
 
@@ -723,7 +723,7 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
   f3_fetch_bundle.lhist    := f3_bpd_resp.lhist
   f3_fetch_bundle.bpd_meta := f3_bpd_resp.meta
 
-  when (f3.io.deq.fire()) {
+  when (f3.io.deq.fire) {
     assert(f3_bpd_resp.pc === f3_fetch_bundle.pc)
   }
 
@@ -823,7 +823,7 @@ class BoomFrontendModule(outer: BoomFrontend) extends LazyModuleImp(outer)
   // RAS takes a cycle to read
   val ras_read_idx = RegInit(0.U(log2Ceil(nRasEntries).W))
   ras.io.read_idx := ras_read_idx
-  when (f3.io.deq.fire()) {
+  when (f3.io.deq.fire) {
     ras_read_idx := f4.io.enq.bits.ghist.ras_idx
     ras.io.read_idx := f4.io.enq.bits.ghist.ras_idx
   }

--- a/src/main/scala/v4/ifu/icache.scala
+++ b/src/main/scala/v4/ifu/icache.scala
@@ -14,7 +14,6 @@ package boom.v4.ifu
 import chisel3._
 import chisel3.util._
 import chisel3.util.random._
-import chisel3.internal.sourceinfo.{SourceInfo}
 
 import org.chipsalliance.cde.config.{Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/v4/lsu/lsu.scala
+++ b/src/main/scala/v4/lsu/lsu.scala
@@ -538,9 +538,9 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
   retry_queue.io.enq.bits.uop.uses_stq := can_enq_store_retry
   retry_queue.io.enq.bits.uop.stq_idx  := stq_enq_retry_idx
 
-  when (can_enq_store_retry && retry_queue.io.enq.fire()) {
+  when (can_enq_store_retry && retry_queue.io.enq.fire) {
     stq_addr(stq_enq_retry_idx).valid := false.B
-  } .elsewhen (can_enq_load_retry && retry_queue.io.enq.fire()) {
+  } .elsewhen (can_enq_load_retry && retry_queue.io.enq.fire) {
     ldq_addr(ldq_enq_retry_idx).valid := false.B
   }
 
@@ -570,7 +570,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
   )
   stq_execute_queue.io.enq.valid := can_enq_store_execute
 
-  when (can_enq_store_execute && stq_execute_queue.io.enq.fire()) {
+  when (can_enq_store_execute && stq_execute_queue.io.enq.fire) {
     stq_execute_head := WrapInc(stq_execute_head, numStqEntries)
   }
 
@@ -1484,7 +1484,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
   val dmem_resp_fired = WireInit(widthMap(w => false.B))
   for (w <- 0 until lsuWidth) {
     val w1 = Reg(Valid(new Wakeup))
-    w1.valid := wakeupArbs(w).io.in(1).fire() && !IsKilledByBranch(io.core.brupdate, io.core.exception, wakeupArbs(w).io.in(1).bits)
+    w1.valid := wakeupArbs(w).io.in(1).fire && !IsKilledByBranch(io.core.brupdate, io.core.exception, wakeupArbs(w).io.in(1).bits)
     w1.bits  := UpdateBrMask(io.core.brupdate, wakeupArbs(w).io.in(1).bits)
 
     val w2 = Reg(Valid(new Wakeup))
@@ -1523,7 +1523,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
     if (w == lsuWidth-1) {
       io.dmem.ll_resp.ready := !io.dmem.resp(w).valid && !wb_spec_wakeups(w).valid
     }
-    when (io.dmem.resp(w).valid || ((w == lsuWidth-1).B && io.dmem.ll_resp.fire())) {
+    when (io.dmem.resp(w).valid || ((w == lsuWidth-1).B && io.dmem.ll_resp.fire)) {
       when (resp.uop.uses_ldq) {
         assert(!resp.is_hella)
         val ldq_idx = resp.uop.ldq_idx
@@ -1838,7 +1838,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
       hella_state := h_wait
     }
   } .elsewhen (hella_state === h_wait) {
-    when (io.dmem.ll_resp.fire() && io.dmem.ll_resp.bits.is_hella) {
+    when (io.dmem.ll_resp.fire && io.dmem.ll_resp.bits.is_hella) {
       hella_state := h_ready
 
       io.hellacache.resp.valid       := true.B
@@ -1873,7 +1873,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
       hella_state := h_wait
     }
   } .elsewhen (hella_state === h_dead) {
-    when (io.dmem.ll_resp.fire() && io.dmem.ll_resp.bits.is_hella) {
+    when (io.dmem.ll_resp.fire && io.dmem.ll_resp.bits.is_hella) {
       hella_state := h_ready
     }
     for (w <- 0 until lsuWidth) {

--- a/src/main/scala/v4/lsu/mshrs.scala
+++ b/src/main/scala/v4/lsu/mshrs.scala
@@ -423,7 +423,7 @@ class BoomIOMSHR(id: Int)(implicit edge: TLEdgeOut, p: Parameters) extends BoomM
   val get      = edge.Get(a_source, a_address, a_size)._2
   val put      = edge.Put(a_source, a_address, a_size, a_data)._2
   val atomics  = if (edge.manager.anySupportLogical) {
-    MuxLookup(req.uop.mem_cmd, (0.U).asTypeOf(new TLBundleA(edge.bundle)), Array(
+    MuxLookup(req.uop.mem_cmd, (0.U).asTypeOf(new TLBundleA(edge.bundle)))(Array(
       M_XA_SWAP -> edge.Logical(a_source, a_address, a_size, a_data, TLAtomics.SWAP)._2,
       M_XA_XOR  -> edge.Logical(a_source, a_address, a_size, a_data, TLAtomics.XOR) ._2,
       M_XA_OR   -> edge.Logical(a_source, a_address, a_size, a_data, TLAtomics.OR)  ._2,

--- a/src/main/scala/v4/lsu/tlb.scala
+++ b/src/main/scala/v4/lsu/tlb.scala
@@ -320,7 +320,7 @@ class NBDTLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge
   if (usingVM) {
     val sfence = io.sfence.valid
     for (w <- 0 until lsuWidth) {
-      when (io.req(w).fire() && tlb_miss(w) && state === s_ready) {
+      when (io.req(w).fire && tlb_miss(w) && state === s_ready) {
         state := s_request
         r_refill_tag := vpn(w)
 

--- a/src/main/scala/v4/lsu/tracegen.scala
+++ b/src/main/scala/v4/lsu/tracegen.scala
@@ -109,12 +109,12 @@ class BoomLSUShim(implicit p: Parameters) extends BoomModule()(p)
   assert(!io.lsu.lxcpt.valid)
 
 
-  io.lsu.agen(0).valid     := ShiftRegister(io.tracegen.req.fire(), 2)
+  io.lsu.agen(0).valid     := ShiftRegister(io.tracegen.req.fire, 2)
   io.lsu.agen(0).bits      := DontCare
   io.lsu.agen(0).bits.uop  := ShiftRegister(tracegen_uop, 2)
   io.lsu.agen(0).bits.data := ShiftRegister(io.tracegen.req.bits.addr, 2)
 
-  io.lsu.dgen(0).valid     := ShiftRegister(io.tracegen.req.fire() && tracegen_uop.uses_stq, 2)
+  io.lsu.dgen(0).valid     := ShiftRegister(io.tracegen.req.fire && tracegen_uop.uses_stq, 2)
   io.lsu.dgen(0).bits      := DontCare
   io.lsu.dgen(0).bits.uop  := ShiftRegister(tracegen_uop, 2)
   io.lsu.dgen(0).bits.data := ShiftRegister(io.tracegen.req.bits.data, 2)

--- a/src/main/scala/v4/util/util.scala
+++ b/src/main/scala/v4/util/util.scala
@@ -492,7 +492,7 @@ class BranchKillableQueue[T <: boom.v4.common.HasBoomUOP](gen: T, entries: Int, 
     out_valid := out_valid && !IsKilledByBranch(io.brupdate, false.B, out_uop) && !(io.flush && flush_fn(out_uop))
 
     main.io.deq.ready := false.B
-    when (io.deq.fire() || !out_valid) {
+    when (io.deq.fire || !out_valid) {
       out_valid := main.io.deq.valid && !IsKilledByBranch(io.brupdate, false.B, main.io.deq.bits.uop) && !(io.flush && flush_fn(main.io.deq.bits.uop))
       out_reg := main.io.deq.bits
       out_uop := UpdateBrMask(io.brupdate, main.io.deq.bits.uop)
@@ -511,7 +511,7 @@ class BranchKillableQueue[T <: boom.v4.common.HasBoomUOP](gen: T, entries: Int, 
     val ptr_match = enq_ptr.value === deq_ptr.value
     io.empty := ptr_match && !maybe_full
     val full = ptr_match && maybe_full
-    val do_enq = WireInit(io.enq.fire() && !IsKilledByBranch(io.brupdate, false.B, io.enq.bits.uop) && !(io.flush && flush_fn(io.enq.bits.uop)))
+    val do_enq = WireInit(io.enq.fire && !IsKilledByBranch(io.brupdate, false.B, io.enq.bits.uop) && !(io.flush && flush_fn(io.enq.bits.uop)))
     val do_deq = WireInit((io.deq.ready || !valids(deq_ptr.value)) && !io.empty)
 
     for (i <- 0 until entries) {


### PR DESCRIPTION
These have been deprecated since Chisel 3.6.0, and were removed in Chisel 6, which makes them compile errors at that point.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
