### PR TITLE
Add non-blocking folded custom multipliers MULE2N MULE3N and MULE5N

### DIFF
--- a/src/main/scala/v3/common/consts.scala
+++ b/src/main/scala/v3/common/consts.scala
@@ -257,6 +257,9 @@ trait ScalarOpConstants
   val uopROCC      = 108.U(UOPC_SZ.W)
 
   val uopMOV       = 109.U(UOPC_SZ.W) // conditional mov decoded from "add rd, x0, rs2"
+  val uopMULE2N    = 110.U(UOPC_SZ.W)
+  val uopMULE3N    = 111.U(UOPC_SZ.W)
+  val uopMULE5N    = 112.U(UOPC_SZ.W)
 
   // The Bubble Instruction (Machine generated NOP)
   // Insert (XOR x0,x0,x0) which is different from software compiler

--- a/src/main/scala/v3/exu/core.scala
+++ b/src/main/scala/v3/exu/core.scala
@@ -129,9 +129,11 @@ class BoomCore()(implicit p: Parameters) extends BoomModule
 
   // wb arbiter for the 0th ll writeback
   // TODO: should this be a multi-arb?
-  val ll_wbarb         = Module(new Arbiter(new ExeUnitResp(xLen), 1 +
-                                                                   (if (usingFPU) 1 else 0) +
-                                                                   (if (usingRoCC) 1 else 0)))
+  val ll_wbarb_inputs  = 1 +
+                         (if (usingFPU) 1 else 0) +
+                         (if (usingRoCC) 1 else 0) +
+                         exe_units.slow_custom_mul_units.length
+  val ll_wbarb         = Module(new Arbiter(new ExeUnitResp(xLen), ll_wbarb_inputs))
   val iregister_read   = Module(new RegisterRead(
                            issue_units.map(_.issueWidth).sum,
                            exe_units.withFilter(_.readsIrf).map(_.supportedFuncUnits).toSeq,
@@ -1202,6 +1204,14 @@ class BoomCore()(implicit p: Parameters) extends BoomModule
   if (usingRoCC) {
     require(usingFPU)
     ll_wbarb.io.in(2)       <> exe_units.rocc_unit.io.ll_iresp
+  }
+  {
+    var ll_idx = 1 + (if (usingFPU) 1 else 0) + (if (usingRoCC) 1 else 0)
+    for (unit <- exe_units.slow_custom_mul_units) {
+      ll_wbarb.io.in(ll_idx) <> unit.io.ll_iresp
+      ll_idx += 1
+    }
+    require(ll_idx == ll_wbarb_inputs)
   }
 
   //-------------------------------------------------------------

--- a/src/main/scala/v3/exu/decode.scala
+++ b/src/main/scala/v3/exu/decode.scala
@@ -160,6 +160,10 @@ object X64Decode extends DecodeConstants
  */
 object XDecode extends DecodeConstants
 {
+  private val MULE2N = BitPat("b0001101??????????000?????0001011")
+  private val MULE3N = BitPat("b0001110??????????000?????0001011")
+  private val MULE5N = BitPat("b0001111??????????000?????0001011")
+
            //                                                                  frs3_en                        wakeup_delay
            //     is val inst?                                                 |  imm sel                     |    bypassable (aka, known/fixed latency)
            //     |  is fp inst?                                               |  |     uses_ldq              |    |  is_br
@@ -215,6 +219,9 @@ object XDecode extends DecodeConstants
   DIVUW   -> List(Y, N, X, uopDIVUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , 0.U, N, N, N, N, N, CSR.N),
   REMW    -> List(Y, N, X, uopREMW , IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , 0.U, N, N, N, N, N, CSR.N),
   REMUW   -> List(Y, N, X, uopREMUW, IQT_INT, FU_DIV , RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , 0.U, N, N, N, N, N, CSR.N),
+  MULE2N  -> List(Y, N, X, uopMULE2N,IQT_INT, FU_MULE2N, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , 0.U, N, N, N, N, N, CSR.N),
+  MULE3N  -> List(Y, N, X, uopMULE3N,IQT_INT, FU_MULE3N, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , 0.U, N, N, N, N, N, CSR.N),
+  MULE5N  -> List(Y, N, X, uopMULE5N,IQT_INT, FU_MULE5N, RT_FIX, RT_FIX, RT_FIX, N, IS_X, N, N, N, N, N, M_X  , 0.U, N, N, N, N, N, CSR.N),
 
   AUIPC   -> List(Y, N, X, uopAUIPC, IQT_INT, FU_JMP , RT_FIX, RT_X  , RT_X  , N, IS_U, N, N, N, N, N, M_X  , 1.U, N, N, N, N, N, CSR.N), // use BRU for the PC read
   JAL     -> List(Y, N, X, uopJAL  , IQT_INT, FU_JMP , RT_FIX, RT_X  , RT_X  , N, IS_J, N, N, N, N, N, M_X  , 1.U, N, N, N, N, N, CSR.N),

--- a/src/main/scala/v3/exu/execution-units/execution-unit.scala
+++ b/src/main/scala/v3/exu/execution-units/execution-unit.scala
@@ -93,6 +93,9 @@ abstract class ExecutionUnit(
   val hasAlu           : Boolean       = false,
   val hasFpu           : Boolean       = false,
   val hasMul           : Boolean       = false,
+  val hasMule2n        : Boolean       = false,
+  val hasMule3n        : Boolean       = false,
+  val hasMule5n        : Boolean       = false,
   val hasDiv           : Boolean       = false,
   val hasFdiv          : Boolean       = false,
   val hasIfpu          : Boolean       = false,
@@ -169,7 +172,7 @@ abstract class ExecutionUnit(
   // TODO add "number of fflag ports", so we can properly account for FPU+Mem combinations
   def hasFFlags     : Boolean = hasFpu || hasFdiv
 
-  require ((hasFpu || hasFdiv) ^ (hasAlu || hasMul || hasMem || hasIfpu),
+  require ((hasFpu || hasFdiv) ^ (hasAlu || hasMul || hasMem || hasIfpu || hasMule2n || hasMule3n || hasMule5n),
     "[execute] we no longer support mixing FP and Integer functional units in the same exe unit.")
   def hasFcsr = hasIfpu || hasFpu || hasFdiv
 
@@ -181,7 +184,7 @@ abstract class ExecutionUnit(
       alu = hasAlu,
       jmp = hasJmpUnit,
       mem = hasMem,
-      muld = hasMul || hasDiv,
+      muld = hasMul || hasMule2n || hasMule3n || hasMule5n || hasDiv,
       fpu = hasFpu,
       csr = hasCSR,
       fdiv = hasFdiv,
@@ -206,6 +209,9 @@ class ALUExeUnit(
   hasCSR         : Boolean = false,
   hasAlu         : Boolean = true,
   hasMul         : Boolean = false,
+  hasMule2n      : Boolean = false,
+  hasMule3n      : Boolean = false,
+  hasMule5n      : Boolean = false,
   hasDiv         : Boolean = false,
   hasIfpu        : Boolean = false,
   hasMem         : Boolean = false,
@@ -214,18 +220,21 @@ class ALUExeUnit(
   extends ExecutionUnit(
     readsIrf         = true,
     writesIrf        = hasAlu || hasMul || hasDiv,
-    writesLlIrf      = hasMem || hasRocc,
+    writesLlIrf      = hasMem || hasRocc || hasMule2n || hasMule3n || hasMule5n,
     writesLlFrf      = (hasIfpu || hasMem) && p(tile.TileKey).core.fpu != None,
     numBypassStages  =
       if (hasAlu && hasMul) 3 //TODO XXX p(tile.TileKey).core.imulLatency
       else if (hasAlu) 1 else 0,
     dataWidth        = 64 + 1,
     bypassable       = hasAlu,
-    alwaysBypassable = hasAlu && !(hasMem || hasJmpUnit || hasMul || hasDiv || hasCSR || hasIfpu || hasRocc),
+    alwaysBypassable = hasAlu && !(hasMem || hasJmpUnit || hasMul || hasMule2n || hasMule3n || hasMule5n || hasDiv || hasCSR || hasIfpu || hasRocc),
     hasCSR           = hasCSR,
     hasJmpUnit       = hasJmpUnit,
     hasAlu           = hasAlu,
     hasMul           = hasMul,
+    hasMule2n        = hasMule2n,
+    hasMule3n        = hasMule3n,
+    hasMule5n        = hasMule5n,
     hasDiv           = hasDiv,
     hasIfpu          = hasIfpu,
     hasMem           = hasMem,
@@ -243,6 +252,9 @@ class ALUExeUnit(
     BoomCoreStringPrefix("==ExeUnit==") +
     (if (hasAlu)  BoomCoreStringPrefix(" - ALU") else "") +
     (if (hasMul)  BoomCoreStringPrefix(" - Mul") else "") +
+    (if (hasMule2n) BoomCoreStringPrefix(" - MULE2N") else "") +
+    (if (hasMule3n) BoomCoreStringPrefix(" - MULE3N") else "") +
+    (if (hasMule5n) BoomCoreStringPrefix(" - MULE5N") else "") +
     (if (hasDiv)  BoomCoreStringPrefix(" - Div") else "") +
     (if (hasIfpu) BoomCoreStringPrefix(" - IFPU") else "") +
     (if (hasMem)  BoomCoreStringPrefix(" - Mem") else "") +
@@ -252,6 +264,9 @@ class ALUExeUnit(
 
   val div_busy  = WireInit(false.B)
   val ifpu_busy = WireInit(false.B)
+  val mule2n_busy = WireInit(false.B)
+  val mule3n_busy = WireInit(false.B)
+  val mule5n_busy = WireInit(false.B)
 
   // The Functional Units --------------------
   // Specifically the functional units with fast writeback to IRF
@@ -259,6 +274,9 @@ class ALUExeUnit(
 
   io.fu_types := Mux(hasAlu.B, FU_ALU, 0.U) |
                  Mux(hasMul.B, FU_MUL, 0.U) |
+                 Mux(!mule2n_busy && hasMule2n.B, FU_MULE2N, 0.U) |
+                 Mux(!mule3n_busy && hasMule3n.B, FU_MULE3N, 0.U) |
+                 Mux(!mule5n_busy && hasMule5n.B, FU_MULE5N, 0.U) |
                  Mux(!div_busy && hasDiv.B, FU_DIV, 0.U) |
                  Mux(hasCSR.B, FU_CSR, 0.U) |
                  Mux(hasJmpUnit.B, FU_JMP, 0.U) |
@@ -299,6 +317,8 @@ class ALUExeUnit(
     }
   }
 
+  val ll_iresp_units = ArrayBuffer[DecoupledIO[ExeUnitResp]]()
+
   var rocc: RoCCShim = null
   if (hasRocc) {
     rocc = Module(new RoCCShim)
@@ -313,10 +333,15 @@ class ALUExeUnit(
     rocc.io.exception         := io.com_exception
     io.rocc                   <> rocc.io.core
 
-    rocc.io.resp.ready        := io.ll_iresp.ready
-    io.ll_iresp.valid         := rocc.io.resp.valid
-    io.ll_iresp.bits.uop      := rocc.io.resp.bits.uop
-    io.ll_iresp.bits.data     := rocc.io.resp.bits.data
+    val rocc_resp = Wire(Decoupled(new ExeUnitResp(dataWidth)))
+    rocc_resp.valid := rocc.io.resp.valid
+    rocc_resp.bits := DontCare
+    rocc_resp.bits.uop := rocc.io.resp.bits.uop
+    rocc_resp.bits.data := rocc.io.resp.bits.data
+    rocc_resp.bits.predicated := false.B
+    rocc_resp.bits.fflags.valid := false.B
+    rocc.io.resp.ready := rocc_resp.ready
+    ll_iresp_units += rocc_resp
   }
 
 
@@ -332,6 +357,81 @@ class ALUExeUnit(
     imul.io.req.bits.kill     := io.req.bits.kill
     imul.io.brupdate := io.brupdate
     iresp_fu_units += imul
+  }
+
+  var mule2n: FoldedMule2NUnit = null
+  if (hasMule2n) {
+    mule2n = Module(new FoldedMule2NUnit(xLen))
+    mule2n.io.req.valid         := io.req.valid && io.req.bits.uop.fu_code_is(FU_MULE2N)
+    mule2n.io.req.bits.uop      := io.req.bits.uop
+    mule2n.io.req.bits.rs1_data := io.req.bits.rs1_data
+    mule2n.io.req.bits.rs2_data := io.req.bits.rs2_data
+    mule2n.io.req.bits.rs3_data := DontCare
+    mule2n.io.req.bits.pred_data := false.B
+    mule2n.io.req.bits.kill     := io.req.bits.kill
+    mule2n.io.brupdate          := io.brupdate
+
+    val mule2n_resp = Wire(Decoupled(new ExeUnitResp(dataWidth)))
+    mule2n_resp.valid := mule2n.io.resp.valid
+    mule2n_resp.bits := DontCare
+    mule2n_resp.bits.uop := mule2n.io.resp.bits.uop
+    mule2n_resp.bits.data := mule2n.io.resp.bits.data
+    mule2n_resp.bits.predicated := mule2n.io.resp.bits.predicated
+    mule2n_resp.bits.fflags.valid := false.B
+    mule2n.io.resp.ready := mule2n_resp.ready
+    ll_iresp_units += mule2n_resp
+
+    mule2n_busy := !mule2n.io.req.ready || (io.req.valid && io.req.bits.uop.fu_code_is(FU_MULE2N))
+  }
+
+  var mule3n: FoldedMule3NUnit = null
+  if (hasMule3n) {
+    mule3n = Module(new FoldedMule3NUnit(xLen))
+    mule3n.io.req.valid         := io.req.valid && io.req.bits.uop.fu_code_is(FU_MULE3N)
+    mule3n.io.req.bits.uop      := io.req.bits.uop
+    mule3n.io.req.bits.rs1_data := io.req.bits.rs1_data
+    mule3n.io.req.bits.rs2_data := io.req.bits.rs2_data
+    mule3n.io.req.bits.rs3_data := DontCare
+    mule3n.io.req.bits.pred_data := false.B
+    mule3n.io.req.bits.kill     := io.req.bits.kill
+    mule3n.io.brupdate          := io.brupdate
+
+    val mule3n_resp = Wire(Decoupled(new ExeUnitResp(dataWidth)))
+    mule3n_resp.valid := mule3n.io.resp.valid
+    mule3n_resp.bits := DontCare
+    mule3n_resp.bits.uop := mule3n.io.resp.bits.uop
+    mule3n_resp.bits.data := mule3n.io.resp.bits.data
+    mule3n_resp.bits.predicated := mule3n.io.resp.bits.predicated
+    mule3n_resp.bits.fflags.valid := false.B
+    mule3n.io.resp.ready := mule3n_resp.ready
+    ll_iresp_units += mule3n_resp
+
+    mule3n_busy := !mule3n.io.req.ready || (io.req.valid && io.req.bits.uop.fu_code_is(FU_MULE3N))
+  }
+
+  var mule5n: FoldedMule5NUnit = null
+  if (hasMule5n) {
+    mule5n = Module(new FoldedMule5NUnit(xLen))
+    mule5n.io.req.valid         := io.req.valid && io.req.bits.uop.fu_code_is(FU_MULE5N)
+    mule5n.io.req.bits.uop      := io.req.bits.uop
+    mule5n.io.req.bits.rs1_data := io.req.bits.rs1_data
+    mule5n.io.req.bits.rs2_data := io.req.bits.rs2_data
+    mule5n.io.req.bits.rs3_data := DontCare
+    mule5n.io.req.bits.pred_data := false.B
+    mule5n.io.req.bits.kill     := io.req.bits.kill
+    mule5n.io.brupdate          := io.brupdate
+
+    val mule5n_resp = Wire(Decoupled(new ExeUnitResp(dataWidth)))
+    mule5n_resp.valid := mule5n.io.resp.valid
+    mule5n_resp.bits := DontCare
+    mule5n_resp.bits.uop := mule5n.io.resp.bits.uop
+    mule5n_resp.bits.data := mule5n.io.resp.bits.data
+    mule5n_resp.bits.predicated := mule5n.io.resp.bits.predicated
+    mule5n_resp.bits.fflags.valid := false.B
+    mule5n.io.resp.ready := mule5n_resp.ready
+    ll_iresp_units += mule5n_resp
+
+    mule5n_busy := !mule5n.io.req.ready || (io.req.valid && io.req.bits.uop.fu_code_is(FU_MULE5N))
   }
 
   var ifpu: IntToFPUnit = null
@@ -401,6 +501,17 @@ class ALUExeUnit(
     io.ll_iresp <> io.lsu_io.iresp
     if (usingFPU) {
       io.ll_fresp <> io.lsu_io.fresp
+    }
+  } else if (writesLlIrf) {
+    require(ll_iresp_units.nonEmpty)
+    if (ll_iresp_units.size == 1) {
+      io.ll_iresp <> ll_iresp_units.head
+    } else {
+      val ll_iresp_arb = Module(new Arbiter(new ExeUnitResp(dataWidth), ll_iresp_units.size))
+      for ((unit, idx) <- ll_iresp_units.zipWithIndex) {
+        ll_iresp_arb.io.in(idx) <> unit
+      }
+      io.ll_iresp <> ll_iresp_arb.io.out
     }
   }
 

--- a/src/main/scala/v3/exu/execution-units/execution-units.scala
+++ b/src/main/scala/v3/exu/execution-units/execution-units.scala
@@ -73,6 +73,22 @@ class ExecutionUnits(val fpu: Boolean)(implicit val p: Parameters) extends HasBo
     exe_units.filter(_.hasAlu)
   }
 
+  lazy val mule2n_units = {
+    exe_units.filter(_.hasMule2n)
+  }
+
+  lazy val mule3n_units = {
+    exe_units.filter(_.hasMule3n)
+  }
+
+  lazy val mule5n_units = {
+    exe_units.filter(_.hasMule5n)
+  }
+
+  lazy val slow_custom_mul_units = {
+    exe_units.filter(u => u.hasMule2n || u.hasMule3n || u.hasMule5n)
+  }
+
   lazy val csr_unit = {
     require (exe_units.count(_.hasCSR) == 1)
     exe_units.find(_.hasCSR).get
@@ -121,6 +137,9 @@ class ExecutionUnits(val fpu: Boolean)(implicit val p: Parameters) extends HasBo
         hasCSR         = is_nth(1),
         hasRocc        = is_nth(1) && usingRoCC,
         hasMul         = is_nth(2),
+        hasMule2n      = is_nth(2),
+        hasMule3n      = is_nth(2),
+        hasMule5n      = is_nth(2),
         hasDiv         = is_nth(3),
         hasIfpu        = is_nth(4) && usingFPU))
       exe_units += alu_exe_unit

--- a/src/main/scala/v3/exu/execution-units/functional-unit.scala
+++ b/src/main/scala/v3/exu/execution-units/functional-unit.scala
@@ -35,7 +35,7 @@ import boom.v3.util._
 object FUConstants
 {
   // bit mask, since a given execution pipeline may support multiple functional units
-  val FUC_SZ = 10
+  val FUC_SZ = 13
   val FU_X   = BitPat.dontCare(FUC_SZ)
   val FU_ALU =   1.U(FUC_SZ.W)
   val FU_JMP =   2.U(FUC_SZ.W)
@@ -47,6 +47,9 @@ object FUConstants
   val FU_FDV = 128.U(FUC_SZ.W)
   val FU_I2F = 256.U(FUC_SZ.W)
   val FU_F2I = 512.U(FUC_SZ.W)
+  val FU_MULE2N = 1024.U(FUC_SZ.W)
+  val FU_MULE3N = 2048.U(FUC_SZ.W)
+  val FU_MULE5N = 4096.U(FUC_SZ.W)
 
   // FP stores generate data through FP F2I, and generate address through MemAddrCalc
   val FU_F2IMEM = 516.U(FUC_SZ.W)
@@ -722,4 +725,724 @@ class PipelinedMulUnit(numStages: Int, dataWidth: Int)(implicit p: Parameters)
   imul.io.req.bits.tag := DontCare
   // response
   io.resp.bits.data    := imul.io.resp.bits.data
+}
+
+class FoldedMule2NUnit(dataWidth: Int)(implicit p: Parameters)
+  extends FunctionalUnit(
+    isPipelined = false,
+    numStages = 1,
+    numBypassStages = 0,
+    dataWidth = dataWidth)
+{
+  require(xLen == 64, "[mule2n] BOOM MULE2N implementation assumes RV64.")
+
+  val prodWidth  = 2 * xLen
+  val chunkWidth = xLen / 2
+
+  val sIdle :: sCalc0 :: sCalc1 :: sResp :: Nil = Enum(4)
+  val state = RegInit(sIdle)
+
+  val r_uop          = Reg(new MicroOp())
+  val sign_r         = RegInit(false.B)
+  val chunk1_valid_r = RegInit(false.B)
+  val multiplicand_r = Reg(UInt(xLen.W))
+  val chunk0_r       = Reg(UInt(chunkWidth.W))
+  val chunk1_r       = Reg(UInt(chunkWidth.W))
+  val chunk0_high_r  = RegInit(false.B)
+  val chunk1_high_r  = RegInit(false.B)
+  val acc_sum_r      = RegInit(0.U(prodWidth.W))
+  val acc_carry_r    = RegInit(0.U(prodWidth.W))
+  val result_r       = RegInit(0.U(xLen.W))
+
+  private def csa(a: UInt, b: UInt, c: UInt): (UInt, UInt) = {
+    val width = a.getWidth
+    val sum   = Wire(UInt(width.W))
+    val carry = Wire(UInt(width.W))
+    sum   := a ^ b ^ c
+    carry := (((a & b) | (a & c) | (b & c)) << 1)(width - 1, 0)
+    (sum, carry)
+  }
+
+  private def absSigned(value: UInt): UInt = {
+    Mux(value(xLen - 1), (~value).asUInt + 1.U, value)
+  }
+
+  private def shiftChunk(value: UInt, upperHalf: Bool): UInt = {
+    val shifted = Wire(UInt(prodWidth.W))
+    shifted := Mux(upperHalf, (value << chunkWidth)(prodWidth - 1, 0), value)
+    shifted
+  }
+
+  val req_a = io.req.bits.rs1_data(xLen - 1, 0)
+  val req_b = io.req.bits.rs2_data(xLen - 1, 0)
+
+  val a_abs = absSigned(req_a)
+  val b_abs = absSigned(req_b)
+
+  val a_low_nonzero  = a_abs(chunkWidth - 1, 0) =/= 0.U
+  val a_high_nonzero = a_abs(xLen - 1, chunkWidth) =/= 0.U
+  val b_low_nonzero  = b_abs(chunkWidth - 1, 0) =/= 0.U
+  val b_high_nonzero = b_abs(xLen - 1, chunkWidth) =/= 0.U
+
+  val a_single_chunk = !(a_low_nonzero && a_high_nonzero)
+  val b_single_chunk = !(b_low_nonzero && b_high_nonzero)
+
+  val choose_a_as_chunk =
+    Mux(a_single_chunk =/= b_single_chunk, a_single_chunk, PopCount(a_abs) <= PopCount(b_abs))
+
+  val chunk_seed        = Mux(choose_a_as_chunk, a_abs, b_abs)
+  val multiplicand_seed = Mux(choose_a_as_chunk, b_abs, a_abs)
+  val sign_seed         = req_a(xLen - 1) ^ req_b(xLen - 1)
+
+  val chunk_low_seed    = chunk_seed(chunkWidth - 1, 0)
+  val chunk_high_seed   = chunk_seed(xLen - 1, chunkWidth)
+  val low_nonzero_seed  = chunk_low_seed =/= 0.U
+  val high_nonzero_seed = chunk_high_seed =/= 0.U
+
+  val choose_high_first =
+    high_nonzero_seed &&
+    (!low_nonzero_seed || (PopCount(chunk_high_seed) < PopCount(chunk_low_seed)))
+
+  val chunk0_seed       = Mux(choose_high_first, chunk_high_seed, chunk_low_seed)
+  val chunk1_seed       = Mux(choose_high_first, chunk_low_seed, chunk_high_seed)
+  val chunk0_high_seed  = choose_high_first
+  val chunk1_high_seed  = !choose_high_first
+  val chunk1_valid_seed = low_nonzero_seed && high_nonzero_seed
+
+  val calc0_active = state === sCalc0
+  val calc1_active = state === sCalc1
+  val current_chunk = Mux(calc1_active, chunk1_r, chunk0_r)
+  val current_high  = Mux(calc1_active, chunk1_high_r, chunk0_high_r)
+  val gated_chunk   = Mux(calc0_active || calc1_active, current_chunk, 0.U(chunkWidth.W))
+
+  val pp_lines = Wire(Vec(chunkWidth, UInt(prodWidth.W)))
+  for (i <- 0 until chunkWidth) {
+    pp_lines(i) := Mux(gated_chunk(i), (Cat(0.U(xLen.W), multiplicand_r) << i)(prodWidth - 1, 0), 0.U(prodWidth.W))
+  }
+
+  val ppm_sum   = Wire(Vec(chunkWidth + 1, UInt(prodWidth.W)))
+  val ppm_carry = Wire(Vec(chunkWidth + 1, UInt(prodWidth.W)))
+  ppm_sum(0)   := 0.U
+  ppm_carry(0) := 0.U
+
+  for (i <- 0 until chunkWidth) {
+    val stage = csa(ppm_sum(i), ppm_carry(i), pp_lines(i))
+    ppm_sum(i + 1)   := stage._1
+    ppm_carry(i + 1) := stage._2
+  }
+
+  val chunk_sum_shifted   = shiftChunk(ppm_sum(chunkWidth), current_high)
+  val chunk_carry_shifted = shiftChunk(ppm_carry(chunkWidth), current_high)
+  val feedback0           = csa(acc_sum_r, acc_carry_r, chunk_sum_shifted)
+  val feedback1           = csa(feedback0._1, feedback0._2, chunk_carry_shifted)
+  val final_product       = feedback1._1 + feedback1._2
+  val final_mag_result    = final_product(xLen - 1, 0)
+  val final_result        = Mux(sign_r, (~final_mag_result).asUInt + 1.U, final_mag_result)
+
+  when (state =/= sIdle) {
+    r_uop.br_mask := GetNewBrMask(io.brupdate, r_uop)
+  }
+
+  val do_kill = (state =/= sIdle) && (IsKilledByBranch(io.brupdate, r_uop) || io.req.bits.kill)
+
+  io.req.ready := state === sIdle
+  io.resp.valid := state === sResp && !do_kill
+  io.resp.bits.predicated := false.B
+  io.resp.bits.data := result_r
+  io.resp.bits.fflags.valid := false.B
+  io.resp.bits.uop := r_uop
+  io.resp.bits.uop.br_mask := GetNewBrMask(io.brupdate, r_uop)
+
+  when (do_kill) {
+    state := sIdle
+    acc_sum_r := 0.U
+    acc_carry_r := 0.U
+  } .otherwise {
+    switch (state) {
+      is (sIdle) {
+        when (io.req.fire) {
+          r_uop := io.req.bits.uop
+          r_uop.br_mask := GetNewBrMask(io.brupdate, io.req.bits.uop)
+          sign_r := sign_seed
+          multiplicand_r := multiplicand_seed
+          chunk0_r := chunk0_seed
+          chunk1_r := chunk1_seed
+          chunk0_high_r := chunk0_high_seed
+          chunk1_high_r := chunk1_high_seed
+          chunk1_valid_r := chunk1_valid_seed
+          acc_sum_r := 0.U
+          acc_carry_r := 0.U
+
+          when (a_abs === 0.U || b_abs === 0.U) {
+            result_r := 0.U
+            state := sResp
+          } .otherwise {
+            state := sCalc0
+          }
+        }
+      }
+
+      is (sCalc0) {
+        when (chunk1_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc1
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc1) {
+        result_r := final_result
+        state := sResp
+      }
+
+      is (sResp) {
+        when (io.resp.ready) {
+          state := sIdle
+        }
+      }
+    }
+  }
+}
+
+class FoldedMule3NUnit(dataWidth: Int)(implicit p: Parameters)
+  extends FunctionalUnit(
+    isPipelined = false,
+    numStages = 1,
+    numBypassStages = 0,
+    dataWidth = dataWidth)
+{
+  require(xLen == 64, "[mule3n] BOOM MULE3N implementation assumes RV64.")
+
+  val prodWidth      = 2 * xLen
+  val chunkWidth     = 22
+  val highChunkShift = 44
+  val shiftWidth     = log2Ceil(prodWidth)
+
+  val sIdle :: sCalc0 :: sCalc1 :: sCalc2 :: sResp :: Nil = Enum(5)
+  val state = RegInit(sIdle)
+
+  val r_uop          = Reg(new MicroOp())
+  val sign_r         = RegInit(false.B)
+  val chunk1_valid_r = RegInit(false.B)
+  val chunk2_valid_r = RegInit(false.B)
+  val multiplicand_r = Reg(UInt(xLen.W))
+  val chunk0_r       = Reg(UInt(chunkWidth.W))
+  val chunk1_r       = Reg(UInt(chunkWidth.W))
+  val chunk2_r       = Reg(UInt(chunkWidth.W))
+  val chunk0_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk1_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk2_shift_r = Reg(UInt(shiftWidth.W))
+  val acc_sum_r      = RegInit(0.U(prodWidth.W))
+  val acc_carry_r    = RegInit(0.U(prodWidth.W))
+  val result_r       = RegInit(0.U(xLen.W))
+
+  private def csa(a: UInt, b: UInt, c: UInt): (UInt, UInt) = {
+    val width = a.getWidth
+    val sum   = Wire(UInt(width.W))
+    val carry = Wire(UInt(width.W))
+    sum   := a ^ b ^ c
+    carry := (((a & b) | (a & c) | (b & c)) << 1)(width - 1, 0)
+    (sum, carry)
+  }
+
+  private def absSigned(value: UInt): UInt = {
+    Mux(value(xLen - 1), (~value).asUInt + 1.U, value)
+  }
+
+  private def chunkComesFirst(weightA: UInt, shiftA: UInt, weightB: UInt, shiftB: UInt): Bool = {
+    (weightA < weightB) || ((weightA === weightB) && (shiftA < shiftB))
+  }
+
+  val req_a = io.req.bits.rs1_data(xLen - 1, 0)
+  val req_b = io.req.bits.rs2_data(xLen - 1, 0)
+
+  val a_abs = absSigned(req_a)
+  val b_abs = absSigned(req_b)
+
+  val a_low_nonzero  = a_abs(21, 0) =/= 0.U
+  val a_mid_nonzero  = a_abs(43, 22) =/= 0.U
+  val a_high_nonzero = a_abs(63, 44) =/= 0.U
+  val b_low_nonzero  = b_abs(21, 0) =/= 0.U
+  val b_mid_nonzero  = b_abs(43, 22) =/= 0.U
+  val b_high_nonzero = b_abs(63, 44) =/= 0.U
+
+  val a_chunk_count = a_low_nonzero.asUInt +& a_mid_nonzero.asUInt +& a_high_nonzero.asUInt
+  val b_chunk_count = b_low_nonzero.asUInt +& b_mid_nonzero.asUInt +& b_high_nonzero.asUInt
+
+  val choose_a_as_chunk =
+    Mux(a_chunk_count =/= b_chunk_count, a_chunk_count < b_chunk_count, PopCount(a_abs) <= PopCount(b_abs))
+
+  val chunk_seed        = Mux(choose_a_as_chunk, a_abs, b_abs)
+  val multiplicand_seed = Mux(choose_a_as_chunk, b_abs, a_abs)
+  val sign_seed         = req_a(xLen - 1) ^ req_b(xLen - 1)
+
+  val chunk_low_seed  = chunk_seed(21, 0)
+  val chunk_mid_seed  = chunk_seed(43, 22)
+  val chunk_high_seed = Cat(0.U(2.W), chunk_seed(63, 44))
+
+  val low_nonzero_seed  = chunk_low_seed =/= 0.U
+  val mid_nonzero_seed  = chunk_mid_seed =/= 0.U
+  val high_nonzero_seed = chunk_high_seed =/= 0.U
+
+  val low_weight  = Mux(low_nonzero_seed, PopCount(chunk_low_seed), 63.U(6.W))
+  val mid_weight  = Mux(mid_nonzero_seed, PopCount(chunk_mid_seed), 63.U(6.W))
+  val high_weight = Mux(high_nonzero_seed, PopCount(chunk_high_seed), 63.U(6.W))
+
+  val shiftLow  = 0.U(shiftWidth.W)
+  val shiftMid  = 22.U(shiftWidth.W)
+  val shiftHigh = highChunkShift.U(shiftWidth.W)
+
+  val swap01 = !chunkComesFirst(low_weight, shiftLow, mid_weight, shiftMid)
+  val stage0_chunk0  = Mux(swap01, chunk_mid_seed, chunk_low_seed)
+  val stage0_chunk1  = Mux(swap01, chunk_low_seed, chunk_mid_seed)
+  val stage0_weight0 = Mux(swap01, mid_weight, low_weight)
+  val stage0_weight1 = Mux(swap01, low_weight, mid_weight)
+  val stage0_shift0  = Mux(swap01, shiftMid, shiftLow)
+  val stage0_shift1  = Mux(swap01, shiftLow, shiftMid)
+  val stage0_valid0  = Mux(swap01, mid_nonzero_seed, low_nonzero_seed)
+  val stage0_valid1  = Mux(swap01, low_nonzero_seed, mid_nonzero_seed)
+
+  val swap12 = !chunkComesFirst(stage0_weight1, stage0_shift1, high_weight, shiftHigh)
+  val stage1_chunk1  = Mux(swap12, chunk_high_seed, stage0_chunk1)
+  val stage1_chunk2  = Mux(swap12, stage0_chunk1, chunk_high_seed)
+  val stage1_weight1 = Mux(swap12, high_weight, stage0_weight1)
+  val stage1_weight2 = Mux(swap12, stage0_weight1, high_weight)
+  val stage1_shift1  = Mux(swap12, shiftHigh, stage0_shift1)
+  val stage1_shift2  = Mux(swap12, stage0_shift1, shiftHigh)
+  val stage1_valid1  = Mux(swap12, high_nonzero_seed, stage0_valid1)
+  val stage1_valid2  = Mux(swap12, stage0_valid1, high_nonzero_seed)
+
+  val swap01b = !chunkComesFirst(stage0_weight0, stage0_shift0, stage1_weight1, stage1_shift1)
+  val chunk0_seed       = Mux(swap01b, stage1_chunk1, stage0_chunk0)
+  val chunk1_seed       = Mux(swap01b, stage0_chunk0, stage1_chunk1)
+  val chunk2_seed       = stage1_chunk2
+  val chunk0_shift_seed = Mux(swap01b, stage1_shift1, stage0_shift0)
+  val chunk1_shift_seed = Mux(swap01b, stage0_shift0, stage1_shift1)
+  val chunk2_shift_seed = stage1_shift2
+  val chunk0_valid_seed = Mux(swap01b, stage1_valid1, stage0_valid0)
+  val chunk1_valid_seed = Mux(swap01b, stage0_valid0, stage1_valid1)
+  val chunk2_valid_seed = stage1_valid2
+
+  val calc0_active = state === sCalc0
+  val calc1_active = state === sCalc1
+  val calc2_active = state === sCalc2
+  val current_chunk = Mux(calc2_active, chunk2_r, Mux(calc1_active, chunk1_r, chunk0_r))
+  val current_shift = Mux(calc2_active, chunk2_shift_r, Mux(calc1_active, chunk1_shift_r, chunk0_shift_r))
+  val gated_chunk   = Mux(calc0_active || calc1_active || calc2_active, current_chunk, 0.U(chunkWidth.W))
+
+  val pp_lines = Wire(Vec(chunkWidth, UInt(prodWidth.W)))
+  for (i <- 0 until chunkWidth) {
+    pp_lines(i) := Mux(gated_chunk(i), (Cat(0.U(xLen.W), multiplicand_r) << i)(prodWidth - 1, 0), 0.U(prodWidth.W))
+  }
+
+  val ppm_sum   = Wire(Vec(chunkWidth + 1, UInt(prodWidth.W)))
+  val ppm_carry = Wire(Vec(chunkWidth + 1, UInt(prodWidth.W)))
+  ppm_sum(0)   := 0.U
+  ppm_carry(0) := 0.U
+
+  for (i <- 0 until chunkWidth) {
+    val stage = csa(ppm_sum(i), ppm_carry(i), pp_lines(i))
+    ppm_sum(i + 1)   := stage._1
+    ppm_carry(i + 1) := stage._2
+  }
+
+  val chunk_sum_shifted   = (ppm_sum(chunkWidth) << current_shift)(prodWidth - 1, 0)
+  val chunk_carry_shifted = (ppm_carry(chunkWidth) << current_shift)(prodWidth - 1, 0)
+  val feedback0           = csa(acc_sum_r, acc_carry_r, chunk_sum_shifted)
+  val feedback1           = csa(feedback0._1, feedback0._2, chunk_carry_shifted)
+  val final_product       = feedback1._1 + feedback1._2
+  val final_mag_result    = final_product(xLen - 1, 0)
+  val final_result        = Mux(sign_r, (~final_mag_result).asUInt + 1.U, final_mag_result)
+
+  when (state =/= sIdle) {
+    r_uop.br_mask := GetNewBrMask(io.brupdate, r_uop)
+  }
+
+  val do_kill = (state =/= sIdle) && (IsKilledByBranch(io.brupdate, r_uop) || io.req.bits.kill)
+
+  io.req.ready := state === sIdle
+  io.resp.valid := state === sResp && !do_kill
+  io.resp.bits.predicated := false.B
+  io.resp.bits.data := result_r
+  io.resp.bits.fflags.valid := false.B
+  io.resp.bits.uop := r_uop
+  io.resp.bits.uop.br_mask := GetNewBrMask(io.brupdate, r_uop)
+
+  when (do_kill) {
+    state := sIdle
+    acc_sum_r := 0.U
+    acc_carry_r := 0.U
+  } .otherwise {
+    switch (state) {
+      is (sIdle) {
+        when (io.req.fire) {
+          r_uop := io.req.bits.uop
+          r_uop.br_mask := GetNewBrMask(io.brupdate, io.req.bits.uop)
+          sign_r := sign_seed
+          multiplicand_r := multiplicand_seed
+          chunk0_r := chunk0_seed
+          chunk1_r := chunk1_seed
+          chunk2_r := chunk2_seed
+          chunk0_shift_r := chunk0_shift_seed
+          chunk1_shift_r := chunk1_shift_seed
+          chunk2_shift_r := chunk2_shift_seed
+          chunk1_valid_r := chunk1_valid_seed
+          chunk2_valid_r := chunk2_valid_seed
+          acc_sum_r := 0.U
+          acc_carry_r := 0.U
+
+          when (a_abs === 0.U || b_abs === 0.U || !chunk0_valid_seed) {
+            result_r := 0.U
+            state := sResp
+          } .otherwise {
+            state := sCalc0
+          }
+        }
+      }
+
+      is (sCalc0) {
+        when (chunk1_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc1
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc1) {
+        when (chunk2_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc2
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc2) {
+        result_r := final_result
+        state := sResp
+      }
+
+      is (sResp) {
+        when (io.resp.ready) {
+          state := sIdle
+        }
+      }
+    }
+  }
+}
+
+class FoldedMule5NUnit(dataWidth: Int)(implicit p: Parameters)
+  extends FunctionalUnit(
+    isPipelined = false,
+    numStages = 1,
+    numBypassStages = 0,
+    dataWidth = dataWidth)
+{
+  require(xLen == 64, "[mule5n] BOOM MULE5N implementation assumes RV64.")
+
+  val prodWidth      = 2 * xLen
+  val chunkWidth     = 13
+  val highChunkShift = 52
+  val shiftWidth     = log2Ceil(prodWidth)
+
+  val sIdle :: sCalc0 :: sCalc1 :: sCalc2 :: sCalc3 :: sCalc4 :: sResp :: Nil = Enum(7)
+  val state = RegInit(sIdle)
+
+  val r_uop          = Reg(new MicroOp())
+  val sign_r         = RegInit(false.B)
+  val multiplicand_r = Reg(UInt(xLen.W))
+  val chunk0_r       = Reg(UInt(chunkWidth.W))
+  val chunk1_r       = Reg(UInt(chunkWidth.W))
+  val chunk2_r       = Reg(UInt(chunkWidth.W))
+  val chunk3_r       = Reg(UInt(chunkWidth.W))
+  val chunk4_r       = Reg(UInt(chunkWidth.W))
+  val chunk0_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk1_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk2_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk3_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk4_shift_r = Reg(UInt(shiftWidth.W))
+  val chunk1_valid_r = RegInit(false.B)
+  val chunk2_valid_r = RegInit(false.B)
+  val chunk3_valid_r = RegInit(false.B)
+  val chunk4_valid_r = RegInit(false.B)
+  val acc_sum_r      = RegInit(0.U(prodWidth.W))
+  val acc_carry_r    = RegInit(0.U(prodWidth.W))
+  val result_r       = RegInit(0.U(xLen.W))
+
+  private def csa(a: UInt, b: UInt, c: UInt): (UInt, UInt) = {
+    val width = a.getWidth
+    val sum   = Wire(UInt(width.W))
+    val carry = Wire(UInt(width.W))
+    sum   := a ^ b ^ c
+    carry := (((a & b) | (a & c) | (b & c)) << 1)(width - 1, 0)
+    (sum, carry)
+  }
+
+  private def absSigned(value: UInt): UInt = {
+    Mux(value(xLen - 1), (~value).asUInt + 1.U, value)
+  }
+
+  private def chunkComesFirst(weightA: UInt, shiftA: UInt, weightB: UInt, shiftB: UInt): Bool = {
+    (weightA < weightB) || ((weightA === weightB) && (shiftA < shiftB))
+  }
+
+  private def sortPair(
+    chunkA: UInt, shiftA: UInt, weightA: UInt, validA: Bool,
+    chunkB: UInt, shiftB: UInt, weightB: UInt, validB: Bool
+  ): (UInt, UInt, UInt, Bool, UInt, UInt, UInt, Bool) = {
+    val swap = !chunkComesFirst(weightA, shiftA, weightB, shiftB)
+    (
+      Mux(swap, chunkB, chunkA),
+      Mux(swap, shiftB, shiftA),
+      Mux(swap, weightB, weightA),
+      Mux(swap, validB, validA),
+      Mux(swap, chunkA, chunkB),
+      Mux(swap, shiftA, shiftB),
+      Mux(swap, weightA, weightB),
+      Mux(swap, validA, validB)
+    )
+  }
+
+  val req_a = io.req.bits.rs1_data(xLen - 1, 0)
+  val req_b = io.req.bits.rs2_data(xLen - 1, 0)
+
+  val a_abs = absSigned(req_a)
+  val b_abs = absSigned(req_b)
+
+  val a_chunk0_nonzero = a_abs(12, 0) =/= 0.U
+  val a_chunk1_nonzero = a_abs(25, 13) =/= 0.U
+  val a_chunk2_nonzero = a_abs(38, 26) =/= 0.U
+  val a_chunk3_nonzero = a_abs(51, 39) =/= 0.U
+  val a_chunk4_nonzero = a_abs(63, 52) =/= 0.U
+  val b_chunk0_nonzero = b_abs(12, 0) =/= 0.U
+  val b_chunk1_nonzero = b_abs(25, 13) =/= 0.U
+  val b_chunk2_nonzero = b_abs(38, 26) =/= 0.U
+  val b_chunk3_nonzero = b_abs(51, 39) =/= 0.U
+  val b_chunk4_nonzero = b_abs(63, 52) =/= 0.U
+
+  val a_chunk_count = a_chunk0_nonzero.asUInt +& a_chunk1_nonzero.asUInt +& a_chunk2_nonzero.asUInt +& a_chunk3_nonzero.asUInt +& a_chunk4_nonzero.asUInt
+  val b_chunk_count = b_chunk0_nonzero.asUInt +& b_chunk1_nonzero.asUInt +& b_chunk2_nonzero.asUInt +& b_chunk3_nonzero.asUInt +& b_chunk4_nonzero.asUInt
+
+  val choose_a_as_chunk =
+    Mux(a_chunk_count =/= b_chunk_count, a_chunk_count < b_chunk_count, PopCount(a_abs) <= PopCount(b_abs))
+
+  val chunk_seed        = Mux(choose_a_as_chunk, a_abs, b_abs)
+  val multiplicand_seed = Mux(choose_a_as_chunk, b_abs, a_abs)
+  val sign_seed         = req_a(xLen - 1) ^ req_b(xLen - 1)
+
+  val chunkSeed0 = chunk_seed(12, 0)
+  val chunkSeed1 = chunk_seed(25, 13)
+  val chunkSeed2 = chunk_seed(38, 26)
+  val chunkSeed3 = chunk_seed(51, 39)
+  val chunkSeed4 = Cat(0.U(1.W), chunk_seed(63, 52))
+
+  val valid0  = chunkSeed0 =/= 0.U
+  val valid1  = chunkSeed1 =/= 0.U
+  val valid2  = chunkSeed2 =/= 0.U
+  val valid3  = chunkSeed3 =/= 0.U
+  val valid4  = chunk_seed(63, 52) =/= 0.U
+  val weight0 = Mux(valid0, PopCount(chunkSeed0), 63.U(6.W))
+  val weight1 = Mux(valid1, PopCount(chunkSeed1), 63.U(6.W))
+  val weight2 = Mux(valid2, PopCount(chunkSeed2), 63.U(6.W))
+  val weight3 = Mux(valid3, PopCount(chunkSeed3), 63.U(6.W))
+  val weight4 = Mux(valid4, PopCount(chunkSeed4), 63.U(6.W))
+
+  val shift0 = 0.U(shiftWidth.W)
+  val shift1 = 13.U(shiftWidth.W)
+  val shift2 = 26.U(shiftWidth.W)
+  val shift3 = 39.U(shiftWidth.W)
+  val shift4 = highChunkShift.U(shiftWidth.W)
+
+  val (s10c0, s10s0, s10w0, s10v0, s10c1, s10s1, s10w1, s10v1) =
+    sortPair(chunkSeed0, shift0, weight0, valid0, chunkSeed1, shift1, weight1, valid1)
+  val (s10c2, s10s2, s10w2, s10v2, s10c3, s10s3, s10w3, s10v3) =
+    sortPair(chunkSeed2, shift2, weight2, valid2, chunkSeed3, shift3, weight3, valid3)
+
+  val (s11c1, s11s1, s11w1, s11v1, s11c2, s11s2, s11w2, s11v2) =
+    sortPair(s10c1, s10s1, s10w1, s10v1, s10c2, s10s2, s10w2, s10v2)
+  val (s11c3, s11s3, s11w3, s11v3, s11c4, s11s4, s11w4, s11v4) =
+    sortPair(s10c3, s10s3, s10w3, s10v3, chunkSeed4, shift4, weight4, valid4)
+
+  val (s12c0, s12s0, s12w0, s12v0, s12c1, s12s1, s12w1, s12v1) =
+    sortPair(s10c0, s10s0, s10w0, s10v0, s11c1, s11s1, s11w1, s11v1)
+  val (s12c2, s12s2, s12w2, s12v2, s12c3, s12s3, s12w3, s12v3) =
+    sortPair(s11c2, s11s2, s11w2, s11v2, s11c3, s11s3, s11w3, s11v3)
+
+  val (s13c1, s13s1, s13w1, s13v1, s13c2, s13s2, s13w2, s13v2) =
+    sortPair(s12c1, s12s1, s12w1, s12v1, s12c2, s12s2, s12w2, s12v2)
+  val (s13c3, s13s3, s13w3, s13v3, s13c4, s13s4, s13w4, s13v4) =
+    sortPair(s12c3, s12s3, s12w3, s12v3, s11c4, s11s4, s11w4, s11v4)
+
+  val (s14c0, s14s0, _, s14v0, s14c1, s14s1, _, s14v1) =
+    sortPair(s12c0, s12s0, s12w0, s12v0, s13c1, s13s1, s13w1, s13v1)
+  val (s14c2, s14s2, _, s14v2, s14c3, s14s3, _, s14v3) =
+    sortPair(s13c2, s13s2, s13w2, s13v2, s13c3, s13s3, s13w3, s13v3)
+
+  val (chunk0_seed, chunk0_shift_seed, _, chunk0_valid_seed, chunk1_seed, chunk1_shift_seed, _, chunk1_valid_seed) =
+    sortPair(s14c0, s14s0, Mux(s14v0, PopCount(s14c0), 63.U(6.W)), s14v0,
+             s14c1, s14s1, Mux(s14v1, PopCount(s14c1), 63.U(6.W)), s14v1)
+  val (chunk2_seed, chunk2_shift_seed, _, chunk2_valid_seed, chunk3_seed, chunk3_shift_seed, _, chunk3_valid_seed) =
+    sortPair(s14c2, s14s2, Mux(s14v2, PopCount(s14c2), 63.U(6.W)), s14v2,
+             s14c3, s14s3, Mux(s14v3, PopCount(s14c3), 63.U(6.W)), s14v3)
+  val chunk4_seed       = s13c4
+  val chunk4_shift_seed = s13s4
+  val chunk4_valid_seed = s13v4
+
+  val calc0_active = state === sCalc0
+  val calc1_active = state === sCalc1
+  val calc2_active = state === sCalc2
+  val calc3_active = state === sCalc3
+  val calc4_active = state === sCalc4
+
+  val currentChunk = Mux(calc4_active, chunk4_r,
+                     Mux(calc3_active, chunk3_r,
+                     Mux(calc2_active, chunk2_r,
+                     Mux(calc1_active, chunk1_r, chunk0_r))))
+  val currentShift = Mux(calc4_active, chunk4_shift_r,
+                     Mux(calc3_active, chunk3_shift_r,
+                     Mux(calc2_active, chunk2_shift_r,
+                     Mux(calc1_active, chunk1_shift_r, chunk0_shift_r))))
+  val gatedChunk = Mux(calc0_active || calc1_active || calc2_active || calc3_active || calc4_active,
+                   currentChunk, 0.U(chunkWidth.W))
+
+  val pp_lines = Wire(Vec(chunkWidth, UInt(prodWidth.W)))
+  for (i <- 0 until chunkWidth) {
+    pp_lines(i) := Mux(gatedChunk(i), (Cat(0.U(xLen.W), multiplicand_r) << i)(prodWidth - 1, 0), 0.U(prodWidth.W))
+  }
+
+  val ppm_sum   = Wire(Vec(chunkWidth + 1, UInt(prodWidth.W)))
+  val ppm_carry = Wire(Vec(chunkWidth + 1, UInt(prodWidth.W)))
+  ppm_sum(0)   := 0.U
+  ppm_carry(0) := 0.U
+
+  for (i <- 0 until chunkWidth) {
+    val stage = csa(ppm_sum(i), ppm_carry(i), pp_lines(i))
+    ppm_sum(i + 1)   := stage._1
+    ppm_carry(i + 1) := stage._2
+  }
+
+  val chunk_sum_shifted   = (ppm_sum(chunkWidth) << currentShift)(prodWidth - 1, 0)
+  val chunk_carry_shifted = (ppm_carry(chunkWidth) << currentShift)(prodWidth - 1, 0)
+  val feedback0           = csa(acc_sum_r, acc_carry_r, chunk_sum_shifted)
+  val feedback1           = csa(feedback0._1, feedback0._2, chunk_carry_shifted)
+  val final_product       = feedback1._1 + feedback1._2
+  val final_mag_result    = final_product(xLen - 1, 0)
+  val final_result        = Mux(sign_r, (~final_mag_result).asUInt + 1.U, final_mag_result)
+
+  when (state =/= sIdle) {
+    r_uop.br_mask := GetNewBrMask(io.brupdate, r_uop)
+  }
+
+  val do_kill = (state =/= sIdle) && (IsKilledByBranch(io.brupdate, r_uop) || io.req.bits.kill)
+
+  io.req.ready := state === sIdle
+  io.resp.valid := state === sResp && !do_kill
+  io.resp.bits.predicated := false.B
+  io.resp.bits.data := result_r
+  io.resp.bits.fflags.valid := false.B
+  io.resp.bits.uop := r_uop
+  io.resp.bits.uop.br_mask := GetNewBrMask(io.brupdate, r_uop)
+
+  when (do_kill) {
+    state := sIdle
+    acc_sum_r := 0.U
+    acc_carry_r := 0.U
+  } .otherwise {
+    switch (state) {
+      is (sIdle) {
+        when (io.req.fire) {
+          r_uop := io.req.bits.uop
+          r_uop.br_mask := GetNewBrMask(io.brupdate, io.req.bits.uop)
+          sign_r := sign_seed
+          multiplicand_r := multiplicand_seed
+          chunk0_r := chunk0_seed
+          chunk1_r := chunk1_seed
+          chunk2_r := chunk2_seed
+          chunk3_r := chunk3_seed
+          chunk4_r := chunk4_seed
+          chunk0_shift_r := chunk0_shift_seed
+          chunk1_shift_r := chunk1_shift_seed
+          chunk2_shift_r := chunk2_shift_seed
+          chunk3_shift_r := chunk3_shift_seed
+          chunk4_shift_r := chunk4_shift_seed
+          chunk1_valid_r := chunk1_valid_seed
+          chunk2_valid_r := chunk2_valid_seed
+          chunk3_valid_r := chunk3_valid_seed
+          chunk4_valid_r := chunk4_valid_seed
+          acc_sum_r := 0.U
+          acc_carry_r := 0.U
+
+          when (a_abs === 0.U || b_abs === 0.U || !chunk0_valid_seed) {
+            result_r := 0.U
+            state := sResp
+          } .otherwise {
+            state := sCalc0
+          }
+        }
+      }
+
+      is (sCalc0) {
+        when (chunk1_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc1
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc1) {
+        when (chunk2_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc2
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc2) {
+        when (chunk3_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc3
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc3) {
+        when (chunk4_valid_r) {
+          acc_sum_r := feedback1._1
+          acc_carry_r := feedback1._2
+          state := sCalc4
+        } .otherwise {
+          result_r := final_result
+          state := sResp
+        }
+      }
+
+      is (sCalc4) {
+        result_r := final_result
+        state := sResp
+      }
+
+      is (sResp) {
+        when (io.resp.ready) {
+          state := sIdle
+        }
+      }
+    }
+  }
 }

--- a/src/main/scala/v3/exu/register-read/func-unit-decode.scala
+++ b/src/main/scala/v3/exu/register-read/func-unit-decode.scala
@@ -147,6 +147,9 @@ object MulDivRRdDecode extends RRdDecodeConstants
          BitPat(uopMULHU) -> List(BR_N , N, Y, N, FN_MULHU, DW_XPR,OP1_RS1 , OP2_RS2 , IS_X,  REN_1,CSR.N),
          BitPat(uopMULHSU)-> List(BR_N , N, Y, N, FN_MULHSU,DW_XPR,OP1_RS1 , OP2_RS2 , IS_X,  REN_1,CSR.N),
          BitPat(uopMULW)  -> List(BR_N , N, Y, N, FN_MUL,   DW_32 ,OP1_RS1 , OP2_RS2 , IS_X,  REN_1,CSR.N),
+         BitPat(uopMULE2N)-> List(BR_N , N, Y, N, FN_MUL,   DW_XPR,OP1_RS1 , OP2_RS2 , IS_X,  REN_1,CSR.N),
+         BitPat(uopMULE3N)-> List(BR_N , N, Y, N, FN_MUL,   DW_XPR,OP1_RS1 , OP2_RS2 , IS_X,  REN_1,CSR.N),
+         BitPat(uopMULE5N)-> List(BR_N , N, Y, N, FN_MUL,   DW_XPR,OP1_RS1 , OP2_RS2 , IS_X,  REN_1,CSR.N),
 
          BitPat(uopDIV)   -> List(BR_N , N, Y, N, FN_DIV , DW_XPR, OP1_RS1 , OP2_RS2 , IS_X, REN_1, CSR.N),
          BitPat(uopDIVU)  -> List(BR_N , N, Y, N, FN_DIVU, DW_XPR, OP1_RS1 , OP2_RS2 , IS_X, REN_1, CSR.N),


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

**Related issue**: <!-- N/A -->

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: new rtl

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Adds custom BOOM non-blocking folded multiplier instructions:

- MULE2N
- MULE3N
- MULE5N

This change includes:
- decode integration
- register-read functional-unit decode updates
- execution-unit integration
- slow/non-blocking integer writeback path support
- RV64 folded multiplier RTL implementations

Validated in Chipyard SmallBoomV3Config with custom baremetal tests.

<!-- Uncomment for forked PRs -->
<!--
**DEVS ONLY: FORKED PR**
Developers should use https://github.com/jklukas/git-push-fork-to-upstream-branch (or similar mechanism) to trigger CI for this PR before merging.
-->
