### PR TITLE
fix: fix an ordering issue that blocks pnr

### DIFF
--- a/src/main/scala/v4/lsu/lsu.scala
+++ b/src/main/scala/v4/lsu/lsu.scala
@@ -1240,8 +1240,10 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
           when ((l_executed || l_succeeded) &&
                 !s1_executing_loads(i) && // If the load is proceeding in parallel we don't need to kill it
                 l_observed) {        // Its only a ordering failure if the cache line was observed between the younger load and us
-            ldq_order_fail(i) := true.B
-            failed_load := true.B
+            //ldq_order_fail(i) := true.B
+            // failed_load := true.B
+
+	    // this case is no longer possible where an older search gets replayed and found that a younger search has already been released. Note that this is stronger than rvwmo.
             assert(false.B)
           }
         } .elsewhen (lcam_ldq_idx(w) =/= i.U) {

--- a/src/main/scala/v4/lsu/lsu.scala
+++ b/src/main/scala/v4/lsu/lsu.scala
@@ -320,6 +320,11 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
 
   def widthMap[T <: Data](f: Int => T) = VecInit((0 until lsuWidth).map(f))
 
+  // default connection from flip flop to next state
+
+  val ldq_will_succeed        = WireDefault(ldq_succeeded)
+  ldq_succeeded := ldq_will_succeed
+
 
   //-------------------------------------------------------------
   //-------------------------------------------------------------
@@ -393,7 +398,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
       ldq_uop            (ldq_idx)       := UpdateBrMask(io.core.brupdate, dis_uops(w).bits)
       ldq_addr           (ldq_idx).valid := false.B
       ldq_executed       (ldq_idx)       := false.B
-      ldq_succeeded      (ldq_idx)       := false.B
+      ldq_will_succeed   (ldq_idx)       := false.B
       ldq_order_fail     (ldq_idx)       := false.B
       ldq_observed       (ldq_idx)       := false.B
       ldq_forward_std_val(ldq_idx)       := false.B
@@ -1179,6 +1184,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
     val l_addr_is_virtual = ldq_addr_is_virtual(i)
     val l_executed        = ldq_executed(i)
     val l_succeeded       = ldq_succeeded(i)
+    val l_will_succeed    = ldq_will_succeed(i)
     val l_observed        = ldq_observed(i)
     val l_mask            = ldq_ld_byte_mask(i)
     val l_st_dep_mask     = ldq_st_dep_mask(i)
@@ -1241,7 +1247,8 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
         } .elsewhen (lcam_ldq_idx(w) =/= i.U) {
           // The load is older, and it wasn't executed
           // we need to kill ourselves, and prevent forwarding
-          when (!(l_executed && l_succeeded)) {
+	  // can also forward from the next cycle
+          when (!(l_executed && (l_succeeded || l_will_succeed))) {
             s1_set_execute(lcam_ldq_idx(w))    := false.B
             when (RegNext(dmem_req_fire(w) && !s0_kills(w)) && !fired_load_agen(w)) {
               io.dmem.s1_kill(w)               := true.B
@@ -1257,6 +1264,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
   for (wi <- 0 until lsuWidth) {
     for (w <- 0 until lsuWidth) {
       // A younger load might find a older nacking load
+      // this is not the full case, need also to account for the situation where the older load already went to sleep above
       val nack_dword_addr_matches = (lcam_addr(w) >> 3) === (io.dmem.nack(wi).bits.addr >> 3)
       val nack_mask = GenByteMask(io.dmem.nack(wi).bits.addr, io.dmem.nack(wi).bits.uop.mem_size)
       val nack_mask_overlap = (nack_mask & lcam_mask(w)) =/= 0.U
@@ -1271,7 +1279,9 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
           io.dmem.s1_kill(w) := true.B
         }
         kill_forward(w) := true.B
-      }
+	    }
+
+
 
       // A older load might find a younger forwarding load
       val forward_dword_addr_matches = (lcam_addr(w) >> 3 === wb_ldst_forward_ld_addr(wi) >> 3)
@@ -1545,7 +1555,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
         assert(send_iresp ^ send_fresp)
         dmem_resp_fired(w) := true.B
 
-        ldq_succeeded    (ldq_idx) := iresp(w).valid || fresp(w).valid
+        ldq_will_succeed (ldq_idx) := iresp(w).valid || fresp(w).valid
         ldq_debug_wb_data(ldq_idx) := resp.data
 
         wb_slow_wakeups(w).valid    := send_iresp
@@ -1610,7 +1620,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
       iresp(w).bits.data := loadgen.data
       fresp(w).bits.data := loadgen.data
 
-      ldq_succeeded      (f_idx) := true.B
+      ldq_will_succeed   (f_idx) := true.B
       ldq_forward_std_val(f_idx) := true.B
       ldq_forward_stq_idx(f_idx) := wb_ldst_forward_stq_idx(w)
 

--- a/src/main/scala/v4/lsu/lsu.scala
+++ b/src/main/scala/v4/lsu/lsu.scala
@@ -1281,7 +1281,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
           io.dmem.s1_kill(w) := true.B
         }
         kill_forward(w) := true.B
-	    }
+      }
 
 
 

--- a/src/main/scala/v4/lsu/lsu.scala
+++ b/src/main/scala/v4/lsu/lsu.scala
@@ -1236,11 +1236,12 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
                 l_observed) {        // Its only a ordering failure if the cache line was observed between the younger load and us
             ldq_order_fail(i) := true.B
             failed_load := true.B
+            assert(false.B)
           }
         } .elsewhen (lcam_ldq_idx(w) =/= i.U) {
           // The load is older, and it wasn't executed
           // we need to kill ourselves, and prevent forwarding
-          when (!(l_executed || l_succeeded)) {
+          when (!(l_executed && l_succeeded)) {
             s1_set_execute(lcam_ldq_idx(w))    := false.B
             when (RegNext(dmem_req_fire(w) && !s0_kills(w)) && !fired_load_agen(w)) {
               io.dmem.s1_kill(w)               := true.B


### PR DESCRIPTION
This commit fixes an ordering issue such that under these scenarios, PNR will be broken.

1. an older load misses
2. a younger load gets issued after the cacheline comes back but before the older load gets replayed
3. immediately after the younger load hits, the line gets evicted due to snooping.

This breaks ld-ld ordering for the same address, and although the old line conceives no memory ordering violation could be made, it still needs to be replayed, thus blocking PnR.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
