### PR TITLE
fix: csmith fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ lib
 /.bloop/
 /.metals/
 /out/
+util/csmith/output/
+util/csmith/csmith/

--- a/util/csmith/sources/syscalls.c
+++ b/util/csmith/sources/syscalls.c
@@ -403,10 +403,10 @@ void* memset(void* dest, int byte, size_t len)
     word |= word << 16 << 16;
 
     uintptr_t *d = dest;
-    while (d < (uintptr_t*)(dest + len))
+    while (d < (uintptr_t*)(dest + (len >> 3)))
       *d++ = word;
   } else {
-    char *d = dest;
+    volatile char *d = dest;
     while (d < (char*)(dest + len))
       *d++ = byte;
   }


### PR DESCRIPTION
1. Add csmith related directories to ignore
2. A curious bug in the current version of the gcc breaks the syscalls.c, where without marking the dest as volatile, the memset in _init_tls() will mysteriously overwrite the instruction segment, generating an illegal instruction fault.
3. The pointer arithmetic for the word case seems to be wrong. Memset sets the number of bytes rather than operators, thus a division is necessary.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: no rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
