### PR TITLE
Mispredicted branches could be committed when issueWidth > coreWidth

### DIFF
--- a/src/main/scala/v3/exu/core.scala
+++ b/src/main/scala/v3/exu/core.scala
@@ -179,7 +179,7 @@ class BoomCore()(implicit p: Parameters) extends BoomModule
   // Dealing with branch resolutions
 
   // The individual branch resolutions from each ALU
-  val brinfos = Reg(Vec(coreWidth, new BrResolutionInfo()))
+  val brinfos = Reg(Vec(exe_units.alu_units.length, new BrResolutionInfo()))
 
   // "Merged" branch update info from all ALUs
   // brmask contains masks for rapidly clearing mispredicted instructions

--- a/src/main/scala/v4/exu/core.scala
+++ b/src/main/scala/v4/exu/core.scala
@@ -206,7 +206,7 @@ class BoomCore(roccCSRs: Seq[Seq[CustomCSR]])(implicit p: Parameters) extends Bo
   // Dealing with branch resolutions
 
   // The individual branch resolutions from each ALU
-  val brinfos = Reg(Vec(coreWidth, Valid(new BrResolutionInfo)))
+  val brinfos = Reg(Vec(alu_exe_units.length, Valid(new BrResolutionInfo)))
 
   // "Merged" branch update info from all ALUs
   // brmask contains masks for rapidly clearing mispredicted instructions


### PR DESCRIPTION
# Mispredicted branches could be committed when issueWidth > coreWidth

**Type of change**: bug fix 

**Impact**:  rtl refactoring 

**Development Phase**: implementation

For a BOOM config with `issueWidth > coreWidth`, a branch instruction issued to a ALU execution unit with index greater than `coreWidth` can lead to architecturally incorrect outcomes. 
Specifically, if the branch predictor mispredicts the outcome of this instruction, the branch resolution info (`brinfo`) from the respective ALU unit gets silently dropped. As a result, the misprediction is never rolled back, and the branch instruction commits architecturally with the incorrect fetch-time guess.

The root cause is a Scala zip truncation in `core.scala` that discards branch resolution outputs when `coreWidth < int_issueWidth`. This causes mispredicted branches to commit and corrupt the architectural state

## Details

The `brinfos` vector is defined in `core.scala` to be of length `coreWidth`. 

``` scala
val brinfos = Reg(Vec(coreWidth, new BrResolutionInfo()))
```

But semantically, the number of ALU units that can generate `brinfos` is the INT `issuewidth`, not `coreWidth`:

``` scala
for (w <- 0 until int_width) {
    ...
    exe_units += alu_exe_unit
}
```

So, for BOOM configs with an OoO backend that is wider than the frontend, the following zip gets truncated to `coreWidth` and the `brinfos` of the upper ports of alu units get dropped, dead-code elimination during firtool's compiliation to SystemVerilog (SV) removes the `brinfos` output ports of the affected ALUs.


``` scala
for ((b, a) <- brinfos zip exe_units.alu_units) {
    b := a.io.brinfo
    b.valid := a.io.brinfo.valid && !rob.io.flush.valid
}
```

## Reproducing Test

So, for example, if we had `coreWidth=1` and `issueWidth=2`, the following conditions will trigger this bug:

1. First, there must be a dual issue where a branch goes to Port 1.
2. Then, that branch must end up being mispredicted.

In this case, Port 1's `brinfo` gets dropped and the rob commits the corrupted state.

The following example achieves that by causing a data dependency between the slow `divu` and the two alu instructions, which puts backpressure on the issue queue. On wakeup, since `addw` is earlier in the program order than the branch, it gets issued to Port 0 while beq goes to Port 1. The cold behaviour of the BP is to predict 'not-taken' which is incorrect in this scenario. And due to the aforementioned bug, this misprediction is never handled.

``` asm
    li x2, 1
    li x1, 0
    divu x1, x1, x2
    addw x3, x1, x0
correct:
    beq x1, x0, correct
bug:
    j bug
```

The incorrect BOOM spins on the bug loop while Spike spins on the correct loop


## Fix

brinfos should be wide enough to zip with alu_units.

``` scala
val brinfos = Reg(Vec(exe_units.alu_units.length, new BrResolutionInfo()))
```

alternatively, this configuration can be disabled entirely by the following require:

``` scala
require(exe_units.alu_units.length == coreWidth)
```
    
-- Found by M Abdullah and Vincent Ulitzsch @ [MIT MATCHA LAB](https://people.csail.mit.edu/mengjia/)
