### PR TITLE
Move perf events and add first-level topdwon events.

### DIFF
--- a/src/main/scala/v3/exu/core.scala
+++ b/src/main/scala/v3/exu/core.scala
@@ -243,31 +243,9 @@ class BoomCore()(implicit p: Parameters) extends BoomModule
 
   //-------------------------------------------------------------
   // Uarch Hardware Performance Events (HPEs)
+  val boomPerfEvents = Module(new boom.v3.perf.BoomPerfEvents)
+  val perfEvents = boomPerfEvents.perfEvents
 
-  val perfEvents = new freechips.rocketchip.rocket.EventSets(Seq(
-    new freechips.rocketchip.rocket.EventSet((mask, hits) => (mask & hits).orR, Seq(
-      ("exception", () => rob.io.com_xcpt.valid),
-      ("nop",       () => false.B),
-      ("nop",       () => false.B),
-      ("nop",       () => false.B))),
-
-    new freechips.rocketchip.rocket.EventSet((mask, hits) => (mask & hits).orR, Seq(
-//      ("I$ blocked",                        () => icache_blocked),
-      ("nop",                               () => false.B),
-      ("branch misprediction",              () => b2.mispredict),
-      ("control-flow target misprediction", () => b2.mispredict &&
-                                                  b2.cfi_type === CFI_JALR),
-      ("flush",                             () => rob.io.flush.valid),
-      ("branch resolved",                   () => b2.valid)
-    )),
-
-    new freechips.rocketchip.rocket.EventSet((mask, hits) => (mask & hits).orR, Seq(
-      ("I$ miss",     () => io.ifu.perf.acquire),
-      ("D$ miss",     () => io.lsu.perf.acquire),
-      ("D$ release",  () => io.lsu.perf.release),
-      ("ITLB miss",   () => io.ifu.perf.tlbMiss),
-      ("DTLB miss",   () => io.lsu.perf.tlbMiss),
-      ("L2 TLB miss", () => io.ptw.perf.l2miss)))))
   val csr = Module(new freechips.rocketchip.rocket.CSRFile(perfEvents, boomParams.customCSRs.decls))
   csr.io.inst foreach { c => c := DontCare }
   csr.io.rocc_interrupt := io.rocc.interrupt
@@ -1312,6 +1290,34 @@ class BoomCore()(implicit p: Parameters) extends BoomModule
 
   assert (!(rob.io.com_xcpt.valid && !rob.io.flush.valid),
     "[core] exception occurred, but pipeline flush signal not set!")
+
+
+  //-------------------------------------------------------------
+  // **** Hook up HPM Perf events ****
+  //-------------------------------------------------------------
+
+  boomPerfEvents.io.branch_mispredict := b2.mispredict
+  boomPerfEvents.io.cfi_target_mispredict := b2.mispredict && b2.cfi_type === CFI_JALR
+  boomPerfEvents.io.branch_resolved := b2.valid
+
+  boomPerfEvents.io.rob_flush := rob.io.flush.valid
+  boomPerfEvents.io.commit_uops := rob.io.commit.valids
+  boomPerfEvents.io.sfence_valid := io.ifu.sfence.valid
+  boomPerfEvents.io.redirect_val := io.ifu.redirect_val
+  boomPerfEvents.io.redirect_flush := io.ifu.redirect_flush
+  boomPerfEvents.io.rob_flush := rob.io.flush.valid
+  boomPerfEvents.io.ifu_acquire := io.ifu.perf.acquire
+  boomPerfEvents.io.lsu_acquire := io.lsu.perf.acquire
+  boomPerfEvents.io.lsu_release := io.lsu.perf.release
+  boomPerfEvents.io.ifu_tlb_miss := io.ifu.perf.tlbMiss
+  boomPerfEvents.io.lsu_tlb_miss := io.lsu.perf.tlbMiss
+  boomPerfEvents.io.ptw_l2_miss := io.ptw.perf.l2miss
+
+  boomPerfEvents.io.dec_valids := dec_valids
+  boomPerfEvents.io.fetchpacket_valid := io.ifu.fetchpacket.valid
+  boomPerfEvents.io.dec_fbundle_valids := VecInit(dec_fbundle.uops.map(_.valid))
+  boomPerfEvents.io.dec_stalls := dec_stalls
+  boomPerfEvents.io.dec_fire := dec_fire
 
   //-------------------------------------------------------------
   //-------------------------------------------------------------

