### PR TITLE
Bump buildfiles for mill and sbt, as well as adding ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ lib
 *~
 .nfs*
 .#*
+/.bloop/
+/.metals/
+/out/

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,24 @@
 import sbt.project
 
-ThisBuild / scalaVersion     := "2.13.10"
+ThisBuild / scalaVersion     := "2.13.14"
 ThisBuild / version          := "3.0"
 ThisBuild / organization     := "ucb-bar"
 
-val chiselVersion = "3.6.0"
+val chiselVersion = "6.5.0"
+
+val rocketVersion = "1.6-snapshot"
 
 lazy val root = (project in file("."))
   .settings(
     name := "boom",
     libraryDependencies ++= Seq(
-      "edu.berkeley.cs" %% "chisel3" % chiselVersion,
-      "edu.berkeley.cs" %% "rocketchip" % "1.6.0",
-	  "ch.epfl.scala" %% "bloop-config" % "1.5.5"
+      "org.chipsalliance" %% "chisel" % chiselVersion,
+      "org.chipsalliance" %% "cde" % rocketVersion,
+      "org.chipsalliance" %% s"diplomacy-$chiselVersion" % rocketVersion,
+      "org.chipsalliance" %% s"hardfloat-$chiselVersion" % rocketVersion,
+      "org.chipsalliance" %% "macros" % rocketVersion,
+      "org.chipsalliance" %% s"rocketchip-$chiselVersion" % rocketVersion,
+	  "ch.epfl.scala" %% "bloop-config" % "2.0.3"
     ),
     scalacOptions ++= Seq(
       "-language:reflectiveCalls",
@@ -21,11 +27,10 @@ lazy val root = (project in file("."))
       "-Xcheckinit",
       "-P:chiselplugin:genBundleElements"
     ),
-    addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % chiselVersion cross CrossVersion.full),
+    addCompilerPlugin("org.chipsalliance" % "chisel-plugin" % chiselVersion cross CrossVersion.full),
 	resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases"),
     Resolver.mavenLocal
 )
-
 )

--- a/build.sc
+++ b/build.sc
@@ -11,7 +11,7 @@ import mill.bsp._
 
 object boom extends ScalaModule { m =>
   override def millSourcePath = os.pwd
-  override def scalaVersion = "2.13.10"
+  override def scalaVersion = "2.13.14"
   override def scalacOptions = Seq(
     "-language:reflectiveCalls",
     "-deprecation",
@@ -19,13 +19,18 @@ object boom extends ScalaModule { m =>
     "-Xcheckinit",
     "-P:chiselplugin:genBundleElements"
   )
+  val chiselVersion = "6.5.0"
+  val rocketVersion = "1.6-snapshot"
   override def ivyDeps = Agg(
-    ivy"edu.berkeley.cs::chisel3:3.5.6",
-    ivy"edu.berkeley.cs::rocketchip:1.6.0",
-	ivy"ch.epfl.scala::bloop-config:1.5.5"
-
+    ivy"org.chipsalliance::chisel:$chiselVersion",
+    ivy"org.chipsalliance::cde:$rocketVersion",
+    ivy"org.chipsalliance::macros:$rocketVersion",
+    ivy"org.chipsalliance::diplomacy-$chiselVersion:$rocketVersion",
+    ivy"org.chipsalliance::hardfloat-$chiselVersion:$rocketVersion",
+    ivy"org.chipsalliance::rocketchip-$chiselVersion:$rocketVersion",
+	ivy"ch.epfl.scala::bloop-config:2.0.3"
   )
   override def scalacPluginIvyDeps = Agg(
-    ivy"edu.berkeley.cs:::chisel3-plugin:3.5.6",
+    ivy"org.chipsalliance:::chisel-plugin:$chiselVersion",
   )
 }


### PR DESCRIPTION
This PR bumps the version for mill and sbt. Mostly for text editor functionalities. Supercedes https://github.com/riscv-boom/riscv-boom/pull/707.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no rtl change 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->