### PR TITLE
fix: prevent a page table walk to commit a nacked store

### DIFF
--- a/src/main/scala/v4/lsu/lsu.scala
+++ b/src/main/scala/v4/lsu/lsu.scala
@@ -1610,7 +1610,7 @@ class LSU(implicit p: Parameters, edge: TLEdgeOut) extends BoomModule()(p)
       }
     }
     // Handle store acks
-    when (io.dmem.store_ack(w).valid) {
+    when (io.dmem.store_ack(w).valid && !io.dmem.store_ack(w).bits.is_hella) {
       stq_succeeded(io.dmem.store_ack(w).bits.uop.stq_idx) := true.B
     }
 


### PR DESCRIPTION
If a ptw introduced hellacache request sends back a store ack with the same stq idx as the head of stq, while the inflight head-of-stq dcache request is nacked later, we would still commit and remove that stq entry, silently dropping a store. Adding this gate solves the issue.

<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: rtl refactoring

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
