### PR TITLE
add: tracing support for boom

### DIFF
--- a/src/main/scala/v4/common/parameters.scala
+++ b/src/main/scala/v4/common/parameters.scala
@@ -122,7 +122,9 @@ case class BoomCoreParams(
   enableMemtracePrintf: Boolean = false,
 
   /* enableConservativeSNI: speculative non-interference */
-  enableConservativeSNI: Boolean = false
+  enableConservativeSNI: Boolean = false,
+
+  enableTraceCoreIngress: Boolean = false,
 
 // DOC include end: BOOM Parameters
 ) extends freechips.rocketchip.tile.CoreParams

--- a/src/main/scala/v4/exu/execution-units/functional-unit.scala
+++ b/src/main/scala/v4/exu/execution-units/functional-unit.scala
@@ -198,7 +198,7 @@ class ALUUnit(dataWidth: Int)(implicit p: Parameters)
                         ))
 
   val is_taken = io.req.valid &&
-                   (uop.br_type =/= BR_N) &&
+                   (uop.br_type =/= B_N) &&
                    (pc_sel =/= PC_PLUS4)
 
 

--- a/src/main/scala/v4/exu/rob.scala
+++ b/src/main/scala/v4/exu/rob.scala
@@ -89,6 +89,9 @@ class RobIo(
   // Let the CSRFile stall us (e.g., wfi).
   val csr_stall = Input(Bool())
 
+  // Let the TraceEncoder stall us
+  val trace_stall = Input(Bool())
+
   // Flush signals (including exceptions, pipeline replays, and memory ordering failures)
   // to send to the frontend for redirection.
   val flush = Valid(new CommitExceptionSignals)
@@ -448,7 +451,7 @@ class Rob(
 
     // Can this instruction commit? (the check for exceptions/rob_state happens later).
     // Block commit if there is mispredict
-    can_commit(w) := rob_val(rob_head) && !(rob_bsy(rob_head)) && !io.csr_stall && !io.brupdate.b2.mispredict
+    can_commit(w) := rob_val(rob_head) && !(rob_bsy(rob_head)) && !io.csr_stall && !io.brupdate.b2.mispredict && !io.trace_stall
 
 
     // use the same "com_uop" for both rollback AND commit


### PR DESCRIPTION
This PR adds support for attaching the tacit tracer to BOOM. 

Also fixes a slight bug of misusing the Rocket constants in the functional unit. 