--- a/src/main/scala/v3/perf/hpm-events.scala
+++ b/src/main/scala/v3/perf/hpm-events.scala
@@ -1,0 +1,161 @@
+package boom.v3.perf
+
+import chisel3._
+import chisel3.util.{PopCount, log2Ceil}
+import org.chipsalliance.cde.config.Parameters
+
+import boom.v3.common._
+import freechips.rocketchip.rocket.{EventSet, EventSets}
+
+class BoomPerfEventsIO(implicit p: Parameters)
+  extends BoomBundle()(p)
+  with HasBoomCoreParameters
+{
+  // Branch and redirect events
+  val branch_mispredict = Input(Bool())
+  val cfi_target_mispredict = Input(Bool())
+  val branch_resolved = Input(Bool())
+
+  // ROB and commit events
+  val rob_flush = Input(Bool())
+  val commit_uops = Input(Vec(retireWidth, Bool()))
+
+  // Memory-system events
+  val ifu_acquire = Input(Bool())
+  val lsu_acquire = Input(Bool())
+  val lsu_release = Input(Bool())
+  val ifu_tlb_miss = Input(Bool())
+  val lsu_tlb_miss = Input(Bool())
+  val ptw_l2_miss = Input(Bool())
+
+  // Frontend and decode events
+  val fetchpacket_valid = Input(Bool())
+  val dec_valids = Input(Vec(coreWidth, Bool()))
+  val dec_fbundle_valids = Input(Vec(coreWidth, Bool()))
+  val dec_stalls = Input(Vec(coreWidth, Bool()))
+  val dec_fire = Input(Vec(coreWidth, Bool()))
+
+  // Flush events
+  val sfence_valid = Input(Bool())
+  val redirect_val = Input(Bool())
+  val redirect_flush = Input(Bool())
+
+  val topdown_slots = Output(UInt(log2Ceil(retireWidth + 1).W))
+  val topdown_retiring_slots = Output(UInt(log2Ceil(retireWidth + 1).W))
+  val topdown_frontend_bound_slots = Output(UInt(log2Ceil(retireWidth + 1).W))
+  val topdown_backend_bound_slots = Output(UInt(log2Ceil(retireWidth + 1).W))
+  val topdown_badspec_bound_slots = Output(UInt(log2Ceil(retireWidth + 1).W))
+}
+
+class BoomPerfEvents(implicit p: Parameters)
+  extends BoomModule()(p)
+  with HasBoomCoreParameters
+{
+  val io = IO(new BoomPerfEventsIO)
+
+  private def any(mask: UInt, hits: UInt): Bool = {
+    (mask & hits).orR
+  }
+
+  private val topdownWidth = log2Ceil(retireWidth + 1)
+
+  // Track cycles spent recovering from frontend redirects or ROB flushes.
+  val recovering = RegInit(false.B)
+
+  when (io.sfence_valid || io.redirect_val || io.redirect_flush || io.rob_flush) {
+    recovering := true.B
+  }
+
+  when (io.fetchpacket_valid) {
+    recovering := false.B
+  }
+
+  //-------------------------------------------------------------
+  // Frontend
+  //-------------------------------------------------------------
+
+  // A frontend-bound slot is a non-stalled decode slot without a valid fetch bundle.
+  val frontend_bound_slots =
+    VecInit((0 until coreWidth).map { w =>
+      !recovering &&
+      !io.dec_stalls(w) &&
+      (!io.fetchpacket_valid || !io.dec_fbundle_valids(w))
+    })
+
+  //-------------------------------------------------------------
+  // Bad speculation
+  //-------------------------------------------------------------
+
+  // Track decode minus commit, using decode as a dispatch proxy.
+  val decCount = PopCount(io.dec_fire)
+  val comCount = PopCount(io.commit_uops)
+  val badspecDelta = decCount.zext - comCount.zext
+
+  // Keep ROB-sized signed debt so commit surplus can cancel later decode surplus.
+  // TODO: is this overkill?
+  val badspecDebtWidth = log2Ceil(numRobEntries + 1) + 1
+  val badspec_debt = RegInit(0.S(badspecDebtWidth.W))
+  val nextBadspecDebt = badspec_debt + badspecDelta
+
+  val badspec_slots =
+    Mux(nextBadspecDebt > retireWidth.S,
+      retireWidth.U(topdownWidth.W),
+      Mux(nextBadspecDebt > 0.S,
+        nextBadspecDebt.asUInt.pad(topdownWidth),
+        0.U(topdownWidth.W)))
+
+  badspec_debt := nextBadspecDebt - badspec_slots.zext
+
+  //-------------------------------------------------------------
+  // Top-down slots
+  //-------------------------------------------------------------
+
+  io.topdown_slots := retireWidth.U(topdownWidth.W)
+  io.topdown_retiring_slots := PopCount(io.commit_uops).pad(topdownWidth)
+  io.topdown_frontend_bound_slots := PopCount(frontend_bound_slots).pad(topdownWidth)
+  io.topdown_badspec_bound_slots := badspec_slots
+
+  val usedTopdownSlots =
+    io.topdown_retiring_slots +
+    io.topdown_frontend_bound_slots +
+    io.topdown_badspec_bound_slots
+
+  io.topdown_backend_bound_slots :=
+    Mux(io.topdown_slots > usedTopdownSlots,
+      io.topdown_slots - usedTopdownSlots,
+      0.U(topdownWidth.W))
+
+  def perfEvents: EventSets = new EventSets(Seq(
+    new EventSet(any, Seq(
+      ("nop", () => false.B),
+      ("nop", () => false.B),
+      ("nop", () => false.B),
+      ("nop", () => false.B)
+    )),
+
+    new EventSet(any, Seq(
+      ("nop",                                () => false.B),
+      ("branch misprediction",              () => io.branch_mispredict.asUInt),
+      ("control-flow target misprediction", () => io.cfi_target_mispredict.asUInt),
+      ("flush",                             () => io.rob_flush.asUInt),
+      ("branch resolved",                   () => io.branch_resolved.asUInt)
+    )),
+
+    new EventSet(any, Seq(
+      ("I$ miss",     () => io.ifu_acquire.asUInt),
+      ("D$ miss",     () => io.lsu_acquire.asUInt),
+      ("D$ release",  () => io.lsu_release.asUInt),
+      ("ITLB miss",   () => io.ifu_tlb_miss.asUInt),
+      ("DTLB miss",   () => io.lsu_tlb_miss.asUInt),
+      ("L2 TLB miss", () => io.ptw_l2_miss.asUInt)
+    )),
+
+    new EventSet(any, Seq(
+      ("TOPDOWN.SLOTS",                 () => io.topdown_slots),
+      ("TOPDOWN.RETIRING.SLOTS",        () => io.topdown_retiring_slots),
+      ("TOPDOWN.FRONTEND_BOUND.SLOTS",  () => io.topdown_frontend_bound_slots),
+      ("TOPDOWN.BACKEND_BOUND.SLOTS",   () => io.topdown_backend_bound_slots),
+      ("TOPDOWN.BAD_SPECULATION.SLOTS", () => io.topdown_badspec_bound_slots)
+    ))
+  ))
+}


### PR DESCRIPTION
Add BOOM HPM events according to the RISC-V performance-event specification

**Related issue**: N/A

**Type of change**: new feature

**Impact**: new rtl

**Development Phase**: implementation

**Release Notes**

Adds BOOM hardware performance monitor events organized according to the RISC-V performance-event specification defined by the  specification https://github.com/riscv/riscv-performance-events.

This introduces a `BoomPerfEvents` module that collects performance relevant events and computes topdown categories. 
Depends on https://github.com/chipsalliance/rocket-chip/pull/3805.
