### PR TITLE
fix: fall back to non-matrix issue for now

### DIFF
--- a/src/main/scala/v4/exu/issue-units/issue-unit.scala
+++ b/src/main/scala/v4/exu/issue-units/issue-unit.scala
@@ -26,7 +26,8 @@ case class IssueParams(
   numEntries: Int = 8,
   useFullIssueSel: Boolean = true,
   numSlowEntries: Int = 0,
-  useMatrixIssue: Boolean = true,
+  // useMatrixIssue: Boolean = true,
+  useMatrixIssue: Boolean = false,
   iqType: Int
 )
 


### PR DESCRIPTION
The matrix issue unit is an experimental feature that will cause the core to hang under some circumstances. Changing it to defaultly use the fallback implementation. 