### PR TITLE
docs: correct Dispatch description to include ROB allocation (#754)

### DIFF
--- a/docs/sections/intro-overview/boom-pipeline.rst
+++ b/docs/sections/intro-overview/boom-pipeline.rst
@@ -46,7 +46,9 @@ Dispatch
 ^^^^^^^^
 
 The :term:`UOP<Micro-Op (UOP)>` is then *dispatched*, or written, into
-a set of :term:`Issue Queue` s.
+the **Reorder Buffer (ROB)** and a set of :term:`Issue Queues` concurrently.
+This occurs after the **Rename** stage, ensuring the ROB can track the 
+instruction using its physical register mappings.
 
 Issue
 ^^^^^
@@ -89,11 +91,11 @@ ALU operations and load operations are *written* back to the
 Commit
 ^^^^^^
 
-The **Reorder Buffer (ROB)**, tracks the status of each instruction
-in the pipeline. When the head of the **ROB** is not-busy, the **ROB**
-*commits* the instruction. For stores, the **ROB** signals to the
-store at the head of the **Store Queue (SAQ/SDQ)** that it can now write its
-data to memory.
+The **Reorder Buffer (ROB)**, which was populated during the **Dispatch** stage, 
+tracks the status of each instruction in the pipeline. When the head of the 
+**ROB** is not-busy, the **ROB** *commits* the instruction. For stores, the 
+**ROB** signals to the store at the head of the **Store Queue (SAQ/SDQ)** that 
+it can now write its data to memory.
 
 Branch Support
 --------------


### PR DESCRIPTION
### Description
This PR addresses #754 by updating the pipeline documentation to correctly reflect the lifecycle of a Micro-Op (UOP) in the BOOM pipeline.

I have verified in `src/main/scala/exu/core.scala` that the ROB enqueue signals (`rob.io.enq_uops`) are driven by the dispatch micro-ops (`dis_uops`). This confirms that the ROB is populated concurrently with the Issue Queues during the **Dispatch** stage, post-**Rename**.

**Related issue**: #754

**Type of change**: other enhancement

**Impact**: no rtl change

**Development Phase**: implementation

**Release Notes**
Updated the pipeline documentation (`boom-pipeline.rst`) to clarify that the Reorder Buffer (ROB) is allocated during the **Dispatch** stage. This aligns the architectural documentation with the RTL implementation where instructions are dispatched to the ROB and Issue Queues simultaneously.